### PR TITLE
fix: consistent summarization behavior between ingest plugins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,10 @@ CHUNK_SIZE=2000
 CHUNK_OVERLAP=400
 BATCH_SIZE=20
 SUMMARY_LENGTH=10000
+# Enable/disable document and BoK summarization during ingestion (default: true)
+SUMMARIZE_ENABLED=true
+# Number of documents summarized in parallel (0 is treated as sequential)
+SUMMARIZE_CONCURRENCY=8
 
 # Health server
 HEALTH_PORT=8080

--- a/core/config.py
+++ b/core/config.py
@@ -214,6 +214,7 @@ class BaseConfig(BaseSettings):
     batch_size: int = 20
     summary_length: int = 10000
     summarize_concurrency: int = 8
+    summarize_enabled: bool = True
 
     # Health
     health_port: int = 8080

--- a/main.py
+++ b/main.py
@@ -209,6 +209,11 @@ async def _run(config: BaseConfig) -> None:
     # Inject chunk threshold for ingest plugins
     if "chunk_threshold" in sig.parameters:
         deps["chunk_threshold"] = config.summary_chunk_threshold
+    # Inject summarization control for ingest plugins
+    if "summarize_enabled" in sig.parameters:
+        deps["summarize_enabled"] = config.summarize_enabled
+    if "summarize_concurrency" in sig.parameters:
+        deps["summarize_concurrency"] = config.summarize_concurrency
     plugin = plugin_class(**deps)
 
     # Plugin lifecycle: startup

--- a/plugins/ingest_space/plugin.py
+++ b/plugins/ingest_space/plugin.py
@@ -43,6 +43,8 @@ class IngestSpacePlugin:
         *,
         summarize_llm: LLMPort | None = None,
         chunk_threshold: int = 4,
+        summarize_enabled: bool = True,
+        summarize_concurrency: int = 8,
     ) -> None:
         self._llm = llm
         self._embeddings = embeddings
@@ -50,6 +52,8 @@ class IngestSpacePlugin:
         self._graphql_client = graphql_client
         self._summarize_llm = summarize_llm
         self._chunk_threshold = chunk_threshold
+        self._summarize_enabled = summarize_enabled
+        self._summarize_concurrency = max(1, summarize_concurrency)
 
     async def startup(self) -> None:
         logger.info("IngestSpacePlugin started")
@@ -80,19 +84,22 @@ class IngestSpacePlugin:
 
             # Run ingest pipeline with ingest-space specific settings
             summary_llm = self._summarize_llm or self._llm
-            engine = IngestEngine(steps=[
+            steps: list = [
                 ChunkStep(chunk_size=9000, chunk_overlap=500),
                 ContentHashStep(),
                 ChangeDetectionStep(knowledge_store_port=self._knowledge_store),
-                DocumentSummaryStep(
+            ]
+            if self._summarize_enabled:
+                steps.append(DocumentSummaryStep(
                     llm_port=summary_llm,
+                    concurrency=self._summarize_concurrency,
                     chunk_threshold=self._chunk_threshold,
-                ),
-                BodyOfKnowledgeSummaryStep(llm_port=summary_llm),
-                EmbedStep(embeddings_port=self._embeddings),
-                StoreStep(knowledge_store_port=self._knowledge_store),
-                OrphanCleanupStep(knowledge_store_port=self._knowledge_store),
-            ])
+                ))
+                steps.append(BodyOfKnowledgeSummaryStep(llm_port=summary_llm))
+            steps.append(EmbedStep(embeddings_port=self._embeddings))
+            steps.append(StoreStep(knowledge_store_port=self._knowledge_store))
+            steps.append(OrphanCleanupStep(knowledge_store_port=self._knowledge_store))
+            engine = IngestEngine(steps=steps)
             result = await engine.run(documents, collection_name)
 
             return IngestBodyOfKnowledgeResult(

--- a/plugins/ingest_website/plugin.py
+++ b/plugins/ingest_website/plugin.py
@@ -41,12 +41,16 @@ class IngestWebsitePlugin:
         *,
         summarize_llm: LLMPort | None = None,
         chunk_threshold: int = 4,
+        summarize_enabled: bool = True,
+        summarize_concurrency: int = 8,
     ) -> None:
         self._llm = llm
         self._embeddings = embeddings
         self._knowledge_store = knowledge_store
         self._summarize_llm = summarize_llm
         self._chunk_threshold = chunk_threshold
+        self._summarize_enabled = summarize_enabled
+        self._summarize_concurrency = max(1, summarize_concurrency)
         self._page_limit = 20  # Default, can be overridden by config
 
     async def startup(self) -> None:
@@ -89,18 +93,16 @@ class IngestWebsitePlugin:
                 )
 
             # Run ingest pipeline
-            from core.config import BaseConfig
-            config = BaseConfig()
             summary_llm = self._summarize_llm or self._llm
             steps: list = [
                 ChunkStep(chunk_size=2000),
                 ContentHashStep(),
                 ChangeDetectionStep(knowledge_store_port=self._knowledge_store),
             ]
-            if config.summarize_concurrency > 0:
+            if self._summarize_enabled:
                 steps.append(DocumentSummaryStep(
                     llm_port=summary_llm,
-                    concurrency=config.summarize_concurrency,
+                    concurrency=self._summarize_concurrency,
                     chunk_threshold=self._chunk_threshold,
                 ))
                 steps.append(BodyOfKnowledgeSummaryStep(llm_port=summary_llm))

--- a/specs/008-consistent-summarization-behavior/clarifications.md
+++ b/specs/008-consistent-summarization-behavior/clarifications.md
@@ -1,0 +1,34 @@
+# Clarifications: Story #1827
+
+**Iteration count:** 2 (1 with findings, 1 clean)
+
+## Iteration 1
+
+### Q1: Semantics of `summarize_concurrency == 0`
+**Question:** Should `summarize_concurrency == 0` mean "disabled" or "sequential"?
+**Chosen answer:** Sequential (normalized to 1).
+**Rationale:** The issue explicitly proposes decoupling the enable/disable concern into a separate boolean flag (`SUMMARIZE_ENABLED`). Using `0` to mean "disabled" overloads the parameter's semantic. Normalizing 0 to 1 (sequential) keeps the concurrency parameter purely about parallelism.
+
+### Q2: Should `ingest-space` also read `summarize_concurrency` from config?
+**Question:** `ingest-space` currently always includes summary steps without reading `summarize_concurrency`. Should it?
+**Chosen answer:** Yes.
+**Rationale:** The story requires consistent behavior. Both plugins must respect the same config parameters. `ingest-space` should pass `config.summarize_concurrency` to `DocumentSummaryStep`.
+
+### Q3: Default value for `summarize_enabled`
+**Question:** Should the new `SUMMARIZE_ENABLED` flag default to `True` or `False`?
+**Chosen answer:** `True`.
+**Rationale:** Backward compatibility. Existing deployments have summarization running (in `ingest-space` always, in `ingest-website` when concurrency > 0). Defaulting to `True` preserves current behavior without requiring config changes.
+
+### Q4: `BaseConfig()` instantiation inside `ingest-website.handle()`
+**Question:** Should the `ingest-website` plugin's inline `BaseConfig()` construction be refactored to injected config?
+**Chosen answer:** No, keep the current pattern to minimize scope. The fix will properly use both `summarize_enabled` and `summarize_concurrency` from the config instance.
+**Rationale:** Refactoring config injection is a separate concern. The inline `BaseConfig()` works and is tested. Changing it introduces risk beyond the story's scope.
+
+### Q5: Should `ingest-space` pass `concurrency` to `DocumentSummaryStep`?
+**Question:** `ingest-space` does not currently pass a `concurrency` argument to `DocumentSummaryStep`. Should it?
+**Chosen answer:** Yes.
+**Rationale:** Without it, `DocumentSummaryStep` falls back to its default of `8`. Both plugins should read `summarize_concurrency` from config and pass it through, ensuring the operator has consistent control over parallelism.
+
+## Iteration 2
+
+No new ambiguities found. Clarification loop complete.

--- a/specs/008-consistent-summarization-behavior/plan.md
+++ b/specs/008-consistent-summarization-behavior/plan.md
@@ -1,0 +1,72 @@
+# Plan: Consistent Summarization Behavior Between Ingest Plugins
+
+**Story:** alkem-io/alkemio#1827
+**Date:** 2026-04-08
+
+## Architecture
+
+No new modules or architectural changes. This is a behavior alignment fix across two existing plugins, plus one new config field.
+
+### Affected Modules
+
+| Module | Change |
+|--------|--------|
+| `core/config.py` | Add `summarize_enabled: bool = True` field to `BaseConfig` |
+| `plugins/ingest_website/plugin.py` | Accept `summarize_enabled` and `summarize_concurrency` as constructor params; remove inline `BaseConfig()`; guard summary steps with `summarize_enabled` |
+| `plugins/ingest_space/plugin.py` | Accept `summarize_enabled` and `summarize_concurrency` as constructor params; guard summary steps with `summarize_enabled`; pass concurrency to `DocumentSummaryStep` |
+| `main.py` | Inject `summarize_enabled` and `summarize_concurrency` from config into ingest plugins |
+| `.env.example` | Add `SUMMARIZE_ENABLED=true` documentation entry |
+| `tests/plugins/test_ingest_website.py` | Add tests for `summarize_enabled=True` and `summarize_enabled=False` |
+| `tests/plugins/test_ingest_space.py` | Add tests for `summarize_enabled=True` and `summarize_enabled=False` |
+
+### Data Model Deltas
+
+- `BaseConfig` gains one new field: `summarize_enabled: bool = True`
+
+### Interface Contracts
+
+No port/adapter interface changes. Both plugins' `handle()` signatures remain unchanged.
+
+### Behavioral Changes
+
+**Before:**
+- `ingest-website`: Skips both summary steps when `summarize_concurrency == 0`
+- `ingest-space`: Always includes summary steps, does not read `summarize_concurrency`
+
+**After:**
+- Both plugins: Include summary steps when `summarize_enabled is True` (default)
+- Both plugins: Omit summary steps when `summarize_enabled is False`
+- Both plugins: Pass `summarize_concurrency` to `DocumentSummaryStep` (0 is normalized to 1)
+- `ingest-space`: Now reads config and respects `summarize_enabled` and `summarize_concurrency`
+
+### Concurrency normalization
+
+In both plugins, when building the pipeline:
+```python
+concurrency = max(1, config.summarize_concurrency)
+```
+This ensures `0` becomes `1` (sequential) and any positive value is passed through.
+
+## Test Strategy
+
+1. **Unit tests for `ingest-website`:**
+   - Pipeline includes summary steps when `summarize_enabled=True`
+   - Pipeline excludes summary steps when `summarize_enabled=False`
+   - `summarize_concurrency` is passed to `DocumentSummaryStep`
+
+2. **Unit tests for `ingest-space`:**
+   - Pipeline includes summary steps when `summarize_enabled=True`
+   - Pipeline excludes summary steps when `summarize_enabled=False`
+   - `summarize_concurrency` is passed to `DocumentSummaryStep`
+
+3. **Config tests:**
+   - `summarize_enabled` defaults to `True`
+   - `summarize_enabled` can be set to `False` via env var
+
+4. **Existing tests:** All must continue to pass unchanged.
+
+## Rollout Notes
+
+- **Zero-config deployment:** No env var changes needed. Default behavior matches current `ingest-space` behavior (summarization on).
+- **Opt-out:** Set `SUMMARIZE_ENABLED=false` to disable summarization in both plugins.
+- **Migration path:** Deployments using `SUMMARIZE_CONCURRENCY=0` to disable summarization in `ingest-website` should switch to `SUMMARIZE_ENABLED=false`. With this change, `SUMMARIZE_CONCURRENCY=0` will mean sequential processing, not disabled.

--- a/specs/008-consistent-summarization-behavior/spec.md
+++ b/specs/008-consistent-summarization-behavior/spec.md
@@ -1,0 +1,42 @@
+# Spec: Consistent Summarization Behavior Between Ingest Plugins
+
+**Story:** alkem-io/alkemio#1827
+**Status:** Draft
+**Author:** SDD Agent
+**Date:** 2026-04-08
+
+## User Value
+
+Operators and developers expect both ingest plugins (`ingest-website` and `ingest-space`) to behave identically regarding summarization. Today, `ingest-website` silently skips summarization when `summarize_concurrency == 0`, while `ingest-space` always runs summarization regardless of the concurrency setting. This inconsistency causes unpredictable behavior: the same document ingested through different paths may or may not get summaries, leading to degraded retrieval quality for website-sourced knowledge.
+
+## Scope
+
+1. **Align summarization pipeline construction** in `ingest-website` with `ingest-space`: always include `DocumentSummaryStep` and `BodyOfKnowledgeSummaryStep` in the pipeline.
+2. **Add a new `SUMMARIZE_ENABLED` boolean config flag** to explicitly control whether summarization is enabled or disabled, rather than overloading `summarize_concurrency`.
+3. **Apply `summarize_concurrency` consistently** as a parallelism control parameter in both plugins (how many documents are summarized in parallel).
+4. **Ensure `summarize_concurrency == 0` means sequential** (concurrency=1), not disabled.
+5. **Update both plugins** to read `summarize_enabled` from config and conditionally include summary steps.
+6. **Update tests** to cover the new flag and the consistent behavior.
+
+## Out of Scope
+
+- Changes to the summarization prompt templates or quality.
+- Changes to the `DocumentSummaryStep` or `BodyOfKnowledgeSummaryStep` internal logic beyond constructor arguments.
+- Changes to the pipeline engine itself.
+- Per-plugin summarization enable/disable (one global flag suffices).
+
+## Acceptance Criteria
+
+1. **AC-1:** Both `ingest-website` and `ingest-space` include `DocumentSummaryStep` and `BodyOfKnowledgeSummaryStep` in their pipelines when `summarize_enabled` is `True` (default).
+2. **AC-2:** Both plugins omit summary steps when `summarize_enabled` is `False`.
+3. **AC-3:** `summarize_concurrency` controls only parallelism degree. A value of `0` is normalized to `1` (sequential).
+4. **AC-4:** Both `ingest-space` and `ingest-website` pass the config's `summarize_concurrency` to `DocumentSummaryStep`.
+5. **AC-5:** A new `SUMMARIZE_ENABLED` env var (default `true`) is added to `BaseConfig`.
+6. **AC-6:** `.env.example` documents the new variable.
+7. **AC-7:** Existing tests continue to pass; new tests validate both plugins with `summarize_enabled=True` and `summarize_enabled=False`.
+
+## Constraints
+
+- Must not break existing deployments where `SUMMARIZE_CONCURRENCY` is set to a positive integer.
+- The default behavior (no env vars set) must remain identical to today's `ingest-space` behavior (summarization enabled).
+- No new dependencies may be added.

--- a/specs/008-consistent-summarization-behavior/tasks.md
+++ b/specs/008-consistent-summarization-behavior/tasks.md
@@ -1,0 +1,85 @@
+# Tasks: Consistent Summarization Behavior Between Ingest Plugins
+
+**Story:** alkem-io/alkemio#1827
+**Date:** 2026-04-08
+
+## Task 1: Add `summarize_enabled` to `BaseConfig`
+
+**File:** `core/config.py`
+**Dependencies:** None
+**Acceptance criteria:**
+- `BaseConfig` has a `summarize_enabled: bool = True` field
+- Default value is `True`
+- Env var `SUMMARIZE_ENABLED` controls it
+**Tests:** Config instantiation with and without env var
+
+## Task 2: Update `ingest-website` plugin
+
+**File:** `plugins/ingest_website/plugin.py`
+**Dependencies:** Task 1
+**Acceptance criteria:**
+- Accept `summarize_enabled: bool = True` and `summarize_concurrency: int = 8` as constructor parameters
+- Remove inline `BaseConfig()` instantiation from `handle()`
+- Conditionally include/exclude summary steps based on `self._summarize_enabled`
+- Pass `concurrency=max(1, self._summarize_concurrency)` to `DocumentSummaryStep`
+- Pipeline includes summary steps when `summarize_enabled=True`
+- Pipeline excludes summary steps when `summarize_enabled=False`
+**Tests:** `test_pipeline_with_summarize_enabled`, `test_pipeline_with_summarize_disabled`
+
+## Task 3: Update `ingest-space` plugin
+
+**File:** `plugins/ingest_space/plugin.py`
+**Dependencies:** Task 1
+**Acceptance criteria:**
+- Accept `summarize_enabled: bool = True` and `summarize_concurrency: int = 8` as constructor parameters
+- Conditionally include/exclude summary steps based on `self._summarize_enabled`
+- Pass `concurrency=max(1, self._summarize_concurrency)` to `DocumentSummaryStep`
+- Pipeline includes summary steps when `summarize_enabled=True`
+- Pipeline excludes summary steps when `summarize_enabled=False`
+**Tests:** `test_pipeline_with_summarize_enabled`, `test_pipeline_with_summarize_disabled`
+
+## Task 4: Update `main.py` to inject new parameters
+
+**File:** `main.py`
+**Dependencies:** Tasks 1, 2, 3
+**Acceptance criteria:**
+- Inject `summarize_enabled` and `summarize_concurrency` from config into ingest plugins via constructor
+- Pattern follows existing `chunk_threshold` injection
+**Tests:** Covered by integration tests
+
+## Task 5: Update `.env.example`
+
+**File:** `.env.example`
+**Dependencies:** Task 1
+**Acceptance criteria:**
+- New `SUMMARIZE_ENABLED=true` entry with comment explaining its purpose
+- Placed near existing summarization config entries
+**Tests:** N/A (documentation)
+
+## Task 6: Add/update tests for `ingest-website`
+
+**File:** `tests/plugins/test_ingest_website.py`
+**Dependencies:** Tasks 1, 2
+**Acceptance criteria:**
+- Test that pipeline includes `DocumentSummaryStep` and `BodyOfKnowledgeSummaryStep` when `summarize_enabled=True`
+- Test that pipeline excludes both summary steps when `summarize_enabled=False`
+- Existing `test_pipeline_composition` updated to match new behavior
+**Tests:** Self (test file)
+
+## Task 7: Add/update tests for `ingest-space`
+
+**File:** `tests/plugins/test_ingest_space.py`
+**Dependencies:** Tasks 1, 3
+**Acceptance criteria:**
+- Test that pipeline includes summary steps when `summarize_enabled=True`
+- Test that pipeline excludes summary steps when `summarize_enabled=False`
+- Test that `summarize_concurrency` is passed through to `DocumentSummaryStep`
+**Tests:** Self (test file)
+
+## Task 8: Verify all tests pass
+
+**Dependencies:** Tasks 1-7
+**Acceptance criteria:**
+- `poetry run pytest` passes with zero failures
+- `poetry run ruff check core/ plugins/ tests/` passes
+- `poetry run pyright core/ plugins/` passes

--- a/tests/plugins/test_ingest_space.py
+++ b/tests/plugins/test_ingest_space.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from core.events.ingest_space import IngestBodyOfKnowledgeResult
@@ -102,3 +104,94 @@ class TestIngestSpacePlugin:
     async def test_startup_shutdown(self, plugin):
         await plugin.startup()
         await plugin.shutdown()
+
+    async def test_pipeline_with_summarize_enabled(self):
+        """Summary steps are included when summarize_enabled=True."""
+        import asyncio
+        from core.domain.ingest_pipeline import Document, DocumentMetadata
+
+        plugin = IngestSpacePlugin(
+            llm=MockLLMPort(),
+            embeddings=MockEmbeddingsPort(),
+            knowledge_store=MockKnowledgeStorePort(),
+            graphql_client=MagicMock(),
+            summarize_enabled=True,
+            summarize_concurrency=4,
+        )
+        event = make_ingest_body_of_knowledge()
+        mock_docs = [
+            Document(
+                content="Test content for space ingestion.",
+                metadata=DocumentMetadata(
+                    document_id="doc-1",
+                    source="space-1",
+                    type="knowledge",
+                    title="Test Doc",
+                ),
+            )
+        ]
+
+        with patch("plugins.ingest_space.space_reader.read_space_tree", return_value=mock_docs), \
+             patch("plugins.ingest_space.plugin.IngestEngine") as mock_engine:
+            mock_engine.return_value.run = MagicMock(
+                side_effect=lambda *a, **kw: asyncio.coroutine(
+                    lambda: MagicMock(success=True, errors=[])
+                )()
+            )
+            await plugin.handle(event)
+
+        call_kwargs = mock_engine.call_args
+        steps = call_kwargs.kwargs.get("steps") or call_kwargs.args[0] if call_kwargs.args else call_kwargs.kwargs["steps"]
+        step_names = [s.name for s in steps]
+        assert "document_summary" in step_names
+        assert "body_of_knowledge_summary" in step_names
+
+    async def test_pipeline_with_summarize_disabled(self):
+        """Summary steps are excluded when summarize_enabled=False."""
+        import asyncio
+        from core.domain.ingest_pipeline import Document, DocumentMetadata
+
+        plugin = IngestSpacePlugin(
+            llm=MockLLMPort(),
+            embeddings=MockEmbeddingsPort(),
+            knowledge_store=MockKnowledgeStorePort(),
+            graphql_client=MagicMock(),
+            summarize_enabled=False,
+        )
+        event = make_ingest_body_of_knowledge()
+        mock_docs = [
+            Document(
+                content="Test content for space ingestion.",
+                metadata=DocumentMetadata(
+                    document_id="doc-1",
+                    source="space-1",
+                    type="knowledge",
+                    title="Test Doc",
+                ),
+            )
+        ]
+
+        with patch("plugins.ingest_space.space_reader.read_space_tree", return_value=mock_docs), \
+             patch("plugins.ingest_space.plugin.IngestEngine") as mock_engine:
+            mock_engine.return_value.run = MagicMock(
+                side_effect=lambda *a, **kw: asyncio.coroutine(
+                    lambda: MagicMock(success=True, errors=[])
+                )()
+            )
+            await plugin.handle(event)
+
+        call_kwargs = mock_engine.call_args
+        steps = call_kwargs.kwargs.get("steps") or call_kwargs.args[0] if call_kwargs.args else call_kwargs.kwargs["steps"]
+        step_names = [s.name for s in steps]
+        assert "document_summary" not in step_names
+        assert "body_of_knowledge_summary" not in step_names
+
+    async def test_concurrency_zero_normalizes_to_one(self):
+        """summarize_concurrency=0 is normalized to 1 (sequential)."""
+        plugin = IngestSpacePlugin(
+            llm=MockLLMPort(),
+            embeddings=MockEmbeddingsPort(),
+            knowledge_store=MockKnowledgeStorePort(),
+            summarize_concurrency=0,
+        )
+        assert plugin._summarize_concurrency == 1

--- a/tests/plugins/test_ingest_website.py
+++ b/tests/plugins/test_ingest_website.py
@@ -161,16 +161,72 @@ class TestIngestWebsitePlugin:
         event = make_ingest_website()
         mock_pages = [{"url": "https://example.com", "html": "<p>Content for ingestion test.</p>"}]
 
-        mock_config = MagicMock()
-        mock_config.summarize_concurrency = 0
-
-        with patch("plugins.ingest_website.plugin.crawl", return_value=mock_pages), \
-             patch("core.config.BaseConfig", return_value=mock_config):
+        with patch("plugins.ingest_website.plugin.crawl", return_value=mock_pages):
             result = await plugin.handle(event)
         assert isinstance(result, IngestWebsiteResult)
         # delete_collection is no longer called — incremental dedup replaces it
         assert plugin._knowledge_store.deleted == []
         assert "example.com-knowledge" in plugin._knowledge_store.collections
+
+    async def test_pipeline_with_summarize_enabled(self):
+        """Summary steps are included when summarize_enabled=True."""
+        plugin = IngestWebsitePlugin(
+            llm=MockLLMPort(),
+            embeddings=MockEmbeddingsPort(),
+            knowledge_store=MockKnowledgeStorePort(),
+            summarize_enabled=True,
+            summarize_concurrency=4,
+        )
+        event = make_ingest_website()
+        mock_pages = [{"url": "https://example.com", "html": "<p>Content for ingestion test.</p>"}]
+
+        with patch("plugins.ingest_website.plugin.crawl", return_value=mock_pages), \
+             patch("plugins.ingest_website.plugin.IngestEngine") as mock_engine:
+            mock_engine.return_value.run = MagicMock(return_value=MagicMock(success=True, errors=[]))
+            # Make run() a coroutine
+            import asyncio
+            mock_engine.return_value.run = MagicMock(side_effect=lambda *a, **kw: asyncio.coroutine(lambda: MagicMock(success=True, errors=[]))())
+            await plugin.handle(event)
+
+        # Verify IngestEngine was created with summary steps
+        call_kwargs = mock_engine.call_args
+        steps = call_kwargs.kwargs.get("steps") or call_kwargs.args[0] if call_kwargs.args else call_kwargs.kwargs["steps"]
+        step_names = [s.name for s in steps]
+        assert "document_summary" in step_names
+        assert "body_of_knowledge_summary" in step_names
+
+    async def test_pipeline_with_summarize_disabled(self):
+        """Summary steps are excluded when summarize_enabled=False."""
+        plugin = IngestWebsitePlugin(
+            llm=MockLLMPort(),
+            embeddings=MockEmbeddingsPort(),
+            knowledge_store=MockKnowledgeStorePort(),
+            summarize_enabled=False,
+        )
+        event = make_ingest_website()
+        mock_pages = [{"url": "https://example.com", "html": "<p>Content for ingestion test.</p>"}]
+
+        with patch("plugins.ingest_website.plugin.crawl", return_value=mock_pages), \
+             patch("plugins.ingest_website.plugin.IngestEngine") as mock_engine:
+            import asyncio
+            mock_engine.return_value.run = MagicMock(side_effect=lambda *a, **kw: asyncio.coroutine(lambda: MagicMock(success=True, errors=[]))())
+            await plugin.handle(event)
+
+        call_kwargs = mock_engine.call_args
+        steps = call_kwargs.kwargs.get("steps") or call_kwargs.args[0] if call_kwargs.args else call_kwargs.kwargs["steps"]
+        step_names = [s.name for s in steps]
+        assert "document_summary" not in step_names
+        assert "body_of_knowledge_summary" not in step_names
+
+    async def test_concurrency_zero_normalizes_to_one(self):
+        """summarize_concurrency=0 is normalized to 1 (sequential)."""
+        plugin = IngestWebsitePlugin(
+            llm=MockLLMPort(),
+            embeddings=MockEmbeddingsPort(),
+            knowledge_store=MockKnowledgeStorePort(),
+            summarize_concurrency=0,
+        )
+        assert plugin._summarize_concurrency == 1
 
     async def test_unsupported_content_skip(self, plugin):
         """Empty crawl results should still succeed."""


### PR DESCRIPTION
## Summary

- Aligns `ingest-website` and `ingest-space` summarization pipeline construction so both respect a new `SUMMARIZE_ENABLED` boolean flag (default `true`) instead of overloading `summarize_concurrency` as an on/off switch
- Both plugins now accept `summarize_enabled` and `summarize_concurrency` as constructor params, injected from `main.py`, and normalize `concurrency=0` to `1` (sequential)
- Removes inline `BaseConfig()` instantiation from `ingest-website` `handle()` in favor of constructor injection matching the existing codebase pattern

## Story

Closes alkem-io/alkemio#1827

## Spec Artifacts

- `specs/008-consistent-summarization-behavior/spec.md`
- `specs/008-consistent-summarization-behavior/plan.md`
- `specs/008-consistent-summarization-behavior/tasks.md`
- `specs/008-consistent-summarization-behavior/clarifications.md`

## SDD Loop Counts

- Clarify iterations: 2 (1 with findings, 1 clean)
- Analyze iterations: 2 (1 with findings, 1 clean)

## Test plan

- [x] All 338 existing tests pass
- [x] New tests verify pipeline includes summary steps when `summarize_enabled=True` (both plugins)
- [x] New tests verify pipeline excludes summary steps when `summarize_enabled=False` (both plugins)
- [x] New tests verify `summarize_concurrency=0` normalizes to `1` (both plugins)
- [x] Ruff lint passes clean
- [x] Pyright type check: 0 errors (41 pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)