### PR TITLE
fix: clean up stale summaries and BoK on edge cases

### DIFF
--- a/core/domain/pipeline/steps.py
+++ b/core/domain/pipeline/steps.py
@@ -278,6 +278,23 @@ class DocumentSummaryStep:
             )
         ]
 
+        # Mark stale summaries for cleanup: changed documents that dropped
+        # below the chunk threshold no longer qualify for summarization,
+        # so their existing summary entry must be removed.
+        if context.change_detection_ran:
+            for doc_id, doc_chunks in chunks_by_doc.items():
+                if (
+                    doc_id in context.changed_document_ids
+                    and len(doc_chunks) < self._chunk_threshold
+                ):
+                    orphan_id = f"{doc_id}-summary-0"
+                    context.orphan_ids.add(orphan_id)
+                    logger.info(
+                        "Marking stale summary %s for cleanup "
+                        "(document %s dropped to %d chunks, threshold=%d)",
+                        orphan_id, doc_id, len(doc_chunks), self._chunk_threshold,
+                    )
+
         for doc_id, doc_chunks in docs_to_summarize:
             try:
                 logger.info(
@@ -352,6 +369,14 @@ class BodyOfKnowledgeSummaryStep:
                 seen_doc_ids.append(doc_id)
 
         if not seen_doc_ids:
+            # All documents removed — clean up the BoK summary entry
+            if context.removed_document_ids:
+                context.orphan_ids.add("body-of-knowledge-summary-0")
+                logger.info(
+                    "Marking body-of-knowledge-summary-0 for cleanup "
+                    "(corpus is empty, %d documents removed)",
+                    len(context.removed_document_ids),
+                )
             return
 
         # For each doc: prefer document_summaries, else concatenate raw chunk content

--- a/specs/036-summary-lifecycle-cleanup/plan.md
+++ b/specs/036-summary-lifecycle-cleanup/plan.md
@@ -1,0 +1,75 @@
+# Plan: Summary Lifecycle Management -- Clean Up Stale Summaries and BoK on Edge Cases
+
+**Story:** #36
+**Date:** 2026-04-08
+
+## Architecture
+
+No new modules, classes, or architectural changes. This is a surgical bug fix within two existing pipeline step classes.
+
+## Affected Modules
+
+### `core/domain/pipeline/steps.py`
+
+#### 1. `DocumentSummaryStep.execute()` (lines 265-313)
+
+**Change:** After building `docs_to_summarize`, iterate over all documents grouped by `chunks_by_doc`. For any document that:
+- Has change detection enabled (`context.change_detection_ran`)
+- Is in `context.changed_document_ids`
+- Has fewer than `self._chunk_threshold` chunks
+
+Add `f"{doc_id}-summary-0"` to `context.orphan_ids`.
+
+**Integration point:** `context.orphan_ids` is consumed by `OrphanCleanupStep` downstream. No changes needed there.
+
+#### 2. `BodyOfKnowledgeSummaryStep.execute()` (lines 338-399)
+
+**Change:** After computing `seen_doc_ids` (line 348-352), before the `if not seen_doc_ids: return` guard (line 354), add a check: if `seen_doc_ids` is empty and `context.removed_document_ids` is non-empty, add `"body-of-knowledge-summary-0"` to `context.orphan_ids`, then return.
+
+**Integration point:** Same as above -- `OrphanCleanupStep` handles deletion.
+
+## Data Model Deltas
+
+None. `PipelineContext.orphan_ids` already exists as `set[str]`.
+
+## Interface Contracts
+
+No interface changes. Both steps continue to implement the `PipelineStep` protocol.
+
+## Test Strategy
+
+### New Tests (in `tests/core/domain/test_pipeline_steps.py`)
+
+1. **`TestDocumentSummaryStepDedup.test_stale_summary_cleanup_on_threshold_drop`**
+   - Setup: Create a context with change detection enabled, doc-1 in `changed_document_ids`, and only 2 content chunks for doc-1.
+   - Assert: `"doc-1-summary-0"` in `context.orphan_ids`.
+
+2. **`TestDocumentSummaryStepDedup.test_no_stale_cleanup_when_above_threshold`**
+   - Setup: Same as above but with 5 chunks (above threshold).
+   - Assert: `"doc-1-summary-0"` not in `context.orphan_ids` (it gets summarized instead).
+
+3. **`TestDocumentSummaryStepDedup.test_no_stale_cleanup_without_change_detection`**
+   - Setup: `change_detection_ran=False`, doc with 2 chunks.
+   - Assert: `orphan_ids` is empty (no cleanup without change detection).
+
+4. **`TestDocumentSummaryStepDedup.test_no_stale_cleanup_for_unchanged_doc`**
+   - Setup: `change_detection_ran=True`, doc-1 NOT in `changed_document_ids`, 2 chunks.
+   - Assert: `orphan_ids` is empty (unchanged docs are not touched).
+
+5. **`TestBoKSummaryStepDedup.test_bok_cleanup_on_empty_corpus`**
+   - Setup: `change_detection_ran=True`, `removed_document_ids={"doc-1"}`, no content chunks.
+   - Assert: `"body-of-knowledge-summary-0"` in `context.orphan_ids`.
+
+6. **`TestBoKSummaryStepDedup.test_no_bok_cleanup_when_docs_remain`**
+   - Setup: `change_detection_ran=True`, `removed_document_ids={"doc-2"}`, content chunks for doc-1 present.
+   - Assert: `"body-of-knowledge-summary-0"` not in `context.orphan_ids`.
+
+### Existing Tests
+
+All existing tests must continue to pass. The new code paths are guarded by conditions (`change_detection_ran`, `changed_document_ids`, `removed_document_ids`) that existing tests do not trigger.
+
+## Rollout Notes
+
+- Zero-risk deployment -- the fix only adds IDs to an existing set that is already consumed by `OrphanCleanupStep`.
+- No configuration changes needed.
+- No migration needed -- stale entries will be cleaned up on the next ingest cycle for affected collections.

--- a/specs/036-summary-lifecycle-cleanup/spec.md
+++ b/specs/036-summary-lifecycle-cleanup/spec.md
@@ -1,0 +1,46 @@
+# Spec: Summary Lifecycle Management -- Clean Up Stale Summaries and BoK on Edge Cases
+
+**Story:** #36
+**Status:** Draft
+**Author:** SDD Agent
+**Date:** 2026-04-08
+
+## User Value
+
+When documents shrink below the summarization threshold or the entire corpus is emptied, stale summary entries persist in the knowledge store. These orphaned entries degrade retrieval quality by returning outdated context to users. Cleaning them up ensures the knowledge base remains accurate and free of stale data.
+
+## Scope
+
+### In Scope
+
+1. **Stale per-document summary cleanup:** When a changed document drops to fewer chunks than the summary threshold (currently `chunk_threshold`, default 4), the existing `{doc_id}-summary-0` entry must be added to `context.orphan_ids` so `OrphanCleanupStep` deletes it.
+
+2. **Empty corpus BoK cleanup:** When `BodyOfKnowledgeSummaryStep` detects that all documents have been removed (i.e., `seen_doc_ids` is empty and `removed_document_ids` is non-empty), it must add `"body-of-knowledge-summary-0"` to `context.orphan_ids`.
+
+### Out of Scope
+
+- Changes to `ChangeDetectionStep` logic itself.
+- Changes to `OrphanCleanupStep` logic -- it already handles `context.orphan_ids` and `context.removed_document_ids` correctly.
+- Changes to the `StoreStep` ID scheme.
+- Multi-chunk summary support (summaries always have `chunk_index=0`).
+- Cleanup of BoK summaries in non-empty-corpus scenarios (the BoK is regenerated when any document changes).
+
+## Acceptance Criteria
+
+1. **AC1:** When a previously summarized document (with >threshold chunks on last ingest) is re-ingested with <=threshold chunks, the `{doc_id}-summary-0` storage ID is added to `context.orphan_ids` during `DocumentSummaryStep.execute()`.
+
+2. **AC2:** When the entire corpus becomes empty (all documents removed, no content chunks remain), `body-of-knowledge-summary-0` is added to `context.orphan_ids` during `BodyOfKnowledgeSummaryStep.execute()`.
+
+3. **AC3:** Both cleanup paths are covered by unit tests that verify the correct IDs appear in `context.orphan_ids`.
+
+4. **AC4:** All existing tests continue to pass without modification.
+
+5. **AC5:** No changes outside `core/domain/pipeline/steps.py` and test files.
+
+## Constraints
+
+- The fix must be minimal and surgical -- only `DocumentSummaryStep.execute()` and `BodyOfKnowledgeSummaryStep.execute()` are modified.
+- The summary storage ID format is `{doc_id}-summary-{chunk_index}`, and `chunk_index` is always 0 for document summaries.
+- The BoK storage ID format is `body-of-knowledge-summary-0`.
+- `context.orphan_ids` is a `set[str]` that `OrphanCleanupStep` already consumes; adding IDs to it is the correct integration point.
+- `change_detection_ran` and `changed_document_ids` must be respected to avoid false positives on fresh ingests without change detection.

--- a/specs/036-summary-lifecycle-cleanup/tasks.md
+++ b/specs/036-summary-lifecycle-cleanup/tasks.md
@@ -1,0 +1,85 @@
+# Tasks: Summary Lifecycle Management -- Clean Up Stale Summaries and BoK on Edge Cases
+
+**Story:** #36
+**Date:** 2026-04-08
+
+## Task List
+
+### T1: Add stale per-document summary cleanup to DocumentSummaryStep
+
+**File:** `core/domain/pipeline/steps.py`
+**Depends on:** None
+**Description:** In `DocumentSummaryStep.execute()`, after building `docs_to_summarize`, detect changed documents that now fall below `self._chunk_threshold` and add their summary storage IDs to `context.orphan_ids`.
+
+**Implementation:**
+- After `docs_to_summarize` is computed (line 279), iterate over `chunks_by_doc`.
+- For each `doc_id` where:
+  - `context.change_detection_ran` is True
+  - `doc_id in context.changed_document_ids`
+  - `len(doc_chunks) < self._chunk_threshold`
+- Add `f"{doc_id}-summary-0"` to `context.orphan_ids`.
+- Log at INFO level.
+
+**Acceptance criteria:**
+- When a changed document drops below chunk threshold, its summary ID appears in `context.orphan_ids`.
+- When a changed document is at or above threshold, it is summarized normally (no orphan ID added).
+- When change detection has not run, no stale cleanup occurs.
+- When a document is not in `changed_document_ids`, no stale cleanup occurs.
+
+**Tests:** T3 (tests 1-4)
+
+---
+
+### T2: Add empty corpus BoK cleanup to BodyOfKnowledgeSummaryStep
+
+**File:** `core/domain/pipeline/steps.py`
+**Depends on:** None
+**Description:** In `BodyOfKnowledgeSummaryStep.execute()`, when no content chunks remain and documents have been removed, add the BoK summary storage ID to `context.orphan_ids`.
+
+**Implementation:**
+- After computing `seen_doc_ids` (line 352), before the `if not seen_doc_ids: return` guard (line 354):
+  - If `not seen_doc_ids` and `context.removed_document_ids`:
+    - Add `"body-of-knowledge-summary-0"` to `context.orphan_ids`
+    - Log at INFO level
+    - Return
+
+**Acceptance criteria:**
+- When corpus is empty and documents were removed, `"body-of-knowledge-summary-0"` appears in `context.orphan_ids`.
+- When corpus still has documents, the BoK summary is regenerated normally (no orphan ID added).
+- No BoK summary chunk is generated for an empty corpus.
+
+**Tests:** T3 (tests 5-6)
+
+---
+
+### T3: Write unit tests for both cleanup paths
+
+**File:** `tests/core/domain/test_pipeline_steps.py`
+**Depends on:** T1, T2
+**Description:** Add test cases to the existing test classes to verify both stale summary and empty corpus BoK cleanup behaviors.
+
+**Tests to add:**
+
+1. `TestDocumentSummaryStepDedup.test_stale_summary_cleanup_on_threshold_drop`
+2. `TestDocumentSummaryStepDedup.test_no_stale_cleanup_when_above_threshold`
+3. `TestDocumentSummaryStepDedup.test_no_stale_cleanup_without_change_detection`
+4. `TestDocumentSummaryStepDedup.test_no_stale_cleanup_for_unchanged_doc`
+5. `TestBoKSummaryStepDedup.test_bok_cleanup_on_empty_corpus`
+6. `TestBoKSummaryStepDedup.test_no_bok_cleanup_when_docs_remain`
+
+**Acceptance criteria:**
+- All 6 new tests pass.
+- All existing tests continue to pass.
+- Tests cover both positive (cleanup triggered) and negative (cleanup not triggered) cases.
+
+---
+
+### T4: Run full test suite and static analysis
+
+**Depends on:** T1, T2, T3
+**Description:** Verify all exit gates pass.
+
+**Acceptance criteria:**
+- `poetry run pytest` passes with zero failures.
+- `poetry run ruff check core/ plugins/ tests/` passes.
+- `poetry run pyright core/ plugins/` passes.

--- a/tests/core/domain/test_pipeline_steps.py
+++ b/tests/core/domain/test_pipeline_steps.py
@@ -922,6 +922,91 @@ class TestDocumentSummaryStepDedup:
 
         assert len(ctx.chunks) == chunks_before + 1
 
+    async def test_stale_summary_cleanup_on_threshold_drop(self):
+        """Changed document dropping below threshold adds summary ID to orphan_ids."""
+        llm = MockLLMPort(response="Summary")
+        meta = DocumentMetadata(
+            document_id="doc-1", source="s", type="knowledge",
+            title="T", embedding_type="chunk",
+        )
+        # Only 2 chunks — below default threshold of 4
+        ctx = PipelineContext(
+            collection_name="test",
+            documents=[],
+            chunks=[
+                Chunk(content="chunk 0", metadata=meta, chunk_index=0),
+                Chunk(content="chunk 1", metadata=meta, chunk_index=1),
+            ],
+        )
+        ctx.change_detection_ran = True
+        ctx.changed_document_ids = {"doc-1"}
+
+        await DocumentSummaryStep(llm_port=llm).execute(ctx)
+
+        assert "doc-1-summary-0" in ctx.orphan_ids
+        # No summary should be generated (below threshold)
+        assert "doc-1" not in ctx.document_summaries
+        assert len(llm.calls) == 0
+
+    async def test_no_stale_cleanup_when_above_threshold(self):
+        """Changed document at or above threshold is summarized, not orphaned."""
+        llm = MockLLMPort(response="Summary")
+        ctx = _make_context()
+        await ChunkStep(chunk_size=100, chunk_overlap=10).execute(ctx)
+        assert len(ctx.chunks) >= 4  # Above default threshold
+
+        ctx.change_detection_ran = True
+        ctx.changed_document_ids = {"doc-1"}
+
+        await DocumentSummaryStep(llm_port=llm).execute(ctx)
+
+        assert "doc-1-summary-0" not in ctx.orphan_ids
+        assert "doc-1" in ctx.document_summaries
+
+    async def test_no_stale_cleanup_without_change_detection(self):
+        """Without change detection, no stale cleanup occurs."""
+        llm = MockLLMPort(response="Summary")
+        meta = DocumentMetadata(
+            document_id="doc-1", source="s", type="knowledge",
+            title="T", embedding_type="chunk",
+        )
+        ctx = PipelineContext(
+            collection_name="test",
+            documents=[],
+            chunks=[
+                Chunk(content="chunk 0", metadata=meta, chunk_index=0),
+                Chunk(content="chunk 1", metadata=meta, chunk_index=1),
+            ],
+        )
+        assert ctx.change_detection_ran is False
+
+        await DocumentSummaryStep(llm_port=llm).execute(ctx)
+
+        assert len(ctx.orphan_ids) == 0
+
+    async def test_no_stale_cleanup_for_unchanged_doc(self):
+        """Unchanged documents below threshold do not trigger stale cleanup."""
+        llm = MockLLMPort(response="Summary")
+        meta = DocumentMetadata(
+            document_id="doc-1", source="s", type="knowledge",
+            title="T", embedding_type="chunk",
+        )
+        ctx = PipelineContext(
+            collection_name="test",
+            documents=[],
+            chunks=[
+                Chunk(content="chunk 0", metadata=meta, chunk_index=0),
+                Chunk(content="chunk 1", metadata=meta, chunk_index=1),
+            ],
+        )
+        ctx.change_detection_ran = True
+        # doc-1 is NOT in changed_document_ids
+        ctx.changed_document_ids = {"other-doc"}
+
+        await DocumentSummaryStep(llm_port=llm).execute(ctx)
+
+        assert len(ctx.orphan_ids) == 0
+
 
 # ---------------------------------------------------------------------------
 # BodyOfKnowledgeSummaryStep dedup tests
@@ -1017,6 +1102,49 @@ class TestBoKSummaryStepDedup:
 
         await BodyOfKnowledgeSummaryStep(llm_port=llm).execute(ctx)
 
+        bok = [c for c in ctx.chunks if c.metadata.document_id == "body-of-knowledge-summary"]
+        assert len(bok) == 1
+
+    async def test_bok_cleanup_on_empty_corpus(self):
+        """When all docs are removed and corpus is empty, BoK summary ID is orphaned."""
+        llm = MockLLMPort(response="BoK overview")
+        ctx = PipelineContext(
+            collection_name="test",
+            documents=[],
+            chunks=[],  # No content chunks — corpus is empty
+        )
+        ctx.change_detection_ran = True
+        ctx.removed_document_ids = {"doc-1", "doc-2"}
+
+        await BodyOfKnowledgeSummaryStep(llm_port=llm).execute(ctx)
+
+        assert "body-of-knowledge-summary-0" in ctx.orphan_ids
+        # No BoK summary should be generated
+        bok = [c for c in ctx.chunks if c.metadata.document_id == "body-of-knowledge-summary"]
+        assert len(bok) == 0
+        assert len(llm.calls) == 0
+
+    async def test_no_bok_cleanup_when_docs_remain(self):
+        """When some docs remain, BoK summary is regenerated, not orphaned."""
+        llm = MockLLMPort(response="Updated BoK")
+        ctx = PipelineContext(
+            collection_name="test",
+            documents=[],
+            chunks=[
+                Chunk(
+                    content="text",
+                    metadata=DocumentMetadata(document_id="d1", source="s", embedding_type="chunk"),
+                    chunk_index=0,
+                ),
+            ],
+        )
+        ctx.change_detection_ran = True
+        ctx.removed_document_ids = {"d2"}
+        ctx.changed_document_ids = set()
+
+        await BodyOfKnowledgeSummaryStep(llm_port=llm).execute(ctx)
+
+        assert "body-of-knowledge-summary-0" not in ctx.orphan_ids
         bok = [c for c in ctx.chunks if c.metadata.document_id == "body-of-knowledge-summary"]
         assert len(bok) == 1
 


### PR DESCRIPTION
## Summary

Closes #36

- When a changed document drops below the summary chunk threshold after re-chunking, its orphaned `{doc_id}-summary-0` entry is now added to `context.orphan_ids` for cleanup by `OrphanCleanupStep`
- When the entire corpus becomes empty (all documents removed), the `body-of-knowledge-summary-0` entry is added to `context.orphan_ids` for cleanup
- Adds 6 new unit tests covering both positive and negative cases for both cleanup paths

**Affected files:** `core/domain/pipeline/steps.py`, `tests/core/domain/test_pipeline_steps.py`

**Spec artifacts:** `specs/036-summary-lifecycle-cleanup/` (`spec.md`, `plan.md`, `tasks.md`)

**SDD loop counts:** Clarify: 2 iterations, Analyze: 2 iterations

## Test plan

- [x] All 338 existing tests pass (0 failures)
- [x] 6 new tests added and passing:
  - `test_stale_summary_cleanup_on_threshold_drop`
  - `test_no_stale_cleanup_when_above_threshold`
  - `test_no_stale_cleanup_without_change_detection`
  - `test_no_stale_cleanup_for_unchanged_doc`
  - `test_bok_cleanup_on_empty_corpus`
  - `test_no_bok_cleanup_when_docs_remain`
- [x] Ruff lint: all checks passed
- [x] Pyright: 0 errors (41 pre-existing warnings, none introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automatic cleanup of document summaries when documents are reprocessed and fall below the summarization threshold.
  * Implemented automatic removal of body-of-knowledge summaries when the corpus becomes empty.

* **Documentation**
  * Added detailed specification and implementation requirements for summary lifecycle cleanup behaviors.

* **Tests**
  * Added comprehensive unit tests covering both document-level and corpus-level summary cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->