### PR TITLE
fix: skip upsert for unchanged chunks in StoreStep

### DIFF
--- a/core/domain/pipeline/steps.py
+++ b/core/domain/pipeline/steps.py
@@ -455,8 +455,18 @@ class StoreStep:
         return "store"
 
     async def execute(self, context: PipelineContext) -> None:
-        storable = [c for c in context.chunks if c.embedding is not None]
-        skipped = len(context.chunks) - len(storable)
+        # Exclude unchanged chunks (already stored with identical content/embedding)
+        changed_chunks = [
+            c for c in context.chunks
+            if c.content_hash is None
+            or c.content_hash not in context.unchanged_chunk_hashes
+        ]
+        unchanged_count = len(context.chunks) - len(changed_chunks)
+        if unchanged_count > 0:
+            logger.info("StoreStep: skipped %d unchanged chunks", unchanged_count)
+
+        storable = [c for c in changed_chunks if c.embedding is not None]
+        skipped = len(changed_chunks) - len(storable)
         if skipped > 0:
             context.errors.append(
                 f"StoreStep: skipped {skipped} chunks without embeddings"

--- a/specs/1825-skip-upsert-unchanged-chunks/clarifications.md
+++ b/specs/1825-skip-upsert-unchanged-chunks/clarifications.md
@@ -1,0 +1,49 @@
+# Clarifications: Skip upsert for unchanged chunks in StoreStep
+
+**Story:** alkem-io/alkemio#1825
+
+## Iteration 1
+
+### Q1: How should unchanged chunks interact with the "skipped without embeddings" error message?
+
+**Question:** Currently StoreStep counts `len(context.chunks) - len(storable)` as skipped. After filtering unchanged chunks, should the "skipped" count reflect chunks missing embeddings from all chunks, or only from the non-unchanged subset?
+
+**Answer:** Filter unchanged chunks first, then compute the "skipped without embeddings" count from the remaining pool. This way the error message accurately reflects actual embedding failures rather than conflating them with intentionally skipped unchanged chunks.
+
+**Rationale:** Mixing unchanged-skip counts with embedding-missing counts would produce misleading error messages. The two skips have different causes: one is healthy optimization, the other indicates a pipeline failure.
+
+### Q2: What log level for the unchanged-chunks-skipped message?
+
+**Question:** Should the new log message reporting unchanged chunks skipped by StoreStep be at INFO, DEBUG, or WARNING level?
+
+**Answer:** INFO level.
+
+**Rationale:** Consistent with the existing `ChangeDetectionStep` logging at line 228 of steps.py which logs skip/change counts at INFO.
+
+### Q3: Does IngestResult.chunks_stored need separate handling?
+
+**Question:** `IngestResult.chunks_stored` is set from `context.chunks_stored` in `engine.py`. Does it need modification?
+
+**Answer:** No. Since `context.chunks_stored` is only incremented when `store.ingest()` is actually called, and we are filtering unchanged chunks before that call, the count will naturally be correct without any changes to `IngestEngine`.
+
+**Rationale:** The engine just reads `context.chunks_stored` at the end. The fix is self-contained in StoreStep.
+
+### Q4: Should the filter guard against None content_hash?
+
+**Question:** The filter `c.content_hash not in context.unchanged_chunk_hashes` works correctly even when `c.content_hash is None` because `None` will never be in the set of string hashes. Should we add an explicit `is not None` guard anyway?
+
+**Answer:** Yes, include `c.content_hash is not None` in the filter for readability and defensive coding.
+
+**Rationale:** Explicit guards prevent future breakage if someone adds None to the set, and make the intent immediately obvious to readers.
+
+### Q5: Should we use the issue's proposed approach (filter on unchanged_chunk_hashes) or the alternative (add a `changed` flag to Chunk)?
+
+**Question:** The issue offers two approaches. Which one?
+
+**Answer:** Use the `unchanged_chunk_hashes` filter approach. Do not add a `changed` flag to `Chunk`.
+
+**Rationale:** The `unchanged_chunk_hashes` set already exists on `PipelineContext` and is populated by `ChangeDetectionStep`. Adding a field to `Chunk` would change the data model for a single consumer, violating the minimal-change principle. The set-based approach is zero-cost at the model layer.
+
+## Iteration 2
+
+No new ambiguities found. All questions resolved.

--- a/specs/1825-skip-upsert-unchanged-chunks/plan.md
+++ b/specs/1825-skip-upsert-unchanged-chunks/plan.md
@@ -1,0 +1,93 @@
+# Plan: Skip upsert for unchanged chunks in StoreStep
+
+**Story:** alkem-io/alkemio#1825
+**Date:** 2026-04-08
+
+## Architecture
+
+No architectural changes. This is a targeted optimization within `StoreStep`, one of the concrete pipeline steps in the ingest pipeline engine.
+
+### Affected Modules
+
+| Module | File | Change |
+|--------|------|--------|
+| StoreStep | `core/domain/pipeline/steps.py` | Filter unchanged chunks before upsert loop; adjust skip-count logic; add INFO log |
+| Tests | `tests/core/domain/test_pipeline_steps.py` | Add tests for unchanged-chunk filtering in StoreStep |
+
+### Modules NOT Changed
+
+| Module | Reason |
+|--------|--------|
+| `Chunk` dataclass (`core/domain/ingest_pipeline.py`) | No model changes needed |
+| `PipelineContext` (`core/domain/pipeline/engine.py`) | Already has `unchanged_chunk_hashes` field |
+| `ChangeDetectionStep` | Already correctly populates `unchanged_chunk_hashes` |
+| `EmbedStep` | Already skips chunks with pre-loaded embeddings |
+| `IngestEngine` | Reads `context.chunks_stored` unchanged |
+
+## Data Model Deltas
+
+None. No fields added or removed from any dataclass.
+
+## Interface Contracts
+
+No interface changes. `StoreStep` continues to implement the `PipelineStep` protocol with the same `execute(context: PipelineContext) -> None` signature.
+
+## Detailed Design
+
+### Current behavior (StoreStep.execute)
+
+```python
+storable = [c for c in context.chunks if c.embedding is not None]
+skipped = len(context.chunks) - len(storable)
+# ... upserts ALL storable chunks
+```
+
+### New behavior
+
+```python
+# 1. Exclude unchanged chunks (content hash in unchanged set)
+changed_chunks = [
+    c for c in context.chunks
+    if c.content_hash is None or c.content_hash not in context.unchanged_chunk_hashes
+]
+
+# 2. From the remaining, select only those with embeddings
+storable = [c for c in changed_chunks if c.embedding is not None]
+
+# 3. Count unchanged separately
+unchanged_count = len(context.chunks) - len(changed_chunks)
+
+# 4. Count missing-embedding from changed pool only
+skipped = len(changed_chunks) - len(storable)
+
+# 5. Log unchanged skip count
+if unchanged_count > 0:
+    logger.info("StoreStep: skipped %d unchanged chunks", unchanged_count)
+```
+
+### Why this ordering matters
+
+- Summary chunks and BoK summary chunks have `content_hash = None`, so `c.content_hash is None` evaluates to `True` and they pass through the filter -- they are always stored.
+- Content chunks identified as unchanged by `ChangeDetectionStep` have their `content_hash` in `unchanged_chunk_hashes`, so they are excluded.
+- New/changed content chunks have embeddings (from `EmbedStep`) and their hash is NOT in the unchanged set, so they are stored.
+
+## Test Strategy
+
+| Test | Verifies |
+|------|----------|
+| `test_skips_unchanged_chunks` | Chunks with `content_hash` in `unchanged_chunk_hashes` are not stored |
+| `test_stores_changed_chunks_with_embeddings` | Changed chunks with embeddings are stored normally |
+| `test_always_stores_summary_chunks` | Summary chunks (content_hash=None) are stored even when unchanged set is populated |
+| `test_chunks_stored_counter_excludes_unchanged` | `chunks_stored` only counts actually written chunks |
+| `test_unchanged_not_counted_as_missing_embeddings` | The "skipped N chunks without embeddings" error does not include unchanged chunks |
+| `test_backward_compat_empty_unchanged_set` | When `unchanged_chunk_hashes` is empty, behavior is identical to before |
+
+All existing tests must continue to pass unchanged.
+
+## Rollout Notes
+
+- No configuration changes.
+- No migration needed.
+- No environment variable changes.
+- Fully backward-compatible: empty `unchanged_chunk_hashes` set means no behavior change.
+- Observable improvement: `chunks_stored` in `IngestResult` will be lower on incremental runs, and INFO log will report skipped unchanged count.

--- a/specs/1825-skip-upsert-unchanged-chunks/spec.md
+++ b/specs/1825-skip-upsert-unchanged-chunks/spec.md
@@ -1,0 +1,39 @@
+# Spec: Skip upsert for unchanged chunks in StoreStep
+
+**Story:** alkem-io/alkemio#1825
+**Status:** Draft
+**Author:** SDD Agent
+**Date:** 2026-04-08
+
+## User Value
+
+Reduce unnecessary ChromaDB I/O during incremental ingest runs by skipping upserts for chunks whose content, metadata, and embeddings have not changed since the last ingest. This directly improves pipeline throughput and reduces vector-store wear for knowledge bases with stable content.
+
+## Scope
+
+- Modify `StoreStep.execute()` in `core/domain/pipeline/steps.py` to filter out chunks whose `content_hash` appears in `context.unchanged_chunk_hashes` before upserting.
+- Ensure summary chunks and BoK summary chunks (which do not participate in change detection) are always stored.
+- Update logging to reflect the number of unchanged chunks skipped by StoreStep.
+
+## Out of Scope
+
+- Changes to `ChangeDetectionStep` -- it already correctly identifies unchanged chunks and pre-loads their embeddings.
+- Adding a `changed: bool` field to the `Chunk` dataclass -- the `unchanged_chunk_hashes` set on `PipelineContext` is sufficient and avoids model changes.
+- Changes to `EmbedStep` -- it already skips chunks with pre-loaded embeddings.
+- Performance benchmarking or metrics instrumentation beyond existing logging.
+
+## Acceptance Criteria
+
+1. `StoreStep` does NOT call `upsert()` for chunks whose `content_hash` is present in `context.unchanged_chunk_hashes`.
+2. `StoreStep` continues to store all chunks that have embeddings and are NOT in the unchanged set (new chunks, changed chunks, summary chunks).
+3. The `chunks_stored` counter on `PipelineContext` only counts chunks that were actually written to the store.
+4. A log message is emitted reporting the number of unchanged chunks skipped by StoreStep.
+5. The skip-error message ("skipped N chunks without embeddings") no longer counts unchanged chunks as "skipped without embeddings."
+6. All existing tests continue to pass.
+7. New unit tests verify: (a) unchanged chunks are excluded from storage, (b) changed chunks with embeddings are stored, (c) summary chunks are always stored regardless of unchanged set, (d) chunks_stored counter accuracy.
+
+## Constraints
+
+- No changes to the `Chunk` dataclass or `PipelineContext` dataclass.
+- Must remain backward-compatible: when `unchanged_chunk_hashes` is empty (no change detection ran, or all chunks are new), behavior is identical to current.
+- Python 3.12, async, follows existing codebase conventions.

--- a/specs/1825-skip-upsert-unchanged-chunks/tasks.md
+++ b/specs/1825-skip-upsert-unchanged-chunks/tasks.md
@@ -1,0 +1,39 @@
+# Tasks: Skip upsert for unchanged chunks in StoreStep
+
+**Story:** alkem-io/alkemio#1825
+**Date:** 2026-04-08
+
+## Task List
+
+### T1: Add unit tests for unchanged-chunk filtering in StoreStep (test-first)
+
+**File:** `tests/core/domain/test_pipeline_steps.py`
+**Depends on:** None
+**Acceptance criteria:**
+- Add `test_skips_unchanged_chunks`: creates a context with chunks whose `content_hash` is in `unchanged_chunk_hashes`, verifies they are NOT stored and `chunks_stored` is 0.
+- Add `test_stores_changed_chunks_alongside_unchanged`: mix of unchanged and changed chunks, verifies only changed ones are stored.
+- Add `test_always_stores_summary_chunks_when_unchanged_set_populated`: summary chunk with `content_hash=None` is stored even when `unchanged_chunk_hashes` is non-empty.
+- Add `test_unchanged_not_counted_as_missing_embeddings`: unchanged chunks with embeddings do not trigger the "skipped N chunks without embeddings" error.
+- Add `test_backward_compat_empty_unchanged_set`: when `unchanged_chunk_hashes` is empty, all embedded chunks are stored (same as current behavior).
+**Proves done:** Tests initially fail (red), then pass after T2.
+
+### T2: Modify StoreStep.execute to filter unchanged chunks
+
+**File:** `core/domain/pipeline/steps.py`
+**Depends on:** T1 (tests exist to validate)
+**Acceptance criteria:**
+- `StoreStep.execute()` filters out chunks whose `content_hash` is not None and is present in `context.unchanged_chunk_hashes`.
+- The "skipped N chunks without embeddings" error count is computed from the non-unchanged pool only.
+- An INFO-level log message reports the count of unchanged chunks skipped.
+- `chunks_stored` counter only increments for actually stored chunks (no change needed -- already correct by construction).
+**Proves done:** All T1 tests pass green. All pre-existing tests pass green.
+
+### T3: Run full test suite, lint, and type check
+
+**File:** N/A (validation)
+**Depends on:** T2
+**Acceptance criteria:**
+- `poetry run pytest` passes with 0 failures.
+- `poetry run ruff check core/ plugins/ tests/` passes with 0 errors.
+- `poetry run pyright core/ plugins/` passes with 0 errors.
+**Proves done:** Clean CI-equivalent run.

--- a/tests/core/domain/test_pipeline_steps.py
+++ b/tests/core/domain/test_pipeline_steps.py
@@ -358,6 +358,102 @@ class TestStoreStep:
 
 
 # ---------------------------------------------------------------------------
+# T1825: StoreStep unchanged-chunk filtering tests
+# ---------------------------------------------------------------------------
+
+
+class TestStoreStepUnchangedFiltering:
+    async def test_skips_unchanged_chunks(self):
+        """Chunks whose content_hash is in unchanged_chunk_hashes are not stored."""
+        store = MockKnowledgeStorePort()
+        meta = DocumentMetadata(document_id="doc-1", source="s", type="knowledge", title="T", embedding_type="chunk")
+        chunk = Chunk(content="unchanged text", metadata=meta, chunk_index=0, embedding=[0.1], content_hash="hash-unchanged")
+
+        ctx = PipelineContext(
+            collection_name="coll",
+            documents=[],
+            chunks=[chunk],
+            unchanged_chunk_hashes={"hash-unchanged"},
+        )
+        await StoreStep(knowledge_store_port=store).execute(ctx)
+
+        assert ctx.chunks_stored == 0
+        assert "coll" not in store.collections or len(store.collections["coll"]) == 0
+
+    async def test_stores_changed_chunks_alongside_unchanged(self):
+        """Only changed chunks are stored; unchanged ones are skipped."""
+        store = MockKnowledgeStorePort()
+        meta = DocumentMetadata(document_id="doc-1", source="s", type="knowledge", title="T", embedding_type="chunk")
+        unchanged = Chunk(content="old text", metadata=meta, chunk_index=0, embedding=[0.1], content_hash="hash-old")
+        changed = Chunk(content="new text", metadata=meta, chunk_index=1, embedding=[0.2], content_hash="hash-new")
+
+        ctx = PipelineContext(
+            collection_name="coll",
+            documents=[],
+            chunks=[unchanged, changed],
+            unchanged_chunk_hashes={"hash-old"},
+        )
+        await StoreStep(knowledge_store_port=store).execute(ctx)
+
+        assert ctx.chunks_stored == 1
+        assert len(store.collections["coll"]) == 1
+        assert store.collections["coll"][0]["document"] == "new text"
+
+    async def test_always_stores_summary_chunks_when_unchanged_set_populated(self):
+        """Summary chunks (content_hash=None) are stored even when unchanged set is non-empty."""
+        store = MockKnowledgeStorePort()
+        chunk_meta = DocumentMetadata(document_id="doc-1", source="s", type="knowledge", title="T", embedding_type="chunk")
+        summary_meta = DocumentMetadata(document_id="doc-1-summary", source="s", type="knowledge", title="T", embedding_type="summary")
+        unchanged = Chunk(content="old", metadata=chunk_meta, chunk_index=0, embedding=[0.1], content_hash="hash-old")
+        summary = Chunk(content="summary text", metadata=summary_meta, chunk_index=0, embedding=[0.3])
+
+        ctx = PipelineContext(
+            collection_name="coll",
+            documents=[],
+            chunks=[unchanged, summary],
+            unchanged_chunk_hashes={"hash-old"},
+        )
+        await StoreStep(knowledge_store_port=store).execute(ctx)
+
+        assert ctx.chunks_stored == 1
+        assert len(store.collections["coll"]) == 1
+        assert store.collections["coll"][0]["document"] == "summary text"
+
+    async def test_unchanged_not_counted_as_missing_embeddings(self):
+        """Unchanged chunks with embeddings should not trigger 'skipped N chunks without embeddings' error."""
+        store = MockKnowledgeStorePort()
+        meta = DocumentMetadata(document_id="doc-1", source="s", type="knowledge", title="T", embedding_type="chunk")
+        unchanged = Chunk(content="text", metadata=meta, chunk_index=0, embedding=[0.1], content_hash="hash-unch")
+
+        ctx = PipelineContext(
+            collection_name="coll",
+            documents=[],
+            chunks=[unchanged],
+            unchanged_chunk_hashes={"hash-unch"},
+        )
+        await StoreStep(knowledge_store_port=store).execute(ctx)
+
+        # No error about skipped chunks without embeddings
+        assert not any("skipped" in e and "without embeddings" in e for e in ctx.errors)
+
+    async def test_backward_compat_empty_unchanged_set(self):
+        """When unchanged_chunk_hashes is empty, all embedded chunks are stored."""
+        store = MockKnowledgeStorePort()
+        meta = DocumentMetadata(document_id="doc-1", source="s", type="knowledge", title="T", embedding_type="chunk")
+        chunk = Chunk(content="text", metadata=meta, chunk_index=0, embedding=[0.1], content_hash="hash-123")
+
+        ctx = PipelineContext(
+            collection_name="coll",
+            documents=[],
+            chunks=[chunk],
+        )
+        await StoreStep(knowledge_store_port=store).execute(ctx)
+
+        assert ctx.chunks_stored == 1
+        assert len(store.collections["coll"]) == 1
+
+
+# ---------------------------------------------------------------------------
 # T026: BodyOfKnowledgeSummaryStep tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **Filters out unchanged chunks in `StoreStep.execute()`** before the upsert loop, so chunks whose `content_hash` is already in `context.unchanged_chunk_hashes` (populated by `ChangeDetectionStep`) are no longer redundantly written to ChromaDB
- **Corrects the "skipped N chunks without embeddings" error count** to exclude unchanged chunks, preventing misleading error messages
- **Adds INFO-level logging** reporting how many unchanged chunks were skipped

Closes alkem-io/alkemio#1825

## Details

For a knowledge base with 500 chunks where only 10 changed, the previous implementation performed 490 unnecessary upserts. This fix reduces ChromaDB I/O by up to 98% on incremental ingest runs.

### Changed files
- `core/domain/pipeline/steps.py` -- StoreStep filter logic (8 net lines added)
- `tests/core/domain/test_pipeline_steps.py` -- 5 new tests in `TestStoreStepUnchangedFiltering`

### SDD artifacts
- `specs/1825-skip-upsert-unchanged-chunks/spec.md`
- `specs/1825-skip-upsert-unchanged-chunks/plan.md`
- `specs/1825-skip-upsert-unchanged-chunks/tasks.md`
- `specs/1825-skip-upsert-unchanged-chunks/clarifications.md`

### SDD loop counts
- Clarify iterations: 2 (5 ambiguities resolved in iteration 1, zero in iteration 2)
- Analyze iterations: 2 (zero findings in both iterations)

## Test plan

- [x] 5 new unit tests for unchanged-chunk filtering pass
- [x] All 337 existing tests pass (0 failures)
- [x] Ruff lint: all checks passed
- [x] Pyright type check: 0 errors (41 pre-existing warnings)

Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Incremental ingestion optimization: Unchanged content is now skipped during storage operations, improving performance when re-processing data with minimal changes.
  * Enhanced logging reports the number of skipped unchanged items.

* **Bug Fixes**
  * Corrected error counts to exclude unchanged items from missing field error reporting, providing more accurate diagnostic messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->