### PR TITLE
feat: configurable vector DB distance function

### DIFF
--- a/.claude/commands/speckit.retrospec.md
+++ b/.claude/commands/speckit.retrospec.md
@@ -1,0 +1,257 @@
+---
+description: Generate single-responsibility SDD specs from current code changes. Decomposes multi-concern changesets into one spec per responsibility, each with all SDD artifacts.
+handoffs:
+  - label: Analyze Specs for Consistency
+    agent: speckit.analyze
+    prompt: Run a project analysis for consistency across the generated specs
+    send: true
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty). The user may specify:
+- A custom diff range (e.g., `origin/develop..HEAD`, `HEAD~3`)
+- A list of files to focus on
+- Hints about how to decompose responsibilities
+- `--dry-run` to only show the proposed decomposition without generating artifacts
+
+## Outline
+
+### Step 1: Determine the Change Set
+
+Determine what "current changes" means based on context:
+
+1. **If `$ARGUMENTS` specifies a diff range** (e.g., `origin/develop..HEAD`, `HEAD~5`, a commit SHA): use that range.
+2. **If there are uncommitted changes** (staged or unstaged): use `git diff HEAD` to capture all working-tree changes.
+3. **If the current branch differs from the main branch** (typically `develop` or `main`): use `git diff $(git merge-base HEAD develop)..HEAD` to capture all branch changes.
+4. **If none of the above produce changes**: ERROR "No changes detected. Specify a diff range as argument."
+
+Run `git status` and the appropriate `git diff` (with `--stat` first for overview, then full diff). Also run `git log --oneline` for the relevant range to understand commit history.
+
+### Step 2: Read and Understand All Changed Files
+
+For each file in the changeset:
+1. Read the **full current content** of the file (not just the diff) to understand context.
+2. Read the **diff hunks** to understand what specifically changed.
+3. Note the file's role in the architecture (core/, plugins/, tests/, config, etc.) using CLAUDE.md as reference.
+
+### Step 3: Decompose into Single-Responsibility Concerns
+
+Analyze all changes and group them into **distinct, single-responsibility concerns**. Each concern should:
+- Address **one cohesive feature, fix, or improvement**
+- Be independently understandable and testable
+- Map to a clear user-facing or operator-facing value proposition
+
+**Decomposition heuristics**:
+- Changes to the same domain concept (e.g., "config validation" vs. "new pipeline step") are separate concerns
+- Changes that serve the same user story belong together even if spread across files
+- Infrastructure/plumbing changes that enable a feature belong WITH that feature, not as a separate spec
+- Test changes belong with the production code they test
+
+**If all changes serve a single responsibility**: create exactly one spec.
+**If multiple responsibilities are detected**: create one spec per responsibility, clearly delineating which files/changes belong to each.
+
+Present the proposed decomposition to the user in this format before generating artifacts:
+
+```markdown
+## Proposed Decomposition
+
+### Spec 1: [Short Title]
+**Responsibility**: [One-sentence description]
+**Files**:
+- `path/to/file1.py` — [what changed and why]
+- `path/to/file2.py` — [what changed and why]
+
+### Spec 2: [Short Title]
+**Responsibility**: [One-sentence description]
+**Files**:
+- `path/to/file3.py` — [what changed and why]
+
+Proceed with generating specs? (Y/n)
+```
+
+Wait for user confirmation unless `$ARGUMENTS` contains `--yes` or `-y`. If `--dry-run` was specified, stop here.
+
+### Step 4: Determine Spec Numbering
+
+For each spec to be created:
+
+1. Look at existing `specs/` directories to find the highest sequential number.
+2. Also check git branches for the highest feature number.
+3. Assign the next sequential number(s): if creating 2 specs and highest existing is `008`, use `009` and `010`.
+4. Generate a short name (2-4 words, kebab-case) for each spec from its responsibility title.
+
+**Do NOT create feature branches** — the code already exists on the current branch. Only create spec directories.
+
+### Step 5: Generate All SDD Artifacts
+
+For each spec, create the directory `specs/NNN-short-name/` and generate ALL of the following artifacts. Each artifact must be populated with concrete content derived from the actual code changes — not templates or placeholders.
+
+#### 5.1: spec.md (Feature Specification)
+
+Generate using the structure from `.specify/templates/spec-template.md`:
+
+```markdown
+# Feature Specification: [FEATURE NAME]
+
+**Feature Branch**: `[current-branch-name]`
+**Created**: [TODAY'S DATE]
+**Status**: Implemented
+**Input**: Retrospec from code changes
+```
+
+**Mandatory sections**:
+- **User Scenarios & Testing**: Derive user stories from what the code changes accomplish. Prioritize by impact (P1, P2, P3). Each story must have acceptance scenarios derived from the actual behavior the code implements. Mark priorities based on which changes are most impactful.
+- **Requirements**: Derive functional requirements (FR-001, FR-002...) from what the code actually does. Each requirement must be a concrete, testable statement about system behavior.
+- **Success Criteria**: Derive measurable outcomes from the implemented behavior.
+- **Assumptions**: Document any assumptions implicit in the implementation.
+
+**Key principle**: Write the spec as if it were written BEFORE implementation. It should read naturally as a specification, not as a code description. Use business/user language, not implementation language.
+
+#### 5.2: plan.md (Implementation Plan)
+
+Generate using the structure from `.specify/templates/plan-template.md`:
+
+```markdown
+# Implementation Plan: [FEATURE NAME]
+
+**Branch**: `[current-branch-name]` | **Date**: [TODAY] | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/NNN-short-name/spec.md`
+```
+
+Include:
+- **Summary**: What the feature does and the technical approach taken.
+- **Technical Context**: Fill from the actual project (Python 3.12, Poetry, pytest, etc.).
+- **Constitution Check**: Evaluate the changes against `.specify/memory/constitution.md`. For each principle/standard, mark PASS/FAIL/N/A with notes.
+- **Project Structure**: Show the actual files changed (documentation tree + source code tree).
+- **Complexity Tracking**: Only if constitution violations exist.
+
+#### 5.3: research.md (Research Decisions)
+
+Document the technical decisions embodied in the code:
+
+```markdown
+# Research: [FEATURE NAME]
+
+**Feature Branch**: `[current-branch-name]`
+**Date**: [TODAY]
+```
+
+For each significant technical decision visible in the code:
+- **Decision**: What was chosen
+- **Rationale**: Why (infer from code patterns, comments, architecture)
+- **Alternatives considered**: What other approaches could have been taken
+
+Include a summary table of all decisions.
+
+#### 5.4: data-model.md (Data Model)
+
+Document any data model changes:
+
+```markdown
+# Data Model: [FEATURE NAME]
+
+**Feature Branch**: `[current-branch-name]`
+**Date**: [TODAY]
+```
+
+Include:
+- New or modified entities (Pydantic models, config fields, domain objects)
+- Field types, defaults, validation rules
+- Relationships between entities
+- State transitions if applicable
+
+If no data model changes exist, write a brief note explaining that and skip the detailed sections.
+
+#### 5.5: contracts/ (Interface Contracts)
+
+Only generate if the changes affect external interfaces (ports, event schemas, HTTP endpoints, plugin contract). For each affected contract:
+- Document the interface before and after
+- Note backward compatibility implications
+
+If no contract changes exist, skip this directory entirely.
+
+#### 5.6: quickstart.md (Quickstart Guide)
+
+```markdown
+# Quickstart: [FEATURE NAME]
+
+**Feature Branch**: `[current-branch-name]`
+**Date**: [TODAY]
+```
+
+Include:
+- What the feature does (brief)
+- Any new environment variables or configuration
+- How to verify the feature works (concrete steps)
+- Files changed (table)
+
+#### 5.7: tasks.md (Task Breakdown)
+
+Generate using the structure from `.specify/templates/tasks-template.md`. Since the code is already implemented, **all tasks MUST be marked as complete** with `[X]`.
+
+```markdown
+# Tasks: [FEATURE NAME]
+
+**Input**: Design documents from `specs/NNN-short-name/`
+**Organization**: Tasks grouped by user story.
+```
+
+Follow the exact task format:
+- `- [X] T001 [P?] [Story?] Description with file path`
+- Use the standard phase structure (Foundational, User Story phases, Polish)
+- Include dependency information and parallel opportunities
+- Each user story phase must reference the spec's user stories
+
+#### 5.8: checklists/requirements.md (Specification Quality Checklist)
+
+```markdown
+# Specification Quality Checklist: [FEATURE NAME]
+
+**Purpose**: Validate specification completeness and quality
+**Created**: [TODAY]
+**Feature**: [spec.md](../spec.md)
+```
+
+Evaluate the generated spec against the standard quality criteria. Mark items as checked `[X]` where the spec passes, unchecked `[ ]` where it has gaps.
+
+### Step 6: Report
+
+After generating all specs, report:
+
+```markdown
+## Retrospec Complete
+
+### Generated Specs
+
+| # | Spec | Directory | Artifacts | Tasks |
+|---|------|-----------|-----------|-------|
+| 1 | [Title] | `specs/NNN-short-name/` | spec, plan, research, data-model, quickstart, tasks, checklist | N tasks |
+| 2 | [Title] | `specs/NNN-short-name/` | spec, plan, research, data-model, tasks, checklist | N tasks |
+
+### Change Coverage
+
+- **Files covered**: N/N files from the changeset are accounted for in specs
+- **Uncovered files**: [list any files not assigned to a spec, with reason]
+
+### Next Steps
+
+- Review generated specs for accuracy
+- Run `/speckit.analyze` for cross-artifact consistency check
+```
+
+## Key Rules
+
+- **Single Responsibility**: Each spec MUST cover exactly one cohesive concern. When in doubt, split.
+- **Concrete, not template**: Every artifact must contain real content from the actual code changes. No placeholder text, no template markers, no `[FILL IN]` items.
+- **Retrospective voice**: Write specs as if they were written before implementation, but informed by what was actually built. They should read as natural specifications.
+- **Complete artifact set**: Every spec gets spec.md, plan.md, research.md, data-model.md, quickstart.md, tasks.md, and checklists/requirements.md. Skip contracts/ only when no external interfaces changed.
+- **Tasks are complete**: All tasks in tasks.md are marked `[X]` because the code already exists.
+- **No branch creation**: Do not create git branches. Only create spec directories under `specs/`.
+- **Worktree-isolated delivery**: Each generated spec is intended to be delivered in isolation in its own git worktree. The decomposition MUST ensure that each spec's file set is self-contained — a spec's changes must be cherry-pickable or applicable independently without requiring changes from another spec. If two concerns share a file, either co-locate them in one spec or split the file changes so each spec's portion is independently viable.
+- **Constitution awareness**: The plan.md must include a constitution check against `.specify/memory/constitution.md`.
+- **Preserve existing numbering**: Spec numbers continue sequentially from the highest existing spec number.

--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,8 @@ RABBITMQ_RESULT_ROUTING_KEY=invoke-engine-result
 VECTOR_DB_HOST=localhost
 VECTOR_DB_PORT=8765
 VECTOR_DB_CREDENTIALS=
+# Distance function for vector similarity: cosine, l2, or ip
+VECTOR_DB_DISTANCE_FN=cosine
 
 # LLM — provider-agnostic configuration
 # Supported providers: mistral, openai, anthropic

--- a/core/adapters/chromadb.py
+++ b/core/adapters/chromadb.py
@@ -28,6 +28,7 @@ class ChromaDBAdapter:
         port: int = 8765,
         credentials: str | None = None,
         embeddings: EmbedFn | None = None,
+        distance_fn: str = "cosine",
     ) -> None:
         settings = chromadb.config.Settings()
         if credentials:
@@ -41,6 +42,7 @@ class ChromaDBAdapter:
             settings=settings,
         )
         self._embeddings = embeddings
+        self._distance_fn = distance_fn
 
     async def query(
         self,
@@ -57,7 +59,9 @@ class ChromaDBAdapter:
 
         def _query():
             col = self._client.get_or_create_collection(
-                collection, embedding_function=None
+                collection,
+                embedding_function=None,
+                metadata={"hnsw:space": self._distance_fn},
             )
             results = col.query(
                 query_embeddings=query_embeddings, n_results=n_results
@@ -86,7 +90,9 @@ class ChromaDBAdapter:
 
         def _ingest():
             col = self._client.get_or_create_collection(
-                collection, embedding_function=None
+                collection,
+                embedding_function=None,
+                metadata={"hnsw:space": self._distance_fn},
             )
             col.upsert(
                 documents=documents,
@@ -119,7 +125,9 @@ class ChromaDBAdapter:
     ) -> GetResult:
         def _get():
             col = self._client.get_or_create_collection(
-                collection, embedding_function=None
+                collection,
+                embedding_function=None,
+                metadata={"hnsw:space": self._distance_fn},
             )
             kwargs: dict = {}
             if ids is not None:

--- a/core/adapters/chromadb.py
+++ b/core/adapters/chromadb.py
@@ -155,7 +155,9 @@ class ChromaDBAdapter:
         def _delete_items():
             try:
                 col = self._client.get_or_create_collection(
-                    collection, embedding_function=None
+                    collection,
+                    embedding_function=None,
+                    metadata={"hnsw:space": self._distance_fn},
                 )
                 kwargs: dict = {}
                 if ids is not None:

--- a/core/config.py
+++ b/core/config.py
@@ -48,6 +48,7 @@ class BaseConfig(BaseSettings):
     vector_db_host: str | None = None
     vector_db_port: int = 8765
     vector_db_credentials: str | None = None
+    vector_db_distance_fn: str = "cosine"  # cosine, l2, or ip
 
     # LLM — provider-agnostic configuration
     llm_provider: LLMProvider = LLMProvider.mistral
@@ -105,6 +106,14 @@ class BaseConfig(BaseSettings):
         if self.rabbitmq_max_retries < 1:
             raise ValueError(
                 f"RABBITMQ_MAX_RETRIES must be >= 1, got {self.rabbitmq_max_retries}"
+            )
+
+        # Vector DB distance function validation
+        valid_distance_fns = {"cosine", "l2", "ip"}
+        if self.vector_db_distance_fn not in valid_distance_fns:
+            raise ValueError(
+                f"VECTOR_DB_DISTANCE_FN must be one of {valid_distance_fns}, "
+                f"got '{self.vector_db_distance_fn}'"
             )
 
         # Summarization LLM validation

--- a/main.py
+++ b/main.py
@@ -130,6 +130,7 @@ def _create_adapters(config: BaseConfig, container: Container) -> None:
                 port=config.vector_db_port,
                 credentials=config.vector_db_credentials,
                 embeddings=embeddings_adapter,
+                distance_fn=config.vector_db_distance_fn,
             ),
         )
 

--- a/specs/009-vector-db-distance-fn/checklists/requirements.md
+++ b/specs/009-vector-db-distance-fn/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Configurable Vector DB Distance Function
+
+**Purpose**: Validate specification completeness and quality
+**Created**: 2026-04-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is concise and well-bounded for a single-concern configuration change.

--- a/specs/009-vector-db-distance-fn/data-model.md
+++ b/specs/009-vector-db-distance-fn/data-model.md
@@ -1,0 +1,49 @@
+# Data Model: Configurable Vector DB Distance Function
+
+**Feature Branch**: `develop`
+**Date**: 2026-04-08
+
+## Entity: BaseConfig (modified)
+
+**File**: `core/config.py`
+
+### New Field
+
+| Field | Type | Default | Env Var | Validation | Description |
+|-------|------|---------|---------|------------|-------------|
+| `vector_db_distance_fn` | `str` | `"cosine"` | `VECTOR_DB_DISTANCE_FN` | Must be one of `{"cosine", "l2", "ip"}` | Distance metric for ChromaDB HNSW index |
+
+### Validation Rule
+
+In `model_validator`: if `vector_db_distance_fn` is not in `{"cosine", "l2", "ip"}`, raise `ValueError` with the invalid value and the set of valid options.
+
+## Entity: ChromaDBAdapter (modified)
+
+**File**: `core/adapters/chromadb.py`
+
+### New Constructor Parameter
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `distance_fn` | `str` | `"cosine"` | Distance metric passed as `hnsw:space` metadata to all collection operations |
+
+### Changed Behavior
+
+All `get_or_create_collection` calls now include `metadata={"hnsw:space": self._distance_fn}`:
+- `query()` — collection access for similarity search
+- `ingest()` — collection access for upserting documents
+- `get()` — collection access for retrieving documents by ID/filter
+
+The `delete()` method is unchanged (does not use `get_or_create_collection` with metadata).
+
+## Relationships
+
+```text
+BaseConfig
+  └── injects → ChromaDBAdapter(distance_fn=config.vector_db_distance_fn)
+          └── passes → get_or_create_collection(metadata={"hnsw:space": distance_fn})
+```
+
+## State Transitions
+
+No state machines affected. Configuration is applied at startup.

--- a/specs/009-vector-db-distance-fn/plan.md
+++ b/specs/009-vector-db-distance-fn/plan.md
@@ -1,0 +1,74 @@
+# Implementation Plan: Configurable Vector DB Distance Function
+
+**Branch**: `develop` | **Date**: 2026-04-08 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/009-vector-db-distance-fn/spec.md`
+
+## Summary
+
+Add a configurable distance function (`cosine`, `l2`, `ip`) for ChromaDB vector similarity search, exposed via the `VECTOR_DB_DISTANCE_FN` environment variable. The value is validated at config load time and passed through to all ChromaDB collection operations as HNSW space metadata. Default is `cosine` for full backward compatibility.
+
+## Technical Context
+
+**Language/Version**: Python 3.12 (Poetry)
+**Primary Dependencies**: chromadb-client ^1.5.0, pydantic-settings ^2.11.0
+**Storage**: ChromaDB (vector store via HTTP client)
+**Testing**: pytest ^9.0 + pytest-asyncio ^1.3 (asyncio_mode = auto)
+**Target Platform**: Linux server (Docker containers, K8s)
+**Project Type**: Microkernel service
+**Performance Goals**: N/A (configuration change)
+**Constraints**: Full backward compatibility when env var is unset
+**Scale/Scope**: 3 files modified, ~25 lines added
+
+## Constitution Check
+
+| # | Principle / Standard | Status | Notes |
+|---|---------------------|--------|-------|
+| P1 | AI-Native Development | PASS | Config-only change, no interactive steps |
+| P2 | SOLID Architecture | PASS | No new interfaces. ChromaDBAdapter gains one constructor param — Open/Closed satisfied |
+| P3 | No Vendor Lock-in | PASS | Distance function is a ChromaDB-specific concept but exposed generically via config |
+| P4 | Optimised Feedback Loops | PASS | Validation at startup provides immediate feedback on misconfiguration |
+| P5 | Best Available Infrastructure | N/A | No CI changes |
+| P6 | SDD | PASS | Retrospec in progress |
+| P7 | No Filling Tests | N/A | No tests added in this changeset |
+| P8 | ADR | PASS | No port/contract changes. No new external dependencies |
+| AS:Microkernel | Microkernel Architecture | PASS | Config stays in core, adapter change is internal |
+| AS:Hexagonal | Hexagonal Boundaries | PASS | KnowledgeStorePort unchanged. Adapter-internal change only |
+| AS:Plugin | Plugin Contract | PASS | PluginContract unchanged |
+| AS:Domain | Domain Logic Isolation | PASS | No domain logic changes |
+| AS:Simplicity | Simplicity Over Speculation | PASS | Single field, single validation, direct passthrough |
+| AS:Async | Async-First Design | PASS | No new sync calls |
+
+**Gate result**: PASS — no violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/009-vector-db-distance-fn/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── tasks.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+core/
+├── config.py              # Add vector_db_distance_fn field + validation
+└── adapters/
+    └── chromadb.py         # Accept distance_fn param, pass to collection metadata
+
+main.py                    # Pass distance_fn from config to ChromaDBAdapter
+
+.env.example               # Document VECTOR_DB_DISTANCE_FN
+```
+
+## Complexity Tracking
+
+No constitution violations to justify.

--- a/specs/009-vector-db-distance-fn/quickstart.md
+++ b/specs/009-vector-db-distance-fn/quickstart.md
@@ -1,0 +1,60 @@
+# Quickstart: Configurable Vector DB Distance Function
+
+**Feature Branch**: `develop`
+**Date**: 2026-04-08
+
+## What This Feature Does
+
+Adds a `VECTOR_DB_DISTANCE_FN` environment variable to configure the distance metric used by ChromaDB for vector similarity search. Supported values: `cosine` (default), `l2`, `ip`.
+
+## New Environment Variables
+
+```env
+# Distance function for vector similarity: cosine, l2, or ip
+VECTOR_DB_DISTANCE_FN=cosine
+```
+
+## Quick Verification
+
+### 1. Verify default behavior (cosine)
+
+```bash
+# Start without setting VECTOR_DB_DISTANCE_FN (or set to cosine)
+export PLUGIN_TYPE=expert
+poetry run python main.py
+
+# Collections will use cosine distance — identical to previous behavior
+```
+
+### 2. Verify L2 distance
+
+```bash
+export VECTOR_DB_DISTANCE_FN=l2
+export PLUGIN_TYPE=ingest-website
+poetry run python main.py
+
+# Ingest content — collections created with hnsw:space=l2
+```
+
+### 3. Verify invalid value rejection
+
+```bash
+export VECTOR_DB_DISTANCE_FN=hamming
+poetry run python main.py
+
+# Expected: startup failure with error:
+# ValueError: VECTOR_DB_DISTANCE_FN must be one of {'cosine', 'l2', 'ip'}, got 'hamming'
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `core/config.py` | Add `vector_db_distance_fn` field with validation |
+| `core/adapters/chromadb.py` | Accept `distance_fn` param, pass to collection metadata |
+| `main.py` | Pass `distance_fn` from config to ChromaDBAdapter |
+| `.env.example` | Document `VECTOR_DB_DISTANCE_FN` |
+
+## Contracts
+
+No external interface changes. `KnowledgeStorePort` is unchanged. This is an adapter-internal configuration change.

--- a/specs/009-vector-db-distance-fn/research.md
+++ b/specs/009-vector-db-distance-fn/research.md
@@ -1,0 +1,47 @@
+# Research: Configurable Vector DB Distance Function
+
+**Feature Branch**: `develop`
+**Date**: 2026-04-08
+
+## Research Tasks
+
+### R1: ChromaDB distance function configuration mechanism
+
+**Context**: ChromaDB collections use HNSW indexes for approximate nearest-neighbor search. The distance metric affects how similarity scores are computed.
+
+**Findings**:
+
+ChromaDB supports three distance functions via the `hnsw:space` metadata key on collections:
+- `cosine` — cosine similarity (default). Best for normalized embeddings.
+- `l2` — Euclidean (L2) distance. Suitable for models that optimize for absolute vector distances.
+- `ip` — inner product. Used by some embedding models optimized for dot-product similarity.
+
+The metadata is passed to `get_or_create_collection(name, metadata={"hnsw:space": value})`. For existing collections, the metadata is applied at creation time; subsequent calls with different metadata do not change the index.
+
+**Decision**: Pass `distance_fn` as constructor parameter to `ChromaDBAdapter`, apply to all `get_or_create_collection` calls via metadata.
+**Rationale**: Consistent distance metric across all collection operations (query, ingest, get). Constructor injection follows existing adapter patterns.
+**Alternatives considered**: (a) Per-collection distance function — rejected (over-engineering, no use case for mixed metrics). (b) Pass through as query parameter — rejected (ChromaDB requires it at collection creation time).
+
+---
+
+### R2: Validation approach for distance function
+
+**Context**: Invalid distance function values would cause silent ChromaDB errors or unexpected behavior.
+
+**Findings**:
+
+Using a set-based validation in the pydantic `model_validator` is consistent with how other config fields are validated (e.g., LLM temperature ranges, retrieval score thresholds). A string field with set-membership validation is simpler than introducing an enum, since the valid values are a small fixed set and ChromaDB expects a raw string.
+
+**Decision**: Validate via set membership (`{"cosine", "l2", "ip"}`) in the existing `model_validator`, raising `ValueError` for invalid values.
+**Rationale**: Fail-fast at startup. Consistent with existing validation patterns. No new types needed.
+**Alternatives considered**: (a) Python `Enum` — rejected (adds a type for 3 strings, ChromaDB expects raw string). (b) Pydantic `Literal["cosine", "l2", "ip"]` — viable but less consistent with existing validator-based pattern.
+
+---
+
+## Summary of Decisions
+
+| Topic | Decision | Key Rationale |
+|-------|----------|---------------|
+| Configuration mechanism | Constructor param + collection metadata | Consistent across all operations |
+| Validation | Set-membership in model_validator | Fail-fast, consistent pattern |
+| Default value | `cosine` | Matches ChromaDB default, backward compatible |

--- a/specs/009-vector-db-distance-fn/spec.md
+++ b/specs/009-vector-db-distance-fn/spec.md
@@ -1,0 +1,58 @@
+# Feature Specification: Configurable Vector DB Distance Function
+
+**Feature Branch**: `develop`
+**Created**: 2026-04-08
+**Status**: Implemented
+**Input**: Retrospec from code changes
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Configure Vector Similarity Distance Metric (Priority: P1)
+
+As a platform operator, I want to configure the distance function used by the vector database for similarity search so that I can optimize retrieval quality for different embedding models without code changes.
+
+**Why this priority**: Different embedding models produce vectors optimized for different distance metrics. Using cosine distance with an L2-optimized embedding model (or vice versa) degrades retrieval quality. This is the only change in this spec and directly impacts answer quality.
+
+**Independent Test**: Set `VECTOR_DB_DISTANCE_FN=l2`, restart the service, ingest content, and verify that ChromaDB collections are created with `hnsw:space=l2` metadata. Query results should reflect L2 distance scoring instead of cosine.
+
+**Acceptance Scenarios**:
+
+1. **Given** `VECTOR_DB_DISTANCE_FN=cosine` (or unset), **When** any ChromaDB operation creates or accesses a collection, **Then** the collection uses cosine distance (default, backward-compatible behavior).
+2. **Given** `VECTOR_DB_DISTANCE_FN=l2`, **When** a collection is created or accessed, **Then** the collection uses L2 (Euclidean) distance.
+3. **Given** `VECTOR_DB_DISTANCE_FN=ip`, **When** a collection is created or accessed, **Then** the collection uses inner product distance.
+4. **Given** `VECTOR_DB_DISTANCE_FN=hamming` (invalid value), **When** the application starts, **Then** configuration validation rejects the value with a clear error message listing valid options.
+
+---
+
+### Edge Cases
+
+- What happens when the distance function is changed after data has already been ingested with a different metric? ChromaDB applies the metadata on `get_or_create_collection`; existing collections retain their original HNSW index. A full re-ingestion is required for the new metric to take effect on existing data.
+- What happens when `VECTOR_DB_DISTANCE_FN` is set to an empty string? Pydantic uses the default value `"cosine"` for empty env vars, preserving backward compatibility.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST support configuring the ChromaDB distance function via the `VECTOR_DB_DISTANCE_FN` environment variable, accepting values `cosine`, `l2`, or `ip`.
+- **FR-002**: System MUST default to `cosine` distance when `VECTOR_DB_DISTANCE_FN` is not set, preserving existing behavior.
+- **FR-003**: System MUST validate the distance function value at configuration load time and reject unsupported values with a clear error message.
+- **FR-004**: System MUST pass the configured distance function as `hnsw:space` metadata to every `get_or_create_collection` call in the ChromaDB adapter (query, ingest, and get operations).
+- **FR-005**: The `.env.example` file MUST document the `VECTOR_DB_DISTANCE_FN` variable with its valid values and default.
+
+### Key Entities
+
+- **Vector DB Distance Configuration**: A string parameter (`cosine`, `l2`, `ip`) that controls the HNSW similarity metric used by ChromaDB collections. Stored in `BaseConfig` and injected into the `ChromaDBAdapter` at construction time.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Operators can switch the vector similarity metric by changing a single environment variable, with the change taking effect on the next service restart.
+- **SC-002**: Invalid distance function values are caught at startup, preventing misconfigured deployments from running.
+- **SC-003**: The default value `cosine` reproduces current system behavior exactly when the variable is unset.
+
+## Assumptions
+
+- ChromaDB's `get_or_create_collection` applies `hnsw:space` metadata correctly when creating new collections.
+- Changing the distance function on an existing collection requires re-ingestion; the system does not handle automatic migration.
+- The three supported distance functions (`cosine`, `l2`, `ip`) cover the needs of all embedding models currently in use.

--- a/specs/009-vector-db-distance-fn/tasks.md
+++ b/specs/009-vector-db-distance-fn/tasks.md
@@ -1,0 +1,61 @@
+# Tasks: Configurable Vector DB Distance Function
+
+**Input**: Design documents from `specs/009-vector-db-distance-fn/`
+**Prerequisites**: plan.md (required), spec.md (required), data-model.md
+**Organization**: Tasks grouped by user story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Foundational (Config + Validation)
+
+**Purpose**: Add the configuration field and validation.
+
+- [X] T001 Add `vector_db_distance_fn: str = "cosine"` field to BaseConfig in core/config.py
+- [X] T002 Add set-membership validation for `vector_db_distance_fn` in the model_validator in core/config.py, rejecting values not in `{"cosine", "l2", "ip"}`
+
+**Checkpoint**: Configuration field and validation in place.
+
+---
+
+## Phase 2: User Story 1 — Configure Vector Similarity Distance Metric (Priority: P1)
+
+**Goal**: Pass the configured distance function through to all ChromaDB collection operations.
+
+**Independent Test**: Set `VECTOR_DB_DISTANCE_FN=l2`, start the service, and verify ChromaDB collections use L2 distance.
+
+### Implementation for User Story 1
+
+- [X] T003 [P] [US1] Add `distance_fn: str = "cosine"` constructor parameter to ChromaDBAdapter in core/adapters/chromadb.py, store as `self._distance_fn`
+- [X] T004 [US1] Pass `metadata={"hnsw:space": self._distance_fn}` to `get_or_create_collection` in `query()`, `ingest()`, and `get()` methods in core/adapters/chromadb.py
+- [X] T005 [US1] Pass `distance_fn=config.vector_db_distance_fn` to ChromaDBAdapter constructor in main.py `_create_adapters()`
+
+**Checkpoint**: Distance function is fully configurable and applied to all collection operations.
+
+---
+
+## Phase 3: Polish & Cross-Cutting Concerns
+
+- [X] T006 [P] Add `VECTOR_DB_DISTANCE_FN=cosine` with description to .env.example
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Foundational (Phase 1)**: No dependencies — start immediately
+- **User Story 1 (Phase 2)**: Depends on Phase 1 (config field must exist)
+- **Polish (Phase 3)**: Independent of other phases
+
+### Parallel Opportunities
+
+- T003 can run in parallel with T001/T002 (different file)
+- T006 can run in parallel with any other task (different file)
+- T004 depends on T003 (same file)
+- T005 depends on T003 (needs adapter to accept the param)


### PR DESCRIPTION
## Summary

- Add `VECTOR_DB_DISTANCE_FN` environment variable to configure ChromaDB HNSW distance metric (`cosine`, `l2`, `ip`)
- Validated at config load time; defaults to `cosine` for full backward compatibility
- Applied to all `get_or_create_collection` calls (query, ingest, get)

## Test plan

- [x] Set `VECTOR_DB_DISTANCE_FN=l2`, start service, verify collections use L2 distance
- [x] Set `VECTOR_DB_DISTANCE_FN=hamming`, verify startup fails with clear error
- [x] Leave unset, verify existing cosine behavior unchanged

## SDD Spec

Full spec at `specs/009-vector-db-distance-fn/` (spec, plan, research, data-model, quickstart, tasks, checklist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable vector database distance via the VECTOR_DB_DISTANCE_FN environment variable (options: cosine [default], l2, ip).
  * Startup validation rejects invalid distance values.
  * Adapter now applies the selected distance metric to vector store operations.
  * Added a Retrospec command specification to produce single-responsibility SDD spec artifacts from current changes.

* **Chores**
  * Updated .env example and added comprehensive specification, plan, research, tasks, and checklists documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->