### PR TITLE
feat: consistent summarization behavior between ingest plugins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,10 @@ CHUNK_SIZE=2000
 CHUNK_OVERLAP=400
 BATCH_SIZE=20
 SUMMARY_LENGTH=10000
+# Whether to include document/BoK summarization steps in ingest pipelines
+SUMMARIZE_ENABLED=true
+# Max parallel document summarizations (0 = sequential)
+SUMMARIZE_CONCURRENCY=8
 
 # Health server
 HEALTH_PORT=8080

--- a/core/config.py
+++ b/core/config.py
@@ -157,6 +157,12 @@ class BaseConfig(BaseSettings):
                 f"got {self.summary_chunk_threshold}"
             )
 
+        # Summarize concurrency validation
+        if self.summarize_concurrency < 0:
+            raise ValueError(
+                f"SUMMARIZE_CONCURRENCY must be >= 0, got {self.summarize_concurrency}"
+            )
+
         # Partial summarize config warning
         summarize_fields = [
             self.summarize_llm_provider,
@@ -214,6 +220,7 @@ class BaseConfig(BaseSettings):
     batch_size: int = 20
     summary_length: int = 10000
     summarize_concurrency: int = 8
+    summarize_enabled: bool = True
 
     # Health
     health_port: int = 8080

--- a/main.py
+++ b/main.py
@@ -209,6 +209,11 @@ async def _run(config: BaseConfig) -> None:
     # Inject chunk threshold for ingest plugins
     if "chunk_threshold" in sig.parameters:
         deps["chunk_threshold"] = config.summary_chunk_threshold
+    # Inject summarization toggle and concurrency for ingest plugins
+    if "summarize_enabled" in sig.parameters:
+        deps["summarize_enabled"] = config.summarize_enabled
+    if "summarize_concurrency" in sig.parameters:
+        deps["summarize_concurrency"] = config.summarize_concurrency
     plugin = plugin_class(**deps)
 
     # Plugin lifecycle: startup

--- a/plugins/ingest_space/plugin.py
+++ b/plugins/ingest_space/plugin.py
@@ -43,6 +43,8 @@ class IngestSpacePlugin:
         *,
         summarize_llm: LLMPort | None = None,
         chunk_threshold: int = 4,
+        summarize_enabled: bool = True,
+        summarize_concurrency: int = 8,
     ) -> None:
         self._llm = llm
         self._embeddings = embeddings
@@ -50,6 +52,8 @@ class IngestSpacePlugin:
         self._graphql_client = graphql_client
         self._summarize_llm = summarize_llm
         self._chunk_threshold = chunk_threshold
+        self._summarize_enabled = summarize_enabled
+        self._summarize_concurrency = summarize_concurrency
 
     async def startup(self) -> None:
         logger.info("IngestSpacePlugin started")
@@ -80,19 +84,22 @@ class IngestSpacePlugin:
 
             # Run ingest pipeline with ingest-space specific settings
             summary_llm = self._summarize_llm or self._llm
-            engine = IngestEngine(steps=[
+            steps: list = [
                 ChunkStep(chunk_size=9000, chunk_overlap=500),
                 ContentHashStep(),
                 ChangeDetectionStep(knowledge_store_port=self._knowledge_store),
-                DocumentSummaryStep(
+            ]
+            if self._summarize_enabled:
+                steps.append(DocumentSummaryStep(
                     llm_port=summary_llm,
+                    concurrency=max(1, self._summarize_concurrency),
                     chunk_threshold=self._chunk_threshold,
-                ),
-                BodyOfKnowledgeSummaryStep(llm_port=summary_llm),
-                EmbedStep(embeddings_port=self._embeddings),
-                StoreStep(knowledge_store_port=self._knowledge_store),
-                OrphanCleanupStep(knowledge_store_port=self._knowledge_store),
-            ])
+                ))
+                steps.append(BodyOfKnowledgeSummaryStep(llm_port=summary_llm))
+            steps.append(EmbedStep(embeddings_port=self._embeddings))
+            steps.append(StoreStep(knowledge_store_port=self._knowledge_store))
+            steps.append(OrphanCleanupStep(knowledge_store_port=self._knowledge_store))
+            engine = IngestEngine(steps=steps)
             result = await engine.run(documents, collection_name)
 
             return IngestBodyOfKnowledgeResult(

--- a/plugins/ingest_website/plugin.py
+++ b/plugins/ingest_website/plugin.py
@@ -41,12 +41,16 @@ class IngestWebsitePlugin:
         *,
         summarize_llm: LLMPort | None = None,
         chunk_threshold: int = 4,
+        summarize_enabled: bool = True,
+        summarize_concurrency: int = 8,
     ) -> None:
         self._llm = llm
         self._embeddings = embeddings
         self._knowledge_store = knowledge_store
         self._summarize_llm = summarize_llm
         self._chunk_threshold = chunk_threshold
+        self._summarize_enabled = summarize_enabled
+        self._summarize_concurrency = summarize_concurrency
         self._page_limit = 20  # Default, can be overridden by config
 
     async def startup(self) -> None:
@@ -89,18 +93,16 @@ class IngestWebsitePlugin:
                 )
 
             # Run ingest pipeline
-            from core.config import BaseConfig
-            config = BaseConfig()
             summary_llm = self._summarize_llm or self._llm
             steps: list = [
                 ChunkStep(chunk_size=2000),
                 ContentHashStep(),
                 ChangeDetectionStep(knowledge_store_port=self._knowledge_store),
             ]
-            if config.summarize_concurrency > 0:
+            if self._summarize_enabled:
                 steps.append(DocumentSummaryStep(
                     llm_port=summary_llm,
-                    concurrency=config.summarize_concurrency,
+                    concurrency=max(1, self._summarize_concurrency),
                     chunk_threshold=self._chunk_threshold,
                 ))
                 steps.append(BodyOfKnowledgeSummaryStep(llm_port=summary_llm))

--- a/specs/008-consistent-summarization-behavior/plan.md
+++ b/specs/008-consistent-summarization-behavior/plan.md
@@ -1,0 +1,91 @@
+# Plan: Consistent Summarization Behavior Between ingest-website and ingest-space
+
+**Story:** alkem-io/alkemio#1827
+**Date:** 2026-04-08
+
+## Architecture
+
+No new modules or services. This is a behavioral alignment change across two existing plugins plus a config addition. The hexagonal architecture is preserved -- config is injected, plugins compose their own pipelines.
+
+## Affected Modules
+
+### 1. `core/config.py`
+- Add `summarize_enabled: bool = True` field to `BaseConfig`.
+- Add validation: `summarize_concurrency >= 0`.
+
+### 2. `plugins/ingest_website/plugin.py`
+- Add `summarize_enabled: bool` and `summarize_concurrency: int` constructor parameters (with defaults).
+- Remove inline `from core.config import BaseConfig; config = BaseConfig()` from `handle()`.
+- Conditionally include summary steps based on `self._summarize_enabled` (not concurrency).
+- Pass `max(1, self._summarize_concurrency)` to `DocumentSummaryStep` to treat 0 as sequential.
+
+### 3. `plugins/ingest_space/plugin.py`
+- Add `summarize_enabled: bool` and `summarize_concurrency: int` constructor parameters (with defaults).
+- Conditionally include summary steps based on `self._summarize_enabled`.
+- Pass `max(1, self._summarize_concurrency)` to `DocumentSummaryStep`.
+
+### 4. `main.py`
+- Inject `summarize_enabled` and `summarize_concurrency` from config into ingest plugins via constructor kwargs, alongside existing `summarize_llm` and `chunk_threshold` injection.
+
+### 5. `.env.example`
+- Add `SUMMARIZE_ENABLED=true` with documentation comment.
+- Add `SUMMARIZE_CONCURRENCY=8` (documenting the existing default explicitly).
+
+### 6. Tests
+- `tests/plugins/test_ingest_website.py`: Update existing `test_pipeline_composition` to no longer mock `summarize_concurrency=0` as disabling summarization. Add new tests for `summarize_enabled=True` and `summarize_enabled=False` pipeline composition.
+- `tests/plugins/test_ingest_space.py`: Add tests for `summarize_enabled=True` and `summarize_enabled=False` pipeline composition.
+- `tests/core/test_config_validation.py`: Add test for `summarize_concurrency` negative value validation and `summarize_enabled` field.
+
+## Data Model Deltas
+
+None. No database/store schema changes.
+
+## Interface Contracts
+
+### `IngestWebsitePlugin.__init__` (updated signature)
+```python
+def __init__(
+    self,
+    llm: LLMPort,
+    embeddings: EmbeddingsPort,
+    knowledge_store: KnowledgeStorePort,
+    *,
+    summarize_llm: LLMPort | None = None,
+    chunk_threshold: int = 4,
+    summarize_enabled: bool = True,
+    summarize_concurrency: int = 8,
+) -> None:
+```
+
+### `IngestSpacePlugin.__init__` (updated signature)
+```python
+def __init__(
+    self,
+    llm: LLMPort,
+    embeddings: EmbeddingsPort,
+    knowledge_store: KnowledgeStorePort,
+    graphql_client: Any = None,
+    *,
+    summarize_llm: LLMPort | None = None,
+    chunk_threshold: int = 4,
+    summarize_enabled: bool = True,
+    summarize_concurrency: int = 8,
+) -> None:
+```
+
+### `BaseConfig` (new field)
+```python
+summarize_enabled: bool = True
+```
+
+## Test Strategy
+
+1. **Unit tests -- plugin pipeline composition:** Verify that both plugins include/exclude summary steps based on `summarize_enabled`. Verify `summarize_concurrency=0` does not skip steps.
+2. **Unit tests -- config validation:** Verify `summarize_concurrency` rejects negative values. Verify `summarize_enabled` accepts bool-like values.
+3. **Regression:** All existing tests pass unmodified (except the one test that mocks `summarize_concurrency=0` to disable summarization -- that test's intent changes).
+
+## Rollout Notes
+
+- **Breaking change for `summarize_concurrency=0` users:** Users who previously set `SUMMARIZE_CONCURRENCY=0` to disable summarization in `ingest-website` must now use `SUMMARIZE_ENABLED=false`. The `SUMMARIZE_CONCURRENCY=0` setting will now mean "sequential" (concurrency=1).
+- **Default behavior unchanged:** For users not setting `SUMMARIZE_CONCURRENCY=0`, behavior is identical. Both plugins will always include summary steps by default.
+- **Helm/deployment:** If deployment configs set `SUMMARIZE_CONCURRENCY=0`, they need updating to `SUMMARIZE_ENABLED=false` to maintain the "no summarization" behavior.

--- a/specs/008-consistent-summarization-behavior/spec.md
+++ b/specs/008-consistent-summarization-behavior/spec.md
@@ -1,0 +1,58 @@
+# Spec: Consistent Summarization Behavior Between ingest-website and ingest-space
+
+**Story:** alkem-io/alkemio#1827
+**Date:** 2026-04-08
+**Status:** Draft
+
+## User Value
+
+Operators and developers can rely on consistent, predictable summarization behavior across both ingest plugins. The `summarize_concurrency` config parameter means the same thing in both `ingest-website` and `ingest-space`, and a new explicit `SUMMARIZE_ENABLED` flag provides a clear, unambiguous way to disable summarization entirely.
+
+## Scope
+
+1. **Align `ingest-website` with `ingest-space`:** Always include `DocumentSummaryStep` and `BodyOfKnowledgeSummaryStep` in the `ingest-website` pipeline, regardless of the `summarize_concurrency` value.
+2. **Introduce `SUMMARIZE_ENABLED` config flag:** Add a boolean `summarize_enabled` field (default `True`) to `BaseConfig` that controls whether summarization steps are included in both plugins' pipelines.
+3. **Treat `summarize_concurrency=0` as sequential (concurrency=1):** Stop overloading `summarize_concurrency=0` as "disabled". A value of 0 means "sequential processing" (i.e., concurrency 1).
+4. **Update both plugins:** Both `ingest-website` and `ingest-space` respect `SUMMARIZE_ENABLED` identically.
+5. **Update `.env.example`:** Document the new `SUMMARIZE_ENABLED` flag.
+6. **Update tests:** Add/modify tests to cover the new behavior.
+
+## Out of Scope
+
+- Changing the summarization algorithm or prompt templates.
+- Changing chunk sizes, overlap, or other pipeline parameters.
+- Changing the `DocumentSummaryStep` or `BodyOfKnowledgeSummaryStep` internal logic.
+- Adding new pipeline steps.
+- Changing the concurrency implementation inside `DocumentSummaryStep` (the `concurrency` parameter is passed through but not actively used for async fan-out in the current codebase).
+
+## Acceptance Criteria
+
+1. When `SUMMARIZE_ENABLED=true` (default), both `ingest-website` and `ingest-space` include `DocumentSummaryStep` and `BodyOfKnowledgeSummaryStep` in their pipelines.
+2. When `SUMMARIZE_ENABLED=false`, both plugins skip `DocumentSummaryStep` and `BodyOfKnowledgeSummaryStep`.
+3. `summarize_concurrency=0` no longer disables summarization; it is treated as sequential (concurrency=1).
+4. All existing tests pass.
+5. New tests verify the conditional pipeline composition for both plugins.
+6. `.env.example` documents `SUMMARIZE_ENABLED`.
+
+## Constraints
+
+- Must not break backward compatibility for users who are not setting `SUMMARIZE_ENABLED` (default=True preserves current `ingest-space` behavior).
+- Users who were relying on `summarize_concurrency=0` to disable summarization in `ingest-website` must now use `SUMMARIZE_ENABLED=false`. This is a deliberate breaking change for correctness.
+- Follow existing codebase conventions: Pydantic Settings, env var binding, duck-typed plugins, mock ports in tests.
+
+## Clarifications (resolved during /speckit.clarify)
+
+| # | Question | Decision | Rationale |
+|---|----------|----------|-----------|
+| 1 | Should `summarize_concurrency=0` mean "sequential" or "use default"? | Treat 0 as sequential (concurrency=1) | The parameter name implies parallelism count. Zero logically maps to "not parallel" = sequential. |
+| 2 | Should `SUMMARIZE_ENABLED` default to `true` or `false`? | Default to `true` | Both plugins currently run summarization by default. Least-surprising default preserves existing behavior. |
+| 3 | Where should the `SUMMARIZE_ENABLED` check live? | In each plugin, at pipeline composition time | Plugins own their step lists. Steps should not know about global enable/disable. |
+| 4 | Should both plugins read `summarize_concurrency` from config? | Yes, both from `BaseConfig` | `ingest-space` currently hardcodes the default. Consistency is the goal. |
+| 5 | Should `SUMMARIZE_ENABLED` validation reject invalid values? | Use Pydantic's built-in bool coercion | Standard pattern, handles true/false/1/0/yes/no. |
+| 6 | Does `summarize_concurrency` need negative-value validation? | Yes, validate >= 0 | Negative concurrency is nonsensical. |
+| 7 | How should `ingest-website` obtain config? | Constructor injection, not inline `BaseConfig()` | Aligns with hexagonal architecture; config read once at startup. |
+| 8 | Remove inline `BaseConfig()` from `ingest-website` handle? | Yes, inject `summarize_concurrency` and `summarize_enabled` via constructor | Clean separation of concerns. |
+
+## Supersedes
+
+- `specs/005-fix-document-reliability/spec.md` FR-013: "The ingest website plugin MUST conditionally include summarization steps based on `summarize_concurrency` configuration -- summarization steps are omitted when the value is 0." This behavior is deliberately replaced by the `SUMMARIZE_ENABLED` flag.

--- a/specs/008-consistent-summarization-behavior/tasks.md
+++ b/specs/008-consistent-summarization-behavior/tasks.md
@@ -1,0 +1,120 @@
+# Tasks: Consistent Summarization Behavior Between ingest-website and ingest-space
+
+**Story:** alkem-io/alkemio#1827
+**Date:** 2026-04-08
+
+## Task List (dependency-ordered)
+
+### Task 1: Add `summarize_enabled` field and `summarize_concurrency` validation to `BaseConfig`
+
+**File:** `core/config.py`
+
+**Changes:**
+- Add `summarize_enabled: bool = True` field to `BaseConfig`.
+- Add validation in `_resolve_backward_compat_and_validate`: reject `summarize_concurrency < 0`.
+
+**Acceptance Criteria:**
+- `BaseConfig(summarize_enabled=True)` and `BaseConfig(summarize_enabled=False)` work.
+- `BaseConfig(summarize_concurrency=-1)` raises `ValueError`.
+- `BaseConfig(summarize_concurrency=0)` is accepted (valid value).
+
+**Tests:** `tests/core/test_config_validation.py` -- add negative concurrency test and summarize_enabled field test.
+
+**Dependencies:** None.
+
+---
+
+### Task 2: Update `IngestWebsitePlugin` to use constructor-injected config
+
+**File:** `plugins/ingest_website/plugin.py`
+
+**Changes:**
+- Add `summarize_enabled: bool = True` and `summarize_concurrency: int = 8` keyword-only constructor parameters.
+- Remove inline `from core.config import BaseConfig; config = BaseConfig()` from `handle()`.
+- Gate summary steps on `self._summarize_enabled` instead of `config.summarize_concurrency > 0`.
+- Pass `max(1, self._summarize_concurrency)` as `concurrency` to `DocumentSummaryStep`.
+
+**Acceptance Criteria:**
+- When `summarize_enabled=True`, both summary steps are in the pipeline.
+- When `summarize_enabled=False`, both summary steps are absent.
+- When `summarize_concurrency=0`, summary steps are included (not skipped) and concurrency defaults to 1.
+
+**Tests:** `tests/plugins/test_ingest_website.py` -- update existing test, add new tests.
+
+**Dependencies:** Task 1.
+
+---
+
+### Task 3: Update `IngestSpacePlugin` to accept summarization config
+
+**File:** `plugins/ingest_space/plugin.py`
+
+**Changes:**
+- Add `summarize_enabled: bool = True` and `summarize_concurrency: int = 8` keyword-only constructor parameters.
+- Gate summary steps on `self._summarize_enabled`.
+- Pass `max(1, self._summarize_concurrency)` as `concurrency` to `DocumentSummaryStep`.
+
+**Acceptance Criteria:**
+- When `summarize_enabled=True`, both summary steps are in the pipeline (same as current behavior).
+- When `summarize_enabled=False`, both summary steps are absent.
+- `summarize_concurrency` is forwarded to `DocumentSummaryStep`.
+
+**Tests:** `tests/plugins/test_ingest_space.py` -- add new tests.
+
+**Dependencies:** Task 1.
+
+---
+
+### Task 4: Update `main.py` to inject `summarize_enabled` and `summarize_concurrency`
+
+**File:** `main.py`
+
+**Changes:**
+- In the plugin construction section, inject `summarize_enabled` and `summarize_concurrency` from config into plugins that accept those parameters (same pattern as `chunk_threshold` and `summarize_llm`).
+
+**Acceptance Criteria:**
+- Ingest plugins receive `summarize_enabled` and `summarize_concurrency` from config.
+- Non-ingest plugins are unaffected.
+
+**Tests:** Covered by integration through plugin tests. No separate unit test needed (main.py wiring is tested via existing startup tests).
+
+**Dependencies:** Tasks 2, 3.
+
+---
+
+### Task 5: Update `.env.example`
+
+**File:** `.env.example`
+
+**Changes:**
+- Add `SUMMARIZE_ENABLED=true` with explanatory comment.
+- Add `SUMMARIZE_CONCURRENCY=8` to document the existing default explicitly.
+
+**Acceptance Criteria:**
+- New fields are documented with clear comments.
+
+**Tests:** None (documentation only).
+
+**Dependencies:** Task 1.
+
+---
+
+### Task 6: Update and add tests
+
+**Files:**
+- `tests/plugins/test_ingest_website.py`
+- `tests/plugins/test_ingest_space.py`
+- `tests/core/test_config_validation.py`
+
+**Changes:**
+- Fix existing `test_pipeline_composition` in `test_ingest_website.py` (remove mock of `summarize_concurrency=0` as disabling summarization).
+- Add `test_summarize_enabled_true_includes_summary_steps` for both plugins.
+- Add `test_summarize_enabled_false_excludes_summary_steps` for both plugins.
+- Add `test_summarize_concurrency_zero_does_not_skip_summary` for ingest-website.
+- Add config validation tests for negative `summarize_concurrency` and `summarize_enabled`.
+
+**Acceptance Criteria:**
+- All new tests pass.
+- All existing tests pass.
+
+**Dependencies:** Tasks 2, 3.

--- a/tests/core/test_config_validation.py
+++ b/tests/core/test_config_validation.py
@@ -154,6 +154,42 @@ class TestPerPluginOverride:
         assert resolved is config
 
 
+class TestSummarizeConcurrencyValidation:
+    """Test summarize_concurrency validation."""
+
+    def test_negative_concurrency_raises(self) -> None:
+        with pytest.raises(ValueError, match="SUMMARIZE_CONCURRENCY must be >= 0"):
+            BaseConfig(llm_api_key="key", summarize_concurrency=-1)
+
+    def test_zero_concurrency_accepted(self) -> None:
+        config = BaseConfig(llm_api_key="key", summarize_concurrency=0)
+        assert config.summarize_concurrency == 0
+
+    def test_positive_concurrency_accepted(self) -> None:
+        config = BaseConfig(llm_api_key="key", summarize_concurrency=4)
+        assert config.summarize_concurrency == 4
+
+    def test_default_concurrency(self) -> None:
+        config = BaseConfig(llm_api_key="key")
+        assert config.summarize_concurrency == 8
+
+
+class TestSummarizeEnabledConfig:
+    """Test summarize_enabled config field."""
+
+    def test_default_is_true(self) -> None:
+        config = BaseConfig(llm_api_key="key")
+        assert config.summarize_enabled is True
+
+    def test_explicit_false(self) -> None:
+        config = BaseConfig(llm_api_key="key", summarize_enabled=False)
+        assert config.summarize_enabled is False
+
+    def test_explicit_true(self) -> None:
+        config = BaseConfig(llm_api_key="key", summarize_enabled=True)
+        assert config.summarize_enabled is True
+
+
 class TestUnsupportedProvider:
     """Test unsupported provider fail-fast (FR-008)."""
 

--- a/tests/plugins/test_ingest_space.py
+++ b/tests/plugins/test_ingest_space.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from core.events.ingest_space import IngestBodyOfKnowledgeResult
@@ -102,3 +104,71 @@ class TestIngestSpacePlugin:
     async def test_startup_shutdown(self, plugin):
         await plugin.startup()
         await plugin.shutdown()
+
+    async def test_summarize_enabled_includes_summary_steps(self):
+        """When summarize_enabled=True, pipeline includes summary steps."""
+        from core.domain.ingest_pipeline import Document, DocumentMetadata
+
+        plugin = IngestSpacePlugin(
+            llm=MockLLMPort(),
+            embeddings=MockEmbeddingsPort(),
+            knowledge_store=MockKnowledgeStorePort(),
+            graphql_client=MagicMock(),
+            summarize_enabled=True,
+        )
+        event = make_ingest_body_of_knowledge()
+        mock_docs = [
+            Document(
+                content="Test content",
+                metadata=DocumentMetadata(
+                    document_id="doc-1", source="test", type="knowledge", title="Test",
+                ),
+            )
+        ]
+
+        import asyncio
+        with patch("plugins.ingest_space.space_reader.read_space_tree", return_value=mock_docs), \
+             patch("plugins.ingest_space.plugin.IngestEngine") as mock_engine:
+            mock_engine.return_value.run = lambda *a, **kw: asyncio.coroutine(
+                lambda: MagicMock(success=True, errors=[])
+            )()
+            await plugin.handle(event)
+
+        call_args = mock_engine.call_args
+        step_types = [type(s).__name__ for s in call_args.kwargs.get("steps", call_args[1].get("steps", []))]
+        assert "DocumentSummaryStep" in step_types
+        assert "BodyOfKnowledgeSummaryStep" in step_types
+
+    async def test_summarize_disabled_excludes_summary_steps(self):
+        """When summarize_enabled=False, pipeline excludes summary steps."""
+        from core.domain.ingest_pipeline import Document, DocumentMetadata
+
+        plugin = IngestSpacePlugin(
+            llm=MockLLMPort(),
+            embeddings=MockEmbeddingsPort(),
+            knowledge_store=MockKnowledgeStorePort(),
+            graphql_client=MagicMock(),
+            summarize_enabled=False,
+        )
+        event = make_ingest_body_of_knowledge()
+        mock_docs = [
+            Document(
+                content="Test content",
+                metadata=DocumentMetadata(
+                    document_id="doc-1", source="test", type="knowledge", title="Test",
+                ),
+            )
+        ]
+
+        import asyncio
+        with patch("plugins.ingest_space.space_reader.read_space_tree", return_value=mock_docs), \
+             patch("plugins.ingest_space.plugin.IngestEngine") as mock_engine:
+            mock_engine.return_value.run = lambda *a, **kw: asyncio.coroutine(
+                lambda: MagicMock(success=True, errors=[])
+            )()
+            await plugin.handle(event)
+
+        call_args = mock_engine.call_args
+        step_types = [type(s).__name__ for s in call_args.kwargs.get("steps", call_args[1].get("steps", []))]
+        assert "DocumentSummaryStep" not in step_types
+        assert "BodyOfKnowledgeSummaryStep" not in step_types

--- a/tests/plugins/test_ingest_website.py
+++ b/tests/plugins/test_ingest_website.py
@@ -161,11 +161,7 @@ class TestIngestWebsitePlugin:
         event = make_ingest_website()
         mock_pages = [{"url": "https://example.com", "html": "<p>Content for ingestion test.</p>"}]
 
-        mock_config = MagicMock()
-        mock_config.summarize_concurrency = 0
-
-        with patch("plugins.ingest_website.plugin.crawl", return_value=mock_pages), \
-             patch("core.config.BaseConfig", return_value=mock_config):
+        with patch("plugins.ingest_website.plugin.crawl", return_value=mock_pages):
             result = await plugin.handle(event)
         assert isinstance(result, IngestWebsiteResult)
         # delete_collection is no longer called — incremental dedup replaces it
@@ -182,3 +178,73 @@ class TestIngestWebsitePlugin:
     async def test_startup_shutdown(self, plugin):
         await plugin.startup()
         await plugin.shutdown()
+
+    async def test_summarize_enabled_includes_summary_steps(self):
+        """When summarize_enabled=True, pipeline includes summary steps."""
+        plugin = IngestWebsitePlugin(
+            llm=MockLLMPort(),
+            embeddings=MockEmbeddingsPort(),
+            knowledge_store=MockKnowledgeStorePort(),
+            summarize_enabled=True,
+        )
+        event = make_ingest_website()
+        mock_pages = [{"url": "https://example.com", "html": "<p>Content for ingestion test.</p>"}]
+
+        with patch("plugins.ingest_website.plugin.crawl", return_value=mock_pages), \
+             patch("plugins.ingest_website.plugin.IngestEngine") as mock_engine:
+            mock_engine.return_value.run = MagicMock(return_value=MagicMock(success=True, errors=[]))
+            # Make run a coroutine
+            import asyncio
+            mock_engine.return_value.run = lambda *a, **kw: asyncio.coroutine(lambda: MagicMock(success=True, errors=[]))()
+            await plugin.handle(event)
+
+        # Verify DocumentSummaryStep and BodyOfKnowledgeSummaryStep are in the steps
+        call_args = mock_engine.call_args
+        step_types = [type(s).__name__ for s in call_args.kwargs.get("steps", call_args[1].get("steps", []))]
+        assert "DocumentSummaryStep" in step_types
+        assert "BodyOfKnowledgeSummaryStep" in step_types
+
+    async def test_summarize_disabled_excludes_summary_steps(self):
+        """When summarize_enabled=False, pipeline excludes summary steps."""
+        plugin = IngestWebsitePlugin(
+            llm=MockLLMPort(),
+            embeddings=MockEmbeddingsPort(),
+            knowledge_store=MockKnowledgeStorePort(),
+            summarize_enabled=False,
+        )
+        event = make_ingest_website()
+        mock_pages = [{"url": "https://example.com", "html": "<p>Content for ingestion test.</p>"}]
+
+        with patch("plugins.ingest_website.plugin.crawl", return_value=mock_pages), \
+             patch("plugins.ingest_website.plugin.IngestEngine") as mock_engine:
+            import asyncio
+            mock_engine.return_value.run = lambda *a, **kw: asyncio.coroutine(lambda: MagicMock(success=True, errors=[]))()
+            await plugin.handle(event)
+
+        call_args = mock_engine.call_args
+        step_types = [type(s).__name__ for s in call_args.kwargs.get("steps", call_args[1].get("steps", []))]
+        assert "DocumentSummaryStep" not in step_types
+        assert "BodyOfKnowledgeSummaryStep" not in step_types
+
+    async def test_summarize_concurrency_zero_includes_summary_steps(self):
+        """When summarize_concurrency=0, summary steps are still included (not skipped)."""
+        plugin = IngestWebsitePlugin(
+            llm=MockLLMPort(),
+            embeddings=MockEmbeddingsPort(),
+            knowledge_store=MockKnowledgeStorePort(),
+            summarize_enabled=True,
+            summarize_concurrency=0,
+        )
+        event = make_ingest_website()
+        mock_pages = [{"url": "https://example.com", "html": "<p>Content for ingestion test.</p>"}]
+
+        with patch("plugins.ingest_website.plugin.crawl", return_value=mock_pages), \
+             patch("plugins.ingest_website.plugin.IngestEngine") as mock_engine:
+            import asyncio
+            mock_engine.return_value.run = lambda *a, **kw: asyncio.coroutine(lambda: MagicMock(success=True, errors=[]))()
+            await plugin.handle(event)
+
+        call_args = mock_engine.call_args
+        step_types = [type(s).__name__ for s in call_args.kwargs.get("steps", call_args[1].get("steps", []))]
+        assert "DocumentSummaryStep" in step_types
+        assert "BodyOfKnowledgeSummaryStep" in step_types


### PR DESCRIPTION
## Summary

- Aligns `ingest-website` and `ingest-space` plugins to use a new `SUMMARIZE_ENABLED` boolean flag (default `true`) for controlling whether summarization steps are included in the ingest pipeline
- Removes the overloaded `SUMMARIZE_CONCURRENCY=0` disabling mechanism from `ingest-website`; value of 0 now means "sequential" (concurrency=1)
- Injects `summarize_enabled` and `summarize_concurrency` via constructor in both plugins, removing inline `BaseConfig()` construction from `ingest-website`

Closes alkem-io/alkemio#1827

## Spec artifacts

- `specs/008-consistent-summarization-behavior/spec.md`
- `specs/008-consistent-summarization-behavior/plan.md`
- `specs/008-consistent-summarization-behavior/tasks.md`

Clarify loop iterations: 3
Analyze loop iterations: 2

## Test plan

- [x] All 344 existing tests pass
- [x] New tests verify pipeline composition with `summarize_enabled=True` includes summary steps (both plugins)
- [x] New tests verify pipeline composition with `summarize_enabled=False` excludes summary steps (both plugins)
- [x] New test verifies `summarize_concurrency=0` does not skip summary steps in ingest-website
- [x] Config validation tests for negative `summarize_concurrency` and `summarize_enabled` field
- [x] Ruff lint passes clean
- [x] Pyright typecheck passes with no new errors

Generated with [Claude Code](https://claude.com/claude-code)