### PR TITLE
feat: incremental embedding after summarization

### DIFF
--- a/core/domain/pipeline/steps.py
+++ b/core/domain/pipeline/steps.py
@@ -239,7 +239,13 @@ class ChangeDetectionStep:
 # ---------------------------------------------------------------------------
 
 class DocumentSummaryStep:
-    """Generate per-document summaries for docs with >= chunk_threshold chunks."""
+    """Generate per-document summaries for docs with >= chunk_threshold chunks.
+
+    When *embeddings_port* is provided, each document's chunks (content + summary)
+    are embedded immediately after that document's summary is produced.  This
+    overlaps LLM-bound summarization I/O with GPU-bound embedding I/O, reducing
+    total pipeline wall-clock time.
+    """
 
     def __init__(
         self,
@@ -247,6 +253,8 @@ class DocumentSummaryStep:
         summary_length: int = 10000,
         concurrency: int = 8,
         chunk_threshold: int = 4,
+        embeddings_port: EmbeddingsPort | None = None,
+        embed_batch_size: int = 50,
     ) -> None:
         if chunk_threshold < 1:
             raise ValueError("chunk_threshold must be >= 1")
@@ -254,6 +262,8 @@ class DocumentSummaryStep:
         self._summary_length = summary_length
         self._concurrency = concurrency
         self._chunk_threshold = chunk_threshold
+        self._embeddings = embeddings_port
+        self._embed_batch_size = embed_batch_size
         self._model_name = getattr(
             getattr(llm_port, "_llm", None), "model", "unknown"
         )
@@ -261,6 +271,30 @@ class DocumentSummaryStep:
     @property
     def name(self) -> str:
         return "document_summary"
+
+    async def _embed_document_chunks(
+        self,
+        chunks: list[Chunk],
+        context: PipelineContext,
+        doc_id: str,
+    ) -> None:
+        """Embed chunks that do not already have an embedding."""
+        assert self._embeddings is not None  # noqa: S101
+        to_embed = [c for c in chunks if c.embedding is None]
+        if not to_embed:
+            return
+
+        for i in range(0, len(to_embed), self._embed_batch_size):
+            batch = to_embed[i : i + self._embed_batch_size]
+            texts = [c.content for c in batch]
+            try:
+                embeddings = await self._embeddings.embed(texts)
+                for chunk, embedding in zip(batch, embeddings):
+                    chunk.embedding = embedding
+            except Exception as exc:
+                context.errors.append(
+                    f"DocumentSummaryStep: embedding failed for {doc_id}: {exc}"
+                )
 
     async def execute(self, context: PipelineContext) -> None:
         # Group chunks by document_id
@@ -302,10 +336,17 @@ class DocumentSummaryStep:
                     title=source_meta.title,
                     embedding_type="summary",
                 )
-                context.chunks.append(
-                    Chunk(content=summary, metadata=summary_meta, chunk_index=0)
+                summary_chunk = Chunk(
+                    content=summary, metadata=summary_meta, chunk_index=0,
                 )
+                context.chunks.append(summary_chunk)
                 logger.info("Summarized document %s", doc_id)
+
+                # Incremental embedding: embed this document's chunks immediately
+                if self._embeddings is not None:
+                    await self._embed_document_chunks(
+                        doc_chunks + [summary_chunk], context, doc_id,
+                    )
             except Exception as exc:
                 logger.warning("Summarization failed for %s: %s", doc_id, exc)
                 context.errors.append(

--- a/plugins/ingest_space/plugin.py
+++ b/plugins/ingest_space/plugin.py
@@ -87,6 +87,7 @@ class IngestSpacePlugin:
                 DocumentSummaryStep(
                     llm_port=summary_llm,
                     chunk_threshold=self._chunk_threshold,
+                    embeddings_port=self._embeddings,
                 ),
                 BodyOfKnowledgeSummaryStep(llm_port=summary_llm),
                 EmbedStep(embeddings_port=self._embeddings),

--- a/plugins/ingest_website/plugin.py
+++ b/plugins/ingest_website/plugin.py
@@ -102,6 +102,7 @@ class IngestWebsitePlugin:
                     llm_port=summary_llm,
                     concurrency=config.summarize_concurrency,
                     chunk_threshold=self._chunk_threshold,
+                    embeddings_port=self._embeddings,
                 ))
                 steps.append(BodyOfKnowledgeSummaryStep(llm_port=summary_llm))
             steps.append(EmbedStep(embeddings_port=self._embeddings))

--- a/specs/008-incremental-embedding/clarifications.md
+++ b/specs/008-incremental-embedding/clarifications.md
@@ -1,0 +1,51 @@
+# Clarifications
+
+**Iteration count:** 1
+
+## Clarification 1: Should DocumentSummaryStep embed ALL of a document's chunks, or only the changed ones?
+
+**Question:** When DocumentSummaryStep finishes summarizing a document, should it embed all chunks for that document, or only those without a pre-existing embedding (from change detection)?
+
+**Resolution:** Only embed chunks that do not already have an embedding (`chunk.embedding is None`). This is consistent with how EmbedStep already works and respects the change detection optimization that pre-loads embeddings for unchanged chunks.
+
+**Rationale:** Unchanged chunks already have their embeddings pre-loaded by ChangeDetectionStep. Re-embedding them would waste GPU resources and contradict the deduplication design (ADR-006).
+
+## Clarification 2: Should the embeddings_port parameter be required or optional in DocumentSummaryStep?
+
+**Question:** Should `embeddings_port` be a required constructor parameter, or optional (defaulting to None for backward compatibility)?
+
+**Resolution:** Optional, defaulting to `None`. When `None`, DocumentSummaryStep behaves exactly as before (no incremental embedding). When provided, it performs incremental embedding after each document's summary.
+
+**Rationale:** This preserves backward compatibility. Any existing code that constructs DocumentSummaryStep without an embeddings_port continues to work. The parameter is only used when explicitly passed by the plugin pipeline assembly.
+
+## Clarification 3: Should the summary chunk itself be embedded incrementally?
+
+**Question:** After DocumentSummaryStep creates a summary chunk for a document, should that summary chunk also be embedded immediately, or left for EmbedStep?
+
+**Resolution:** Yes, embed the summary chunk immediately as well. Since we already have the embeddings port available and the summary chunk is freshly created, embedding it right away avoids leaving it for EmbedStep and maximizes the overlap benefit.
+
+**Rationale:** The summary chunk is produced at the same time as the document's content chunks are ready for embedding. Embedding it together with the content chunks (or right after) is a natural extension and avoids any gap.
+
+## Clarification 4: What batch_size should DocumentSummaryStep use for embedding?
+
+**Question:** EmbedStep uses a configurable `batch_size` (default 50). Should DocumentSummaryStep use the same batch size, or a different default?
+
+**Resolution:** Use the same default of 50, exposed as an `embed_batch_size` constructor parameter for consistency. In practice, a single document's chunks will typically be fewer than 50, so most documents will be embedded in a single batch call.
+
+**Rationale:** Consistency with EmbedStep defaults. The batch_size controls API call granularity to the embedding service; same default makes behavior predictable.
+
+## Clarification 5: How should embedding errors within DocumentSummaryStep be reported?
+
+**Question:** If embedding fails for a document's chunks during DocumentSummaryStep, should it be reported as a DocumentSummaryStep error or an EmbedStep error?
+
+**Resolution:** Report as a DocumentSummaryStep error with a clear prefix indicating it was the embedding sub-operation that failed, e.g., `"DocumentSummaryStep: embedding failed for {doc_id}: {exc}"`. The summarization itself succeeded; only the incremental embedding failed. EmbedStep will still attempt to embed any chunks left without embeddings.
+
+**Rationale:** The error originates within DocumentSummaryStep's execute method, so attributing it there is accurate. EmbedStep's fallback behavior (embed chunks without embeddings) provides resilience.
+
+## Clarification 6: Should documents below the chunk_threshold also get their chunks embedded incrementally?
+
+**Question:** Documents with fewer chunks than `chunk_threshold` are not summarized. Should their chunks be embedded during DocumentSummaryStep anyway?
+
+**Resolution:** No. Documents below the threshold are not processed by DocumentSummaryStep at all. Their chunks will be embedded by EmbedStep as before.
+
+**Rationale:** The purpose of incremental embedding is to overlap with summarization I/O. Documents that are not summarized have no summarization I/O to overlap with, so there is no benefit. Keeping DocumentSummaryStep focused on its core responsibility (summarize + embed summarized documents) is cleaner.

--- a/specs/008-incremental-embedding/plan.md
+++ b/specs/008-incremental-embedding/plan.md
@@ -1,0 +1,77 @@
+# Plan: Incremental Embedding After Summarization
+
+**Story:** alkem-io/alkemio#1826
+**Created:** 2026-04-08
+
+## Architecture
+
+The change follows Option A from the story: per-document embed after summary. The modification is entirely within the pipeline steps layer, requiring no changes to the pipeline engine, ports, adapters, or event models.
+
+### Affected Modules
+
+| Module | Change |
+|--------|--------|
+| `core/domain/pipeline/steps.py` | Modify `DocumentSummaryStep.__init__` to accept optional `embeddings_port` and `embed_batch_size`. Add `_embed_document_chunks` helper method. Call it after each document summary. |
+| `plugins/ingest_space/plugin.py` | Pass `embeddings_port=self._embeddings` to `DocumentSummaryStep` constructor. |
+| `plugins/ingest_website/plugin.py` | Pass `embeddings_port=self._embeddings` to `DocumentSummaryStep` constructor. |
+| `tests/core/domain/test_pipeline_steps.py` | Add new tests for incremental embedding behavior in `TestDocumentSummaryStep`. |
+
+### Modules NOT Changed
+
+- `core/domain/pipeline/engine.py` -- No engine changes needed.
+- `core/domain/pipeline/__init__.py` -- No new exports.
+- `core/ports/embeddings.py` -- Port interface unchanged.
+- `core/domain/ingest_pipeline.py` -- Data models unchanged.
+- `tests/conftest.py` -- Existing mock ports sufficient.
+
+## Data Model Deltas
+
+None. The `Chunk`, `Document`, `DocumentMetadata`, `IngestResult`, and `PipelineContext` dataclasses are unchanged. The only runtime difference is that `chunk.embedding` gets populated earlier (during DocumentSummaryStep instead of during EmbedStep).
+
+## Interface Contracts
+
+### DocumentSummaryStep Constructor (modified)
+
+```python
+def __init__(
+    self,
+    llm_port: LLMPort,
+    summary_length: int = 10000,
+    concurrency: int = 8,
+    chunk_threshold: int = 4,
+    embeddings_port: EmbeddingsPort | None = None,  # NEW
+    embed_batch_size: int = 50,                       # NEW
+) -> None:
+```
+
+When `embeddings_port is None`: behavior identical to current (no incremental embedding).
+When `embeddings_port is not None`: after each document summary, embeds that document's chunks + summary chunk.
+
+### _embed_document_chunks helper (new private method)
+
+```python
+async def _embed_document_chunks(
+    self,
+    chunks: list[Chunk],
+    context: PipelineContext,
+    doc_id: str,
+) -> None:
+```
+
+Filters to chunks needing embedding (`embedding is None`), batches them by `embed_batch_size`, calls `self._embeddings.embed(texts)`, and assigns embeddings. Errors are appended to `context.errors`.
+
+## Test Strategy
+
+1. **Unit test: incremental embedding after summary** -- Verify that after DocumentSummaryStep runs with an embeddings_port, all chunks for summarized documents have embeddings.
+2. **Unit test: summary chunk gets embedded** -- Verify the summary chunk itself receives an embedding.
+3. **Unit test: unchanged chunks not re-embedded** -- Pre-load embedding on a chunk, verify it is not sent to the embeddings port.
+4. **Unit test: no embeddings_port means no embedding** -- Verify backward compat: without embeddings_port, chunks remain un-embedded after DocumentSummaryStep.
+5. **Unit test: embedding error does not block summarization** -- Verify that if embedding fails, the summary still exists and errors are recorded.
+6. **Integration test: full pipeline still produces correct results** -- Existing TestIngestEngine tests cover this; ensure they still pass.
+
+## Rollout Notes
+
+- This is a pure performance optimization. No configuration changes required.
+- The feature activates automatically when both plugins pass embeddings_port to DocumentSummaryStep.
+- Monitoring: the `document_summary` step's duration in metrics will now include embedding time for that step. The `embed` step's duration will decrease proportionally since most chunks are pre-embedded.
+- Rollback: simply remove the `embeddings_port` parameter from the plugin pipeline assemblies to revert to batch embedding.

--- a/specs/008-incremental-embedding/spec.md
+++ b/specs/008-incremental-embedding/spec.md
@@ -1,0 +1,42 @@
+# Spec: Incremental Embedding After Summarization
+
+**Story:** alkem-io/alkemio#1826
+**Status:** Draft
+**Created:** 2026-04-08
+
+## User Value
+
+Reduce total ingest pipeline wall-clock time by overlapping summarization (LLM-bound I/O) with embedding (GPU-bound I/O). Currently, all document chunks wait idle after summarization until every document finishes before embedding begins. By embedding each document's chunks immediately after its summary completes, the pipeline exploits the fact that summarization and embedding use different resources (LLM vs GPU), enabling parallel utilization and cutting total pipeline time significantly.
+
+## Scope
+
+- Modify `DocumentSummaryStep` to accept an `EmbeddingsPort` and embed each document's chunks immediately after that document's summary is produced.
+- Ensure the existing `EmbedStep` gracefully handles chunks that were already embedded by `DocumentSummaryStep` (skip pre-embedded chunks, which it already does).
+- Maintain backward compatibility: pipelines that do not use `DocumentSummaryStep` continue to work unchanged with `EmbedStep` alone.
+- Update both plugin pipeline assemblies (`ingest_space`, `ingest_website`) to pass the embeddings port to `DocumentSummaryStep`.
+
+## Out of Scope
+
+- Background embedding workers or async queues (Option B from the story).
+- Streaming pipeline engine redesign (Option C from the story).
+- Concurrent summarization across documents (covered by sibling story #1823).
+- Changes to `BodyOfKnowledgeSummaryStep` -- its single summary chunk can be embedded by the existing `EmbedStep` which runs after.
+- Changes to the pipeline engine itself (`IngestEngine`).
+
+## Acceptance Criteria
+
+1. After `DocumentSummaryStep` completes summarization of a document, all of that document's content chunks (that need embedding) are embedded before the next document's summarization begins.
+2. The summary chunk produced for each document is also embedded immediately after creation.
+3. `EmbedStep` continues to embed any remaining un-embedded chunks (e.g., BoK summary, chunks from documents below the chunk threshold that were not summarized).
+4. No change in the final stored data -- the same chunks with the same embeddings and metadata end up in ChromaDB.
+5. Existing tests pass without modification (EmbedStep skip-pre-embedded behavior is already tested).
+6. New unit tests cover the incremental embedding behavior within DocumentSummaryStep.
+7. Pipeline assembly in both ingest plugins passes embeddings_port to DocumentSummaryStep.
+
+## Constraints
+
+- Python 3.12, async throughout.
+- No new dependencies.
+- Must not break the pipeline step protocol (`PipelineStep` with `name` property and `async execute(context)` method).
+- Embedding is done via `EmbeddingsPort.embed(texts)` which accepts batches.
+- Change detection pre-loads embeddings for unchanged chunks; these must not be re-embedded.

--- a/specs/008-incremental-embedding/tasks.md
+++ b/specs/008-incremental-embedding/tasks.md
@@ -1,0 +1,79 @@
+# Tasks: Incremental Embedding After Summarization
+
+**Story:** alkem-io/alkemio#1826
+**Created:** 2026-04-08
+
+## Task Dependency Order
+
+```
+T1 --> T2 --> T3 --> T4 --> T5
+```
+
+## T1: Add embeddings_port parameter and _embed_document_chunks helper to DocumentSummaryStep
+
+**File:** `core/domain/pipeline/steps.py`
+
+**Changes:**
+1. Add `embeddings_port: EmbeddingsPort | None = None` and `embed_batch_size: int = 50` to `DocumentSummaryStep.__init__`.
+2. Add private `_embed_document_chunks(self, chunks, context, doc_id)` method that:
+   - Filters chunks to those with `embedding is None`.
+   - Batches by `self._embed_batch_size`.
+   - Calls `self._embeddings.embed(texts)` for each batch.
+   - Assigns embeddings to chunks.
+   - On error, appends `"DocumentSummaryStep: embedding failed for {doc_id}: {exc}"` to context.errors.
+3. After each document summary loop iteration (after creating summary chunk and appending to context), if `self._embeddings is not None`, call `_embed_document_chunks` with the document's content chunks plus the newly created summary chunk.
+
+**Acceptance Criteria:**
+- DocumentSummaryStep accepts optional embeddings_port.
+- When provided, chunks for each summarized document are embedded immediately after summary.
+- When not provided, behavior is identical to current.
+
+**Tests:** T3 covers this.
+
+## T2: Update plugin pipeline assemblies to pass embeddings_port
+
+**Files:** `plugins/ingest_space/plugin.py`, `plugins/ingest_website/plugin.py`
+
+**Changes:**
+1. In `IngestSpacePlugin.handle`, add `embeddings_port=self._embeddings` to the `DocumentSummaryStep(...)` constructor call.
+2. In `IngestWebsitePlugin.handle`, add `embeddings_port=self._embeddings` to the `DocumentSummaryStep(...)` constructor call.
+
+**Acceptance Criteria:**
+- Both ingest plugins pass their embeddings port to DocumentSummaryStep.
+- Pipeline step order is unchanged.
+- EmbedStep remains in the pipeline to handle any remaining un-embedded chunks.
+
+**Tests:** Existing plugin tests, plus T3 unit tests.
+
+## T3: Write unit tests for incremental embedding behavior
+
+**File:** `tests/core/domain/test_pipeline_steps.py`
+
+**Tests to add in `TestDocumentSummaryStep`:**
+1. `test_incremental_embedding_after_summary` -- With embeddings_port, all chunks for a summarized document have embeddings after execute.
+2. `test_summary_chunk_gets_embedded` -- The summary chunk produced for the document also has an embedding.
+3. `test_unchanged_chunks_not_re_embedded` -- Chunks with pre-existing embeddings are not sent to the embeddings port.
+4. `test_no_embedding_without_port` -- Without embeddings_port (None), chunks remain without embeddings after DocumentSummaryStep.
+5. `test_embedding_error_does_not_block_summary` -- If embedding raises, the summary still exists and errors are recorded but no exception propagates.
+
+**Acceptance Criteria:**
+- All five tests pass.
+- Tests use MockEmbeddingsPort from conftest.
+
+## T4: Verify existing tests pass
+
+**Command:** `poetry run pytest`
+
+**Acceptance Criteria:**
+- All existing tests pass without modification.
+- No regressions in EmbedStep, StoreStep, ChangeDetectionStep, or IngestEngine tests.
+
+## T5: Lint, type-check, build verification
+
+**Commands:**
+- `poetry run ruff check core/ plugins/ tests/`
+- `poetry run pyright core/ plugins/`
+
+**Acceptance Criteria:**
+- Zero ruff violations.
+- Zero pyright errors.

--- a/tests/core/domain/test_pipeline_steps.py
+++ b/tests/core/domain/test_pipeline_steps.py
@@ -238,6 +238,113 @@ class TestDocumentSummaryStep:
         llm = MockLLMPort()
         assert DocumentSummaryStep(llm_port=llm).name == "document_summary"
 
+    async def test_incremental_embedding_after_summary(self):
+        """With embeddings_port, all chunks for a summarized document have embeddings."""
+        llm = MockLLMPort(response="Generated summary")
+        embeddings = MockEmbeddingsPort()
+        ctx = _make_context()
+        await ChunkStep(chunk_size=100, chunk_overlap=10).execute(ctx)
+        assert len(ctx.chunks) > 3, "Test doc should produce >3 chunks"
+
+        await DocumentSummaryStep(
+            llm_port=llm, embeddings_port=embeddings,
+        ).execute(ctx)
+
+        # All chunks for doc-1 (content + summary) should have embeddings
+        doc1_chunks = [
+            c for c in ctx.chunks
+            if c.metadata.document_id in ("doc-1", "doc-1-summary")
+        ]
+        assert all(c.embedding is not None for c in doc1_chunks)
+        # Embeddings port should have been called
+        assert len(embeddings.calls) >= 1
+
+    async def test_summary_chunk_gets_embedded(self):
+        """The summary chunk produced for a document also receives an embedding."""
+        llm = MockLLMPort(response="Summary text")
+        embeddings = MockEmbeddingsPort()
+        ctx = _make_context()
+        await ChunkStep(chunk_size=100, chunk_overlap=10).execute(ctx)
+
+        await DocumentSummaryStep(
+            llm_port=llm, embeddings_port=embeddings,
+        ).execute(ctx)
+
+        summary_chunks = [
+            c for c in ctx.chunks if c.metadata.embedding_type == "summary"
+        ]
+        assert len(summary_chunks) == 1
+        assert summary_chunks[0].embedding is not None
+
+    async def test_unchanged_chunks_not_re_embedded(self):
+        """Chunks with pre-existing embeddings are not sent to the embeddings port."""
+        llm = MockLLMPort(response="Summary")
+        embeddings = MockEmbeddingsPort()
+        meta = DocumentMetadata(
+            document_id="doc-1", source="s", type="knowledge",
+            title="T", embedding_type="chunk",
+        )
+        # Create chunks where all content chunks already have embeddings
+        pre_embedded_chunks = [
+            Chunk(
+                content=f"chunk {i}", metadata=meta, chunk_index=i,
+                embedding=[float(i)] * 384,
+            )
+            for i in range(5)
+        ]
+        ctx = PipelineContext(
+            collection_name="test",
+            documents=[_make_doc()],
+            chunks=pre_embedded_chunks,
+        )
+
+        await DocumentSummaryStep(
+            llm_port=llm, embeddings_port=embeddings,
+        ).execute(ctx)
+
+        # Only the summary chunk (which is new) should be sent for embedding
+        assert len(embeddings.calls) == 1
+        assert len(embeddings.calls[0]) == 1  # Just the summary chunk
+
+    async def test_no_embedding_without_port(self):
+        """Without embeddings_port, chunks remain without embeddings after step."""
+        llm = MockLLMPort(response="Summary")
+        ctx = _make_context()
+        await ChunkStep(chunk_size=100, chunk_overlap=10).execute(ctx)
+
+        await DocumentSummaryStep(llm_port=llm).execute(ctx)
+
+        content_chunks = [
+            c for c in ctx.chunks if c.metadata.embedding_type == "chunk"
+        ]
+        assert all(c.embedding is None for c in content_chunks)
+
+    async def test_embedding_error_does_not_block_summary(self):
+        """If embedding fails, the summary still exists and errors are recorded."""
+        class FailingEmbeddings:
+            async def embed(self, texts):
+                raise RuntimeError("GPU unavailable")
+
+        llm = MockLLMPort(response="Summary despite error")
+        ctx = _make_context()
+        await ChunkStep(chunk_size=100, chunk_overlap=10).execute(ctx)
+
+        await DocumentSummaryStep(
+            llm_port=llm, embeddings_port=FailingEmbeddings(),  # type: ignore[arg-type]
+        ).execute(ctx)
+
+        # Summary should still be produced
+        assert "doc-1" in ctx.document_summaries
+        assert ctx.document_summaries["doc-1"] == "Summary despite error"
+        summary_chunks = [
+            c for c in ctx.chunks if c.metadata.embedding_type == "summary"
+        ]
+        assert len(summary_chunks) == 1
+        # Error should be recorded
+        assert any(
+            "DocumentSummaryStep: embedding failed" in e for e in ctx.errors
+        )
+
 
 # ---------------------------------------------------------------------------
 # T025: StoreStep tests


### PR DESCRIPTION
## Summary

- Modifies `DocumentSummaryStep` to accept an optional `EmbeddingsPort` and embed each document's chunks (content + summary) immediately after that document's summary is produced, overlapping LLM-bound summarization I/O with GPU-bound embedding I/O.
- Updates both `ingest_space` and `ingest_website` plugin pipeline assemblies to pass `embeddings_port` to `DocumentSummaryStep`.
- `EmbedStep` remains in the pipeline to handle remaining un-embedded chunks (BoK summary, below-threshold documents).

Resolves alkem-io/alkemio#1826

## Artifacts

- `specs/008-incremental-embedding/spec.md`
- `specs/008-incremental-embedding/plan.md`
- `specs/008-incremental-embedding/tasks.md`
- `specs/008-incremental-embedding/clarifications.md`

**Clarify loop iterations:** 2 (zero new ambiguities on iteration 2)
**Analyze loop iterations:** 2 (zero findings on iteration 2)

## Test plan

- [x] New unit test: incremental embedding after summary -- all chunks for summarized docs have embeddings
- [x] New unit test: summary chunk itself gets embedded
- [x] New unit test: unchanged chunks with pre-existing embeddings are not re-embedded
- [x] New unit test: without embeddings_port, behavior is unchanged (backward compat)
- [x] New unit test: embedding errors do not block summarization
- [x] Full test suite: 337 passed, 0 failed
- [x] Ruff lint: all checks passed
- [x] Pyright: 0 errors (only pre-existing warnings)

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Document summarization now optionally triggers immediate embedding of document chunks, reducing latency compared to batch embedding later.
  * Enhanced error handling for embedding failures with descriptive error messages.

* **Documentation**
  * Added comprehensive specifications defining incremental embedding behavior and implementation details.

* **Tests**
  * Added five test cases covering embedding during summarization, error handling, and backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->