### PR TITLE
fix: clean up stale summaries and BoK on edge cases

### DIFF
--- a/core/domain/pipeline/steps.py
+++ b/core/domain/pipeline/steps.py
@@ -278,6 +278,23 @@ class DocumentSummaryStep:
             )
         ]
 
+        # Detect stale per-document summaries: changed documents that dropped
+        # below the chunk threshold no longer qualify for summarization, so
+        # their existing summary entry should be cleaned up.
+        if context.change_detection_ran:
+            for doc_id, doc_chunks in chunks_by_doc.items():
+                if (
+                    doc_id in context.changed_document_ids
+                    and len(doc_chunks) < self._chunk_threshold
+                ):
+                    orphan_id = f"{doc_id}-summary-0"
+                    context.orphan_ids.add(orphan_id)
+                    logger.info(
+                        "Marking stale summary %s for cleanup "
+                        "(document %s dropped to %d chunks, below threshold %d)",
+                        orphan_id, doc_id, len(doc_chunks), self._chunk_threshold,
+                    )
+
         for doc_id, doc_chunks in docs_to_summarize:
             try:
                 logger.info(
@@ -351,7 +368,17 @@ class BodyOfKnowledgeSummaryStep:
             if doc_id not in seen_doc_ids and chunk.metadata.embedding_type != "summary":
                 seen_doc_ids.append(doc_id)
 
+        # When the corpus is completely empty (all documents removed),
+        # mark the BoK summary entry for orphan cleanup.
         if not seen_doc_ids:
+            if context.removed_document_ids:
+                bok_orphan_id = "body-of-knowledge-summary-0"
+                context.orphan_ids.add(bok_orphan_id)
+                logger.info(
+                    "Marking BoK summary %s for cleanup "
+                    "(corpus is empty, %d documents were removed)",
+                    bok_orphan_id, len(context.removed_document_ids),
+                )
             return
 
         # For each doc: prefer document_summaries, else concatenate raw chunk content

--- a/specs/036-summary-lifecycle-management/plan.md
+++ b/specs/036-summary-lifecycle-management/plan.md
@@ -1,0 +1,72 @@
+# Plan: Summary Lifecycle Management -- Clean Up Stale Summaries and BoK on Edge Cases
+
+**Story:** #36
+**Spec:** spec.md
+**Date:** 2026-04-08
+
+## Architecture
+
+This change is entirely within the pipeline step layer (`core/domain/pipeline/steps.py`). No new modules, ports, adapters, or external dependencies are introduced. The fix adds orphan-tagging logic to two existing pipeline steps so that the existing `OrphanCleanupStep` handles the deletion.
+
+### Pipeline Flow (Relevant Steps)
+
+```
+ChunkStep -> ContentHashStep -> ChangeDetectionStep -> DocumentSummaryStep* -> BodyOfKnowledgeSummaryStep* -> EmbedStep -> StoreStep -> OrphanCleanupStep
+```
+
+(*) = modified steps
+
+The key insight is that `OrphanCleanupStep` already deletes any IDs in `context.orphan_ids`. The fix simply ensures the two edge-case IDs are added to that set by the summary steps, which run before `OrphanCleanupStep` in the pipeline.
+
+## Affected Modules
+
+| Module | Change |
+|--------|--------|
+| `core/domain/pipeline/steps.py` :: `DocumentSummaryStep.execute()` | Add stale per-document summary detection after computing `docs_to_summarize` |
+| `core/domain/pipeline/steps.py` :: `BodyOfKnowledgeSummaryStep.execute()` | Add empty-corpus BoK cleanup before the `not seen_doc_ids` early return |
+| `tests/core/domain/test_pipeline_steps.py` | Add tests for both edge cases and no-op paths |
+
+## Data Model Deltas
+
+None. No schema changes. The `PipelineContext.orphan_ids` set is already the correct mechanism for tagging entries to delete.
+
+## Interface Contracts
+
+No changes to any port, adapter, or plugin interface.
+
+## Detailed Design
+
+### Change 1: DocumentSummaryStep -- Stale Summary Cleanup
+
+**Location:** `DocumentSummaryStep.execute()`, after the `docs_to_summarize` list comprehension (line ~279).
+
+**Logic:** Iterate over `chunks_by_doc`. For each `doc_id` that is in `context.changed_document_ids` AND has `len(doc_chunks) < self._chunk_threshold`, add `f"{doc_id}-summary-0"` to `context.orphan_ids`. Log the action.
+
+**Why after `docs_to_summarize`?** The `chunks_by_doc` dict and `changed_document_ids` are both available at this point. The stale detection is logically the complement of the summarization filter.
+
+### Change 2: BodyOfKnowledgeSummaryStep -- Empty Corpus Cleanup
+
+**Location:** `BodyOfKnowledgeSummaryStep.execute()`, after computing `seen_doc_ids` but before the `if not seen_doc_ids: return` guard.
+
+**Logic:** If `not seen_doc_ids` AND `context.removed_document_ids` is non-empty, add `"body-of-knowledge-summary-0"` to `context.orphan_ids` and return. Log the action.
+
+**Why before the early return?** The current early return at `if not seen_doc_ids: return` would skip any cleanup logic. By placing the check first, we ensure the orphan ID is tagged before returning.
+
+## Test Strategy
+
+| Test | AC | Description |
+|------|----|-------------|
+| `test_stale_summary_added_to_orphans_when_below_threshold` | AC-1 | Changed document with < threshold chunks: verify `{doc_id}-summary-0` is in `context.orphan_ids` |
+| `test_no_stale_summary_for_unchanged_document_below_threshold` | AC-3 | Unchanged document with < threshold chunks: verify no orphan ID added |
+| `test_no_stale_summary_for_changed_document_above_threshold` | AC-3 | Changed document with >= threshold chunks: verify no orphan ID added (gets re-summarized) |
+| `test_bok_orphan_on_empty_corpus` | AC-2 | All docs removed, empty chunks: verify `body-of-knowledge-summary-0` in `context.orphan_ids` |
+| `test_bok_no_orphan_when_docs_remain` | AC-3 | Some docs remain after removal: verify BoK orphan NOT added |
+| `test_bok_no_orphan_when_no_removals` | AC-3 | Normal ingest (no removals): verify BoK orphan NOT added |
+
+All tests use the existing `MockLLMPort` and `MockKnowledgeStorePort` fixtures.
+
+## Rollout Notes
+
+- No configuration changes required.
+- No migration needed -- orphan summaries from prior runs will not be retroactively cleaned up. They will be cleaned on the next ingest cycle that triggers change detection for the affected document/corpus.
+- Zero risk to existing functionality: the changes only ADD items to `orphan_ids` under specific conditions that previously resulted in no action.

--- a/specs/036-summary-lifecycle-management/spec.md
+++ b/specs/036-summary-lifecycle-management/spec.md
@@ -1,0 +1,55 @@
+# Spec: Summary Lifecycle Management -- Clean Up Stale Summaries and BoK on Edge Cases
+
+**Story:** #36
+**Status:** Draft
+**Author:** SDD Agent
+**Date:** 2026-04-08
+
+## User Value
+
+Prevent orphaned summary entries from accumulating in the knowledge store, which can pollute RAG retrieval results with stale or irrelevant summaries. Users receive cleaner, more accurate answers when the knowledge store does not contain ghost summaries from documents that no longer qualify or from entirely emptied corpora.
+
+## Scope
+
+### In Scope
+
+1. **Stale per-document summary cleanup:** When a changed document drops below the summary chunk threshold (currently `chunk_threshold`, default 4), add its `{doc_id}-summary-0` entry to `context.orphan_ids` so `OrphanCleanupStep` deletes it.
+
+2. **Empty corpus BoK cleanup:** When all documents have been removed from the source (i.e., `seen_doc_ids` is empty and `removed_document_ids` is non-empty), add `body-of-knowledge-summary-0` to `context.orphan_ids` so `OrphanCleanupStep` deletes it.
+
+### Out of Scope
+
+- Modifying `OrphanCleanupStep` itself (it already handles `context.orphan_ids`).
+- Changing the summary threshold logic or the chunk threshold configuration.
+- Addressing partial corpus removal (some documents remain); the BoK summary step already regenerates in that case.
+- Any transport, event, or API changes.
+- Changes to the store port interface or adapter implementations.
+
+## Acceptance Criteria
+
+1. **AC-1:** When a document previously had >= `chunk_threshold` chunks and after re-chunking has < `chunk_threshold` chunks, and the document is in `changed_document_ids`, the `{doc_id}-summary-0` ID is added to `context.orphan_ids`.
+
+2. **AC-2:** When change detection reports all documents removed (no remaining content chunks) and `removed_document_ids` is non-empty, `body-of-knowledge-summary-0` is added to `context.orphan_ids`.
+
+3. **AC-3:** Normal operation (documents above threshold, partial corpus, no changes) is unaffected -- no false positives on cleanup.
+
+4. **AC-4:** Unit tests cover both edge cases and the no-op paths.
+
+## Constraints
+
+- Changes are limited to `core/domain/pipeline/steps.py`.
+- No new dependencies.
+- Must not break existing tests.
+- The summary storage ID format is `{doc_id}-summary-0` (deterministic, see `StoreStep`).
+- The BoK storage ID format is `body-of-knowledge-summary-0`.
+
+## Clarifications
+
+| # | Ambiguity | Decision | Rationale |
+|---|-----------|----------|-----------|
+| 1 | Should stale summary cleanup apply to all below-threshold documents or only changed ones? | Only documents in `changed_document_ids` | Unchanged documents below threshold never had a summary, or their summary was already cleaned in a prior run. Avoids false positives. |
+| 2 | Issue says "<=3 chunks" but code uses configurable `chunk_threshold=4` with `>=` | Use `len(doc_chunks) < self._chunk_threshold` | Makes the cleanup condition consistent with the summarization condition and respects the configurable threshold. |
+| 3 | Should the empty-corpus BoK check fire before or after the `not seen_doc_ids` early return? | Before the early return | The early return would skip the cleanup logic; the check must precede it to ensure the orphan ID is added. |
+| 4 | Partial removal: should BoK be deleted when some documents remain? | No, only when corpus is fully empty | Partial removal triggers BoK regeneration (existing behavior). Deletion only when zero content documents remain. |
+
+**Clarify loop iterations:** 2 (0 new ambiguities on iteration 2)

--- a/specs/036-summary-lifecycle-management/tasks.md
+++ b/specs/036-summary-lifecycle-management/tasks.md
@@ -1,0 +1,83 @@
+# Tasks: Summary Lifecycle Management -- Clean Up Stale Summaries and BoK on Edge Cases
+
+**Story:** #36
+**Plan:** plan.md
+**Date:** 2026-04-08
+
+## Task List
+
+### T1: Add stale per-document summary detection to DocumentSummaryStep
+
+**File:** `core/domain/pipeline/steps.py`
+**Depends on:** None
+**AC:** AC-1, AC-3
+
+**Description:** In `DocumentSummaryStep.execute()`, after computing `docs_to_summarize`, iterate over all entries in `chunks_by_doc`. For each `doc_id` where:
+- `context.change_detection_ran` is True
+- `doc_id` is in `context.changed_document_ids`
+- `len(doc_chunks) < self._chunk_threshold`
+
+Add `f"{doc_id}-summary-0"` to `context.orphan_ids` and log at INFO level.
+
+**Acceptance test:** `test_stale_summary_added_to_orphans_when_below_threshold`
+
+---
+
+### T2: Add empty-corpus BoK cleanup to BodyOfKnowledgeSummaryStep
+
+**File:** `core/domain/pipeline/steps.py`
+**Depends on:** None
+**AC:** AC-2, AC-3
+
+**Description:** In `BodyOfKnowledgeSummaryStep.execute()`, after computing `seen_doc_ids` and before the `if not seen_doc_ids: return` guard, add a check: if `not seen_doc_ids` and `context.removed_document_ids`, add `"body-of-knowledge-summary-0"` to `context.orphan_ids`, log at INFO, and return early.
+
+**Acceptance test:** `test_bok_orphan_on_empty_corpus`
+
+---
+
+### T3: Write unit tests for stale per-document summary cleanup
+
+**File:** `tests/core/domain/test_pipeline_steps.py`
+**Depends on:** T1
+**AC:** AC-1, AC-3, AC-4
+
+**Tests:**
+1. `test_stale_summary_added_to_orphans_when_below_threshold` -- Changed doc with < threshold chunks has summary orphan tagged
+2. `test_no_stale_summary_for_unchanged_document_below_threshold` -- Unchanged doc below threshold: no orphan tagged
+3. `test_no_stale_summary_for_changed_document_above_threshold` -- Changed doc above threshold: no orphan tagged (gets re-summarized instead)
+
+---
+
+### T4: Write unit tests for empty-corpus BoK cleanup
+
+**File:** `tests/core/domain/test_pipeline_steps.py`
+**Depends on:** T2
+**AC:** AC-2, AC-3, AC-4
+
+**Tests:**
+1. `test_bok_orphan_on_empty_corpus` -- All docs removed, no content chunks: BoK orphan tagged
+2. `test_bok_no_orphan_when_docs_remain` -- Some docs remain: BoK orphan NOT tagged
+3. `test_bok_no_orphan_when_no_removals` -- No removals: BoK orphan NOT tagged
+
+---
+
+### T5: Run full test suite and verify all gates pass
+
+**Depends on:** T1, T2, T3, T4
+**AC:** All
+
+**Description:** Run `poetry run pytest`, `poetry run ruff check core/ plugins/ tests/`, and `poetry run pyright core/ plugins/`. All must pass.
+
+## Dependency Order
+
+```
+T1 ──┐
+     ├── T3 ──┐
+T2 ──┤        ├── T5
+     ├── T4 ──┘
+     │
+```
+
+T1 and T2 are independent and can be done in parallel.
+T3 depends on T1. T4 depends on T2.
+T5 depends on all prior tasks.

--- a/tests/core/domain/test_pipeline_steps.py
+++ b/tests/core/domain/test_pipeline_steps.py
@@ -1117,3 +1117,206 @@ class TestPipelineIntegration:
         remaining_doc_ids = {it["metadata"].get("documentId") for it in remaining}
         assert "doc-b" not in remaining_doc_ids
         assert "doc-a" in remaining_doc_ids
+
+
+# ---------------------------------------------------------------------------
+# T036-1: Stale per-document summary cleanup tests
+# ---------------------------------------------------------------------------
+
+class TestStaleSummaryCleanup:
+    """Tests for DocumentSummaryStep marking stale summaries as orphans."""
+
+    async def test_stale_summary_added_to_orphans_when_below_threshold(self):
+        """Changed document below threshold: its summary should be orphaned."""
+        llm = MockLLMPort(response="Summary")
+        step = DocumentSummaryStep(llm_port=llm, chunk_threshold=4)
+
+        meta = DocumentMetadata(
+            document_id="doc-shrunk", source="s", type="knowledge",
+            title="T", embedding_type="chunk",
+        )
+        # Only 2 chunks -- below threshold of 4
+        chunks = [
+            Chunk(content=f"chunk {i}", metadata=meta, chunk_index=i)
+            for i in range(2)
+        ]
+
+        ctx = PipelineContext(
+            collection_name="test",
+            documents=[],
+            chunks=chunks,
+            change_detection_ran=True,
+            changed_document_ids={"doc-shrunk"},
+        )
+
+        await step.execute(ctx)
+
+        assert "doc-shrunk-summary-0" in ctx.orphan_ids
+        # No summary should be generated (below threshold)
+        assert "doc-shrunk" not in ctx.document_summaries
+        assert len(llm.calls) == 0
+
+    async def test_no_stale_summary_for_unchanged_document_below_threshold(self):
+        """Unchanged document below threshold: no orphan should be tagged."""
+        llm = MockLLMPort()
+        step = DocumentSummaryStep(llm_port=llm, chunk_threshold=4)
+
+        meta = DocumentMetadata(
+            document_id="doc-small", source="s", type="knowledge",
+            title="T", embedding_type="chunk",
+        )
+        chunks = [
+            Chunk(content=f"chunk {i}", metadata=meta, chunk_index=i)
+            for i in range(2)
+        ]
+
+        ctx = PipelineContext(
+            collection_name="test",
+            documents=[],
+            chunks=chunks,
+            change_detection_ran=True,
+            changed_document_ids=set(),  # doc-small is NOT changed
+        )
+
+        await step.execute(ctx)
+
+        assert "doc-small-summary-0" not in ctx.orphan_ids
+        assert len(llm.calls) == 0
+
+    async def test_no_stale_summary_for_changed_document_above_threshold(self):
+        """Changed document above threshold: no orphan, gets re-summarized."""
+        llm = MockLLMPort(response="New summary")
+        step = DocumentSummaryStep(llm_port=llm, chunk_threshold=4)
+
+        meta = DocumentMetadata(
+            document_id="doc-big", source="s", type="knowledge",
+            title="T", embedding_type="chunk",
+        )
+        # 5 chunks -- above threshold of 4
+        chunks = [
+            Chunk(content=f"chunk {i}", metadata=meta, chunk_index=i)
+            for i in range(5)
+        ]
+
+        ctx = PipelineContext(
+            collection_name="test",
+            documents=[],
+            chunks=chunks,
+            change_detection_ran=True,
+            changed_document_ids={"doc-big"},
+        )
+
+        await step.execute(ctx)
+
+        assert "doc-big-summary-0" not in ctx.orphan_ids
+        # Should be re-summarized
+        assert "doc-big" in ctx.document_summaries
+        assert len(llm.calls) > 0
+
+    async def test_no_stale_detection_when_change_detection_did_not_run(self):
+        """When change detection did not run, no stale summary detection."""
+        llm = MockLLMPort()
+        step = DocumentSummaryStep(llm_port=llm, chunk_threshold=4)
+
+        meta = DocumentMetadata(
+            document_id="doc-x", source="s", type="knowledge",
+            title="T", embedding_type="chunk",
+        )
+        chunks = [
+            Chunk(content=f"chunk {i}", metadata=meta, chunk_index=i)
+            for i in range(2)
+        ]
+
+        ctx = PipelineContext(
+            collection_name="test",
+            documents=[],
+            chunks=chunks,
+            change_detection_ran=False,  # change detection did not run
+        )
+
+        await step.execute(ctx)
+
+        assert "doc-x-summary-0" not in ctx.orphan_ids
+
+
+# ---------------------------------------------------------------------------
+# T036-2: Empty corpus BoK summary cleanup tests
+# ---------------------------------------------------------------------------
+
+class TestBokSummaryCleanup:
+    """Tests for BodyOfKnowledgeSummaryStep marking BoK summary as orphan on empty corpus."""
+
+    async def test_bok_orphan_on_empty_corpus(self):
+        """All docs removed, no content chunks: BoK summary should be orphaned."""
+        llm = MockLLMPort()
+        ctx = PipelineContext(
+            collection_name="test",
+            documents=[],
+            chunks=[],  # No chunks at all
+            change_detection_ran=True,
+            removed_document_ids={"doc-a", "doc-b"},
+        )
+
+        await BodyOfKnowledgeSummaryStep(llm_port=llm).execute(ctx)
+
+        assert "body-of-knowledge-summary-0" in ctx.orphan_ids
+        assert len(llm.calls) == 0  # No LLM call since there's nothing to summarize
+
+    async def test_bok_no_orphan_when_docs_remain(self):
+        """Some docs remain after removal: BoK should be regenerated, not orphaned."""
+        llm = MockLLMPort(response="New BoK overview")
+        meta = DocumentMetadata(
+            document_id="remaining-doc", source="s", type="knowledge",
+            title="T", embedding_type="chunk",
+        )
+        ctx = PipelineContext(
+            collection_name="test",
+            documents=[],
+            chunks=[
+                Chunk(content="remaining content", metadata=meta, chunk_index=0),
+            ],
+            change_detection_ran=True,
+            changed_document_ids=set(),
+            removed_document_ids={"removed-doc"},
+        )
+
+        await BodyOfKnowledgeSummaryStep(llm_port=llm).execute(ctx)
+
+        assert "body-of-knowledge-summary-0" not in ctx.orphan_ids
+        # BoK should have been regenerated
+        bok_chunks = [c for c in ctx.chunks if c.metadata.document_id == "body-of-knowledge-summary"]
+        assert len(bok_chunks) == 1
+
+    async def test_bok_no_orphan_when_no_removals(self):
+        """Normal ingest with no removals: BoK should not be orphaned."""
+        llm = MockLLMPort(response="BoK overview")
+        meta = DocumentMetadata(
+            document_id="doc-1", source="s", type="knowledge",
+            title="T", embedding_type="chunk",
+        )
+        ctx = PipelineContext(
+            collection_name="test",
+            documents=[],
+            chunks=[
+                Chunk(content="content", metadata=meta, chunk_index=0),
+            ],
+        )
+
+        await BodyOfKnowledgeSummaryStep(llm_port=llm).execute(ctx)
+
+        assert "body-of-knowledge-summary-0" not in ctx.orphan_ids
+
+    async def test_bok_no_orphan_empty_corpus_no_removals(self):
+        """Empty corpus but no removals (first run with no docs): no orphan."""
+        llm = MockLLMPort()
+        ctx = PipelineContext(
+            collection_name="test",
+            documents=[],
+            chunks=[],
+            removed_document_ids=set(),
+        )
+
+        await BodyOfKnowledgeSummaryStep(llm_port=llm).execute(ctx)
+
+        assert "body-of-knowledge-summary-0" not in ctx.orphan_ids
+        assert len(llm.calls) == 0


### PR DESCRIPTION
## Summary

- Adds stale per-document summary cleanup in `DocumentSummaryStep`: when a changed document drops below the chunk threshold, its `{doc_id}-summary-0` entry is tagged as an orphan for deletion
- Adds empty-corpus BoK cleanup in `BodyOfKnowledgeSummaryStep`: when all documents are removed, `body-of-knowledge-summary-0` is tagged as an orphan for deletion
- Adds 8 unit tests covering both edge cases and all no-op guard paths

Closes #36

## Spec artifacts

- `specs/036-summary-lifecycle-management/spec.md`
- `specs/036-summary-lifecycle-management/plan.md`
- `specs/036-summary-lifecycle-management/tasks.md`

**Clarify loop iterations:** 2
**Analyze loop iterations:** 2

## Test plan

- [x] Stale summary orphaned when changed doc drops below threshold
- [x] No false orphan for unchanged docs below threshold
- [x] No false orphan for changed docs above threshold (re-summarized)
- [x] No stale detection when change detection did not run
- [x] BoK orphaned on fully empty corpus with removals
- [x] BoK NOT orphaned when docs remain after partial removal
- [x] BoK NOT orphaned on normal ingest (no removals)
- [x] BoK NOT orphaned on empty corpus with no removals (first run)
- [x] Full test suite passes (340 tests)
- [x] Ruff lint clean
- [x] Pyright 0 errors

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic cleanup of stale per-document summaries when modified documents fall below configured chunk threshold
  * Automatic cleanup of knowledge base summary when entire corpus is emptied

* **Documentation**
  * Added specification documents for Summary Lifecycle Management behavior

* **Tests**
  * Added test coverage for stale summary cleanup and empty corpus scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->