### PR TITLE
feat: BoK LLM, summarize base URL, and LLM factory hardening

### DIFF
--- a/.claude/commands/speckit.retrospec.md
+++ b/.claude/commands/speckit.retrospec.md
@@ -1,0 +1,257 @@
+---
+description: Generate single-responsibility SDD specs from current code changes. Decomposes multi-concern changesets into one spec per responsibility, each with all SDD artifacts.
+handoffs:
+  - label: Analyze Specs for Consistency
+    agent: speckit.analyze
+    prompt: Run a project analysis for consistency across the generated specs
+    send: true
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty). The user may specify:
+- A custom diff range (e.g., `origin/develop..HEAD`, `HEAD~3`)
+- A list of files to focus on
+- Hints about how to decompose responsibilities
+- `--dry-run` to only show the proposed decomposition without generating artifacts
+
+## Outline
+
+### Step 1: Determine the Change Set
+
+Determine what "current changes" means based on context:
+
+1. **If `$ARGUMENTS` specifies a diff range** (e.g., `origin/develop..HEAD`, `HEAD~5`, a commit SHA): use that range.
+2. **If there are uncommitted changes** (staged or unstaged): use `git diff HEAD` to capture all working-tree changes.
+3. **If the current branch differs from the main branch** (typically `develop` or `main`): use `git diff $(git merge-base HEAD develop)..HEAD` to capture all branch changes.
+4. **If none of the above produce changes**: ERROR "No changes detected. Specify a diff range as argument."
+
+Run `git status` and the appropriate `git diff` (with `--stat` first for overview, then full diff). Also run `git log --oneline` for the relevant range to understand commit history.
+
+### Step 2: Read and Understand All Changed Files
+
+For each file in the changeset:
+1. Read the **full current content** of the file (not just the diff) to understand context.
+2. Read the **diff hunks** to understand what specifically changed.
+3. Note the file's role in the architecture (core/, plugins/, tests/, config, etc.) using CLAUDE.md as reference.
+
+### Step 3: Decompose into Single-Responsibility Concerns
+
+Analyze all changes and group them into **distinct, single-responsibility concerns**. Each concern should:
+- Address **one cohesive feature, fix, or improvement**
+- Be independently understandable and testable
+- Map to a clear user-facing or operator-facing value proposition
+
+**Decomposition heuristics**:
+- Changes to the same domain concept (e.g., "config validation" vs. "new pipeline step") are separate concerns
+- Changes that serve the same user story belong together even if spread across files
+- Infrastructure/plumbing changes that enable a feature belong WITH that feature, not as a separate spec
+- Test changes belong with the production code they test
+
+**If all changes serve a single responsibility**: create exactly one spec.
+**If multiple responsibilities are detected**: create one spec per responsibility, clearly delineating which files/changes belong to each.
+
+Present the proposed decomposition to the user in this format before generating artifacts:
+
+```markdown
+## Proposed Decomposition
+
+### Spec 1: [Short Title]
+**Responsibility**: [One-sentence description]
+**Files**:
+- `path/to/file1.py` — [what changed and why]
+- `path/to/file2.py` — [what changed and why]
+
+### Spec 2: [Short Title]
+**Responsibility**: [One-sentence description]
+**Files**:
+- `path/to/file3.py` — [what changed and why]
+
+Proceed with generating specs? (Y/n)
+```
+
+Wait for user confirmation unless `$ARGUMENTS` contains `--yes` or `-y`. If `--dry-run` was specified, stop here.
+
+### Step 4: Determine Spec Numbering
+
+For each spec to be created:
+
+1. Look at existing `specs/` directories to find the highest sequential number.
+2. Also check git branches for the highest feature number.
+3. Assign the next sequential number(s): if creating 2 specs and highest existing is `008`, use `009` and `010`.
+4. Generate a short name (2-4 words, kebab-case) for each spec from its responsibility title.
+
+**Do NOT create feature branches** — the code already exists on the current branch. Only create spec directories.
+
+### Step 5: Generate All SDD Artifacts
+
+For each spec, create the directory `specs/NNN-short-name/` and generate ALL of the following artifacts. Each artifact must be populated with concrete content derived from the actual code changes — not templates or placeholders.
+
+#### 5.1: spec.md (Feature Specification)
+
+Generate using the structure from `.specify/templates/spec-template.md`:
+
+```markdown
+# Feature Specification: [FEATURE NAME]
+
+**Feature Branch**: `[current-branch-name]`
+**Created**: [TODAY'S DATE]
+**Status**: Implemented
+**Input**: Retrospec from code changes
+```
+
+**Mandatory sections**:
+- **User Scenarios & Testing**: Derive user stories from what the code changes accomplish. Prioritize by impact (P1, P2, P3). Each story must have acceptance scenarios derived from the actual behavior the code implements. Mark priorities based on which changes are most impactful.
+- **Requirements**: Derive functional requirements (FR-001, FR-002...) from what the code actually does. Each requirement must be a concrete, testable statement about system behavior.
+- **Success Criteria**: Derive measurable outcomes from the implemented behavior.
+- **Assumptions**: Document any assumptions implicit in the implementation.
+
+**Key principle**: Write the spec as if it were written BEFORE implementation. It should read naturally as a specification, not as a code description. Use business/user language, not implementation language.
+
+#### 5.2: plan.md (Implementation Plan)
+
+Generate using the structure from `.specify/templates/plan-template.md`:
+
+```markdown
+# Implementation Plan: [FEATURE NAME]
+
+**Branch**: `[current-branch-name]` | **Date**: [TODAY] | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/NNN-short-name/spec.md`
+```
+
+Include:
+- **Summary**: What the feature does and the technical approach taken.
+- **Technical Context**: Fill from the actual project (Python 3.12, Poetry, pytest, etc.).
+- **Constitution Check**: Evaluate the changes against `.specify/memory/constitution.md`. For each principle/standard, mark PASS/FAIL/N/A with notes.
+- **Project Structure**: Show the actual files changed (documentation tree + source code tree).
+- **Complexity Tracking**: Only if constitution violations exist.
+
+#### 5.3: research.md (Research Decisions)
+
+Document the technical decisions embodied in the code:
+
+```markdown
+# Research: [FEATURE NAME]
+
+**Feature Branch**: `[current-branch-name]`
+**Date**: [TODAY]
+```
+
+For each significant technical decision visible in the code:
+- **Decision**: What was chosen
+- **Rationale**: Why (infer from code patterns, comments, architecture)
+- **Alternatives considered**: What other approaches could have been taken
+
+Include a summary table of all decisions.
+
+#### 5.4: data-model.md (Data Model)
+
+Document any data model changes:
+
+```markdown
+# Data Model: [FEATURE NAME]
+
+**Feature Branch**: `[current-branch-name]`
+**Date**: [TODAY]
+```
+
+Include:
+- New or modified entities (Pydantic models, config fields, domain objects)
+- Field types, defaults, validation rules
+- Relationships between entities
+- State transitions if applicable
+
+If no data model changes exist, write a brief note explaining that and skip the detailed sections.
+
+#### 5.5: contracts/ (Interface Contracts)
+
+Only generate if the changes affect external interfaces (ports, event schemas, HTTP endpoints, plugin contract). For each affected contract:
+- Document the interface before and after
+- Note backward compatibility implications
+
+If no contract changes exist, skip this directory entirely.
+
+#### 5.6: quickstart.md (Quickstart Guide)
+
+```markdown
+# Quickstart: [FEATURE NAME]
+
+**Feature Branch**: `[current-branch-name]`
+**Date**: [TODAY]
+```
+
+Include:
+- What the feature does (brief)
+- Any new environment variables or configuration
+- How to verify the feature works (concrete steps)
+- Files changed (table)
+
+#### 5.7: tasks.md (Task Breakdown)
+
+Generate using the structure from `.specify/templates/tasks-template.md`. Since the code is already implemented, **all tasks MUST be marked as complete** with `[X]`.
+
+```markdown
+# Tasks: [FEATURE NAME]
+
+**Input**: Design documents from `specs/NNN-short-name/`
+**Organization**: Tasks grouped by user story.
+```
+
+Follow the exact task format:
+- `- [X] T001 [P?] [Story?] Description with file path`
+- Use the standard phase structure (Foundational, User Story phases, Polish)
+- Include dependency information and parallel opportunities
+- Each user story phase must reference the spec's user stories
+
+#### 5.8: checklists/requirements.md (Specification Quality Checklist)
+
+```markdown
+# Specification Quality Checklist: [FEATURE NAME]
+
+**Purpose**: Validate specification completeness and quality
+**Created**: [TODAY]
+**Feature**: [spec.md](../spec.md)
+```
+
+Evaluate the generated spec against the standard quality criteria. Mark items as checked `[X]` where the spec passes, unchecked `[ ]` where it has gaps.
+
+### Step 6: Report
+
+After generating all specs, report:
+
+```markdown
+## Retrospec Complete
+
+### Generated Specs
+
+| # | Spec | Directory | Artifacts | Tasks |
+|---|------|-----------|-----------|-------|
+| 1 | [Title] | `specs/NNN-short-name/` | spec, plan, research, data-model, quickstart, tasks, checklist | N tasks |
+| 2 | [Title] | `specs/NNN-short-name/` | spec, plan, research, data-model, tasks, checklist | N tasks |
+
+### Change Coverage
+
+- **Files covered**: N/N files from the changeset are accounted for in specs
+- **Uncovered files**: [list any files not assigned to a spec, with reason]
+
+### Next Steps
+
+- Review generated specs for accuracy
+- Run `/speckit.analyze` for cross-artifact consistency check
+```
+
+## Key Rules
+
+- **Single Responsibility**: Each spec MUST cover exactly one cohesive concern. When in doubt, split.
+- **Concrete, not template**: Every artifact must contain real content from the actual code changes. No placeholder text, no template markers, no `[FILL IN]` items.
+- **Retrospective voice**: Write specs as if they were written before implementation, but informed by what was actually built. They should read as natural specifications.
+- **Complete artifact set**: Every spec gets spec.md, plan.md, research.md, data-model.md, quickstart.md, tasks.md, and checklists/requirements.md. Skip contracts/ only when no external interfaces changed.
+- **Tasks are complete**: All tasks in tasks.md are marked `[X]` because the code already exists.
+- **No branch creation**: Do not create git branches. Only create spec directories under `specs/`.
+- **Worktree-isolated delivery**: Each generated spec is intended to be delivered in isolation in its own git worktree. The decomposition MUST ensure that each spec's file set is self-contained — a spec's changes must be cherry-pickable or applicable independently without requiring changes from another spec. If two concerns share a file, either co-locate them in one spec or split the file changes so each spec's portion is independently viable.
+- **Constitution awareness**: The plan.md must include a constitution check against `.specify/memory/constitution.md`.
+- **Preserve existing numbering**: Spec numbers continue sequentially from the highest existing spec number.

--- a/.env.example
+++ b/.env.example
@@ -46,9 +46,20 @@ MISTRAL_SMALL_MODEL_NAME=mistral-small-latest
 SUMMARIZE_LLM_PROVIDER=
 SUMMARIZE_LLM_MODEL=
 SUMMARIZE_LLM_API_KEY=
+# Optional: base URL override for summarization (e.g., different port for a local model)
+SUMMARIZE_LLM_BASE_URL=
 # Optional tuning (defaults: temperature=0.3 when active, timeout=LLM_TIMEOUT)
 SUMMARIZE_LLM_TEMPERATURE=
 SUMMARIZE_LLM_TIMEOUT=
+
+# BoK LLM — optional separate model for body-of-knowledge summarization
+# Needs large context window. Falls back to summarize LLM, then main LLM.
+BOK_LLM_PROVIDER=
+BOK_LLM_MODEL=
+BOK_LLM_API_KEY=
+BOK_LLM_BASE_URL=
+BOK_LLM_TEMPERATURE=
+BOK_LLM_TIMEOUT=
 
 # Per-plugin retrieval parameters
 EXPERT_N_RESULTS=5

--- a/core/config.py
+++ b/core/config.py
@@ -189,8 +189,18 @@ class BaseConfig(BaseSettings):
     summarize_llm_provider: LLMProvider | None = None
     summarize_llm_model: str | None = None
     summarize_llm_api_key: str | None = None
+    summarize_llm_base_url: str | None = None
     summarize_llm_temperature: float | None = None
     summarize_llm_timeout: int | None = None
+
+    # BoK LLM — optional separate model for body-of-knowledge summarization
+    # (needs large context window; falls back to summarize LLM, then main LLM)
+    bok_llm_provider: LLMProvider | None = None
+    bok_llm_model: str | None = None
+    bok_llm_api_key: str | None = None
+    bok_llm_base_url: str | None = None
+    bok_llm_temperature: float | None = None
+    bok_llm_timeout: int | None = None
 
     # Retrieval — per-plugin parameters
     expert_n_results: int = 5

--- a/core/config.py
+++ b/core/config.py
@@ -178,6 +178,41 @@ class BaseConfig(BaseSettings):
                 ", ".join(missing),
             )
 
+        # BoK LLM validation
+        if self.bok_llm_temperature is not None and not (
+            0.0 <= self.bok_llm_temperature <= 2.0
+        ):
+            raise ValueError(
+                f"BOK_LLM_TEMPERATURE must be between 0.0 and 2.0, "
+                f"got {self.bok_llm_temperature}"
+            )
+        if self.bok_llm_timeout is not None and self.bok_llm_timeout <= 0:
+            raise ValueError(
+                f"BOK_LLM_TIMEOUT must be greater than 0, "
+                f"got {self.bok_llm_timeout}"
+            )
+
+        # Partial BoK config warning
+        bok_fields = [
+            self.bok_llm_provider,
+            self.bok_llm_model,
+            self.bok_llm_api_key,
+        ]
+        bok_set_count = sum(1 for f in bok_fields if f is not None)
+        if 0 < bok_set_count < 3:
+            missing = []
+            if self.bok_llm_provider is None:
+                missing.append("BOK_LLM_PROVIDER")
+            if self.bok_llm_model is None:
+                missing.append("BOK_LLM_MODEL")
+            if self.bok_llm_api_key is None:
+                missing.append("BOK_LLM_API_KEY")
+            logger.warning(
+                "Partial BoK LLM config — missing: %s. "
+                "Falling back to summarize/main LLM for BoK summarization.",
+                ", ".join(missing),
+            )
+
         return self
 
     # Embeddings

--- a/core/provider_factory.py
+++ b/core/provider_factory.py
@@ -62,7 +62,7 @@ def create_llm_adapter(
         kwargs["max_tokens"] = config.llm_max_tokens
     if config.llm_top_p is not None:
         kwargs["top_p"] = config.llm_top_p
-    if disable_thinking:
+    if disable_thinking and provider == LLMProvider.openai:
         kwargs["extra_body"] = {
             "chat_template_kwargs": {"enable_thinking": False}
         }

--- a/core/provider_factory.py
+++ b/core/provider_factory.py
@@ -32,10 +32,14 @@ def _get_model_class(provider: LLMProvider) -> type:
     raise ValueError(f"Unsupported provider: {provider}")
 
 
-def create_llm_adapter(config: BaseConfig) -> LangChainLLMAdapter:
+def create_llm_adapter(
+    config: BaseConfig, *, disable_thinking: bool = False
+) -> LangChainLLMAdapter:
     """Create a LangChainLLMAdapter for the configured provider.
 
     Reads provider, model, API key, and generation parameters from config.
+    When *disable_thinking* is True, sends ``enable_thinking: false`` via
+    ``extra_body`` to suppress Qwen3-style chain-of-thought reasoning.
     Returns a ready-to-use adapter implementing LLMPort.
     """
     provider = config.llm_provider
@@ -58,15 +62,20 @@ def create_llm_adapter(config: BaseConfig) -> LangChainLLMAdapter:
         kwargs["max_tokens"] = config.llm_max_tokens
     if config.llm_top_p is not None:
         kwargs["top_p"] = config.llm_top_p
+    if disable_thinking:
+        kwargs["extra_body"] = {
+            "chat_template_kwargs": {"enable_thinking": False}
+        }
 
     llm = model_cls(**kwargs)
 
     # Disable keep-alive to prevent stale connections to local LLM servers.
     # Must be done post-construction since ChatMistralAI serializes constructor kwargs.
-    if config.llm_base_url:
+    # Only applies to Mistral SDK client (httpx-based); ChatOpenAI uses a different client.
+    if config.llm_base_url and provider == LLMProvider.mistral:
         import httpx
         no_keepalive = httpx.Limits(max_keepalive_connections=0)
-        if hasattr(llm, "async_client") and llm.async_client:
+        if hasattr(llm, "async_client") and hasattr(llm.async_client, "headers"):
             llm.async_client = httpx.AsyncClient(
                 base_url=config.llm_base_url,
                 limits=no_keepalive,

--- a/main.py
+++ b/main.py
@@ -199,8 +199,6 @@ async def _run(config: BaseConfig) -> None:
         config.bok_llm_api_key,
     ]
     if all(f is not None for f in bok_fields):
-        from core.provider_factory import create_llm_adapter as _create_bok
-
         synth_data = config.model_dump()
         synth_data["llm_provider"] = config.bok_llm_provider
         synth_data["llm_model"] = config.bok_llm_model
@@ -214,7 +212,7 @@ async def _run(config: BaseConfig) -> None:
             synth_data["llm_base_url"] = config.bok_llm_base_url
         if config.bok_llm_timeout is not None:
             synth_data["llm_timeout"] = config.bok_llm_timeout
-        bok_llm = _create_bok(BaseConfig(**synth_data), disable_thinking=True)
+        bok_llm = create_llm_adapter(BaseConfig(**synth_data), disable_thinking=True)
         logger.info(
             "BoK LLM configured: provider=%s, model=%s, base_url=%s",
             config.bok_llm_provider.value,

--- a/main.py
+++ b/main.py
@@ -36,8 +36,13 @@ def _log_config(config: BaseConfig) -> None:
         "summarize_llm_provider",
         "summarize_llm_model",
         "summarize_llm_api_key",
+        "summarize_llm_base_url",
         "summarize_llm_temperature",
         "summarize_llm_timeout",
+        "bok_llm_provider",
+        "bok_llm_model",
+        "bok_llm_api_key",
+        "bok_llm_base_url",
         "expert_n_results",
         "expert_min_score",
         "guidance_n_results",
@@ -172,13 +177,49 @@ async def _run(config: BaseConfig) -> None:
             if config.summarize_llm_temperature is not None
             else 0.3
         )
+        if config.summarize_llm_base_url is not None:
+            synth_data["llm_base_url"] = config.summarize_llm_base_url
         if config.summarize_llm_timeout is not None:
             synth_data["llm_timeout"] = config.summarize_llm_timeout
-        summarize_llm = create_llm_adapter(BaseConfig(**synth_data))
+        summarize_llm = create_llm_adapter(
+            BaseConfig(**synth_data), disable_thinking=True
+        )
         logger.info(
-            "Summarization LLM configured: provider=%s, model=%s",
+            "Summarization LLM configured: provider=%s, model=%s, base_url=%s",
             config.summarize_llm_provider.value,
             config.summarize_llm_model,
+            config.summarize_llm_base_url or "(inherited from main LLM)",
+        )
+
+    # Create BoK LLM adapter if fully configured (needs large context window)
+    bok_llm = None
+    bok_fields = [
+        config.bok_llm_provider,
+        config.bok_llm_model,
+        config.bok_llm_api_key,
+    ]
+    if all(f is not None for f in bok_fields):
+        from core.provider_factory import create_llm_adapter as _create_bok
+
+        synth_data = config.model_dump()
+        synth_data["llm_provider"] = config.bok_llm_provider
+        synth_data["llm_model"] = config.bok_llm_model
+        synth_data["llm_api_key"] = config.bok_llm_api_key
+        synth_data["llm_temperature"] = (
+            config.bok_llm_temperature
+            if config.bok_llm_temperature is not None
+            else 0.3
+        )
+        if config.bok_llm_base_url is not None:
+            synth_data["llm_base_url"] = config.bok_llm_base_url
+        if config.bok_llm_timeout is not None:
+            synth_data["llm_timeout"] = config.bok_llm_timeout
+        bok_llm = _create_bok(BaseConfig(**synth_data), disable_thinking=True)
+        logger.info(
+            "BoK LLM configured: provider=%s, model=%s, base_url=%s",
+            config.bok_llm_provider.value,
+            config.bok_llm_model,
+            config.bok_llm_base_url or "(inherited from main LLM)",
         )
 
     # Construct plugin with dependencies
@@ -206,6 +247,9 @@ async def _run(config: BaseConfig) -> None:
     # Inject summarization LLM for ingest plugins
     if "summarize_llm" in sig.parameters:
         deps["summarize_llm"] = summarize_llm
+    # Inject BoK LLM for ingest plugins (large-context model for BoK summary)
+    if "bok_llm" in sig.parameters:
+        deps["bok_llm"] = bok_llm
     # Inject chunk threshold for ingest plugins
     if "chunk_threshold" in sig.parameters:
         deps["chunk_threshold"] = config.summary_chunk_threshold

--- a/plugins/ingest_space/plugin.py
+++ b/plugins/ingest_space/plugin.py
@@ -42,6 +42,7 @@ class IngestSpacePlugin:
         graphql_client: Any = None,
         *,
         summarize_llm: LLMPort | None = None,
+        bok_llm: LLMPort | None = None,
         chunk_threshold: int = 4,
     ) -> None:
         self._llm = llm
@@ -49,6 +50,7 @@ class IngestSpacePlugin:
         self._knowledge_store = knowledge_store
         self._graphql_client = graphql_client
         self._summarize_llm = summarize_llm
+        self._bok_llm = bok_llm
         self._chunk_threshold = chunk_threshold
 
     async def startup(self) -> None:
@@ -88,7 +90,7 @@ class IngestSpacePlugin:
                     llm_port=summary_llm,
                     chunk_threshold=self._chunk_threshold,
                 ),
-                BodyOfKnowledgeSummaryStep(llm_port=summary_llm),
+                BodyOfKnowledgeSummaryStep(llm_port=self._bok_llm or summary_llm),
                 EmbedStep(embeddings_port=self._embeddings),
                 StoreStep(knowledge_store_port=self._knowledge_store),
                 OrphanCleanupStep(knowledge_store_port=self._knowledge_store),

--- a/plugins/ingest_website/plugin.py
+++ b/plugins/ingest_website/plugin.py
@@ -40,12 +40,14 @@ class IngestWebsitePlugin:
         knowledge_store: KnowledgeStorePort,
         *,
         summarize_llm: LLMPort | None = None,
+        bok_llm: LLMPort | None = None,
         chunk_threshold: int = 4,
     ) -> None:
         self._llm = llm
         self._embeddings = embeddings
         self._knowledge_store = knowledge_store
         self._summarize_llm = summarize_llm
+        self._bok_llm = bok_llm
         self._chunk_threshold = chunk_threshold
         self._page_limit = 20  # Default, can be overridden by config
 
@@ -103,7 +105,8 @@ class IngestWebsitePlugin:
                     concurrency=config.summarize_concurrency,
                     chunk_threshold=self._chunk_threshold,
                 ))
-                steps.append(BodyOfKnowledgeSummaryStep(llm_port=summary_llm))
+                bok_llm = self._bok_llm or summary_llm
+                steps.append(BodyOfKnowledgeSummaryStep(llm_port=bok_llm))
             steps.append(EmbedStep(embeddings_port=self._embeddings))
             steps.append(StoreStep(knowledge_store_port=self._knowledge_store))
             steps.append(OrphanCleanupStep(knowledge_store_port=self._knowledge_store))

--- a/specs/010-bok-llm-factory-hardening/checklists/requirements.md
+++ b/specs/010-bok-llm-factory-hardening/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: BoK LLM, Summarize Base URL, and LLM Factory Hardening
+
+**Purpose**: Validate specification completeness and quality
+**Created**: 2026-04-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [ ] No implementation details leak into specification
+
+## Notes
+
+- One checklist item unchecked: US3 (LLM Factory Hardening) references Qwen3-specific behavior and httpx client details, which are implementation-level concerns. This is acceptable because the user story is inherently about fixing provider-specific backend behavior — the acceptance scenarios need to reference specific provider behaviors to be testable.

--- a/specs/010-bok-llm-factory-hardening/data-model.md
+++ b/specs/010-bok-llm-factory-hardening/data-model.md
@@ -1,0 +1,99 @@
+# Data Model: BoK LLM, Summarize Base URL, and LLM Factory Hardening
+
+**Feature Branch**: `develop`
+**Date**: 2026-04-08
+
+## Overview
+
+This feature adds configuration fields for a third LLM tier (BoK LLM) and a base URL for the summarization LLM. No new database tables, event schemas, or domain entities. All changes are additive fields on `BaseConfig`.
+
+## Entity: BaseConfig (modified)
+
+**File**: `core/config.py`
+
+### New Fields — BoK LLM
+
+| Field | Type | Default | Env Var | Description |
+|-------|------|---------|---------|-------------|
+| `bok_llm_provider` | `LLMProvider \| None` | `None` | `BOK_LLM_PROVIDER` | Provider for BoK summarization LLM |
+| `bok_llm_model` | `str \| None` | `None` | `BOK_LLM_MODEL` | Model name for BoK summarization |
+| `bok_llm_api_key` | `str \| None` | `None` | `BOK_LLM_API_KEY` | API key for BoK LLM |
+| `bok_llm_base_url` | `str \| None` | `None` | `BOK_LLM_BASE_URL` | Base URL override for BoK LLM |
+| `bok_llm_temperature` | `float \| None` | `None` | `BOK_LLM_TEMPERATURE` | Temperature (defaults to 0.3 when BoK LLM is active) |
+| `bok_llm_timeout` | `int \| None` | `None` | `BOK_LLM_TIMEOUT` | Timeout in seconds (falls back to `LLM_TIMEOUT`) |
+
+**Activation rule**: BoK LLM is active when ALL THREE of `bok_llm_provider`, `bok_llm_model`, and `bok_llm_api_key` are set.
+
+**Fallback**: BoK LLM -> summarize LLM -> main LLM.
+
+### New Field — Summarize LLM Base URL
+
+| Field | Type | Default | Env Var | Description |
+|-------|------|---------|---------|-------------|
+| `summarize_llm_base_url` | `str \| None` | `None` | `SUMMARIZE_LLM_BASE_URL` | Base URL override for summarization LLM endpoint |
+
+## Entity: create_llm_adapter (modified)
+
+**File**: `core/provider_factory.py`
+
+### New Parameter
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `disable_thinking` | `bool` | `False` | When True, sends `extra_body: {"chat_template_kwargs": {"enable_thinking": false}}` to suppress Qwen3 chain-of-thought |
+
+### Changed Behavior — Mistral-only keepalive
+
+- **Before**: httpx keep-alive disabling applied to all providers when `base_url` was set
+- **After**: Only applied when `provider == LLMProvider.mistral` AND `hasattr(llm.async_client, "headers")`
+
+## Entity: IngestSpacePlugin (modified)
+
+**File**: `plugins/ingest_space/plugin.py`
+
+### New Constructor Parameter
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `bok_llm` | `LLMPort \| None` | `None` | Optional dedicated LLM for BoK summarization |
+
+### Changed Behavior
+
+- `BodyOfKnowledgeSummaryStep` receives `self._bok_llm or summary_llm` as `llm_port`
+- Previously received `summary_llm` directly
+
+## Entity: IngestWebsitePlugin (modified)
+
+**File**: `plugins/ingest_website/plugin.py`
+
+### New Constructor Parameter
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `bok_llm` | `LLMPort \| None` | `None` | Optional dedicated LLM for BoK summarization |
+
+### Changed Behavior
+
+- `BodyOfKnowledgeSummaryStep` receives `self._bok_llm or summary_llm` as `llm_port`
+- Previously received `summary_llm` directly
+
+## Relationships
+
+```text
+BaseConfig
+  ├── creates → main LLM adapter (via create_llm_adapter)
+  ├── creates → summarization LLM adapter (via create_llm_adapter, disable_thinking=True)
+  ├── creates → BoK LLM adapter (via create_llm_adapter, disable_thinking=True)
+  ├── injects → IngestWebsitePlugin(summarize_llm, bok_llm)
+  └── injects → IngestSpacePlugin(summarize_llm, bok_llm)
+
+BodyOfKnowledgeSummaryStep
+  └── uses → bok_llm or summarize_llm or main LLM (via llm_port)
+
+DocumentSummaryStep
+  └── uses → summarize_llm or main LLM (via llm_port, unchanged)
+```
+
+## State Transitions
+
+No state machines affected. Configuration and fallback resolved at startup/plugin construction.

--- a/specs/010-bok-llm-factory-hardening/plan.md
+++ b/specs/010-bok-llm-factory-hardening/plan.md
@@ -1,0 +1,79 @@
+# Implementation Plan: BoK LLM, Summarize Base URL, and LLM Factory Hardening
+
+**Branch**: `develop` | **Date**: 2026-04-08 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/010-bok-llm-factory-hardening/spec.md`
+
+## Summary
+
+Add a third LLM tier for body-of-knowledge summarization (large-context-window model), support base URL overrides for the summarization LLM, and harden the LLM factory for local model backends. The BoK LLM falls back to the summarize LLM, then to the main LLM. The factory gains a `disable_thinking` parameter for Qwen3 models and restricts httpx keep-alive patching to the Mistral provider. All changes are additive with full backward compatibility.
+
+## Technical Context
+
+**Language/Version**: Python 3.12 (Poetry)
+**Primary Dependencies**: langchain ^1.1.0, langchain-openai ^1.1.0, langchain-mistralai ^1.1.0, langchain-anthropic ^0.3, pydantic-settings ^2.11.0
+**Storage**: ChromaDB (unchanged)
+**Testing**: pytest ^9.0 + pytest-asyncio ^1.3 (asyncio_mode = auto)
+**Target Platform**: Linux server (Docker containers, K8s)
+**Project Type**: Microkernel service
+**Performance Goals**: N/A (configuration and wiring change)
+**Constraints**: Full backward compatibility; no port interface changes
+**Scale/Scope**: 6 files modified, ~85 lines added
+
+## Constitution Check
+
+| # | Principle / Standard | Status | Notes |
+|---|---------------------|--------|-------|
+| P1 | AI-Native Development | PASS | Config + wiring change, no interactive steps |
+| P2 | SOLID Architecture | PASS | No new port interfaces. BoK LLM reuses existing `LLMPort`. Ingest plugins gain an optional constructor param — Open/Closed satisfied |
+| P3 | No Vendor Lock-in | PASS | BoK LLM uses same provider-agnostic factory. All 3 providers supported. Factory hardening improves multi-provider support |
+| P4 | Optimised Feedback Loops | PASS | Config validation catches invalid values at startup |
+| P5 | Best Available Infrastructure | N/A | No CI changes |
+| P6 | SDD | PASS | Retrospec in progress |
+| P7 | No Filling Tests | N/A | No tests added in this changeset |
+| P8 | ADR | PASS | No port/contract changes. No new external dependencies |
+| AS:Microkernel | Microkernel Architecture | PASS | Config stays in core. No cross-plugin coupling. Ingest plugins receive BoK LLM via constructor injection |
+| AS:Hexagonal | Hexagonal Boundaries | PASS | BoK LLM is another `LLMPort` instance — same port, same adapter, different config |
+| AS:Plugin | Plugin Contract | PASS | `PluginContract` unchanged. Ingest plugins gain optional `bok_llm` constructor param |
+| AS:Domain | Domain Logic Isolation | PASS | `BodyOfKnowledgeSummaryStep` already accepts `llm_port` — no domain change needed |
+| AS:Simplicity | Simplicity Over Speculation | PASS | Reuses existing patterns: synthetic config + create_llm_adapter. Factory param is minimal |
+| AS:Async | Async-First Design | PASS | No new sync calls |
+
+**Gate result**: PASS — no violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/010-bok-llm-factory-hardening/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── tasks.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+core/
+├── config.py              # Add bok_llm_* fields (6) + summarize_llm_base_url
+└── provider_factory.py    # Add disable_thinking param; Mistral-only keepalive; tighter hasattr
+
+main.py                    # BoK LLM creation/wiring/logging; summarize base_url; disable_thinking
+
+plugins/
+├── ingest_space/
+│   └── plugin.py          # Accept optional bok_llm, route to BodyOfKnowledgeSummaryStep
+└── ingest_website/
+    └── plugin.py          # Accept optional bok_llm, route to BodyOfKnowledgeSummaryStep
+
+.env.example               # Document BOK_LLM_* and SUMMARIZE_LLM_BASE_URL
+```
+
+## Complexity Tracking
+
+No constitution violations to justify.

--- a/specs/010-bok-llm-factory-hardening/quickstart.md
+++ b/specs/010-bok-llm-factory-hardening/quickstart.md
@@ -1,0 +1,107 @@
+# Quickstart: BoK LLM, Summarize Base URL, and LLM Factory Hardening
+
+**Feature Branch**: `develop`
+**Date**: 2026-04-08
+
+## What This Feature Does
+
+Adds three improvements to the LLM configuration for ingest pipelines:
+
+1. **BoK LLM** — a separate, large-context-window model for body-of-knowledge summarization
+2. **Summarize LLM Base URL** — point the summarization LLM to a local model server
+3. **LLM Factory Hardening** — suppress Qwen3 chain-of-thought, fix Mistral-only keepalive
+
+All configuration is backward compatible: the system behaves identically when no new env vars are set.
+
+## New Environment Variables
+
+### BoK LLM
+
+```env
+# All three required to activate a separate BoK LLM.
+# Falls back to summarize LLM, then main LLM.
+BOK_LLM_PROVIDER=              # mistral | openai | anthropic
+BOK_LLM_MODEL=                 # e.g., mistral-large-latest (128K context)
+BOK_LLM_API_KEY=
+
+# Optional
+BOK_LLM_BASE_URL=              # Override endpoint (e.g., local vLLM)
+BOK_LLM_TEMPERATURE=           # Default: 0.3 when active
+BOK_LLM_TIMEOUT=               # Default: LLM_TIMEOUT
+```
+
+### Summarize LLM Base URL
+
+```env
+# Optional: override endpoint for summarization LLM
+SUMMARIZE_LLM_BASE_URL=        # e.g., http://localhost:8000/v1
+```
+
+## Quick Verification
+
+### 1. Three-tier LLM setup
+
+```bash
+# Main LLM (user-facing)
+export LLM_PROVIDER=openai
+export LLM_MODEL=gpt-4o
+export LLM_API_KEY=sk-main
+
+# Summarization LLM (per-document, cheap)
+export SUMMARIZE_LLM_PROVIDER=mistral
+export SUMMARIZE_LLM_MODEL=mistral-small-latest
+export SUMMARIZE_LLM_API_KEY=ms-key
+
+# BoK LLM (aggregated summary, large context)
+export BOK_LLM_PROVIDER=mistral
+export BOK_LLM_MODEL=mistral-large-latest
+export BOK_LLM_API_KEY=ml-key
+
+export PLUGIN_TYPE=ingest-space
+poetry run python main.py
+
+# Check logs for:
+#   INFO: Summarization LLM configured: provider=mistral, model=mistral-small-latest, base_url=(inherited from main LLM)
+#   INFO: BoK LLM configured: provider=mistral, model=mistral-large-latest, base_url=(inherited from main LLM)
+```
+
+### 2. Local model with base URL
+
+```bash
+export SUMMARIZE_LLM_PROVIDER=openai
+export SUMMARIZE_LLM_MODEL=Qwen/Qwen3-8B
+export SUMMARIZE_LLM_API_KEY=not-needed
+export SUMMARIZE_LLM_BASE_URL=http://localhost:8000/v1
+
+# Summarization calls go to local vLLM, with thinking disabled automatically
+```
+
+### 3. Fallback verification
+
+```bash
+# Only set summarize LLM, no BoK LLM
+export SUMMARIZE_LLM_PROVIDER=mistral
+export SUMMARIZE_LLM_MODEL=mistral-small-latest
+export SUMMARIZE_LLM_API_KEY=key
+
+# BoK summarization falls back to summarize LLM
+# No BoK LLM log line appears at startup
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `core/config.py` | Add `bok_llm_*` fields (6) and `summarize_llm_base_url` |
+| `core/provider_factory.py` | Add `disable_thinking` param; Mistral-only keepalive; tighter `hasattr` |
+| `main.py` | BoK LLM creation/wiring/logging; summarize base_url; `disable_thinking=True` |
+| `plugins/ingest_space/plugin.py` | Accept `bok_llm`, route to `BodyOfKnowledgeSummaryStep` |
+| `plugins/ingest_website/plugin.py` | Accept `bok_llm`, route to `BodyOfKnowledgeSummaryStep` |
+| `.env.example` | Document `BOK_LLM_*` and `SUMMARIZE_LLM_BASE_URL` |
+
+## Contracts
+
+No external interface changes:
+- **LLMPort**: Unchanged (BoK LLM uses the same port)
+- **PluginContract**: Unchanged (no new lifecycle methods)
+- **Event schemas**: Unchanged

--- a/specs/010-bok-llm-factory-hardening/research.md
+++ b/specs/010-bok-llm-factory-hardening/research.md
@@ -1,0 +1,85 @@
+# Research: BoK LLM, Summarize Base URL, and LLM Factory Hardening
+
+**Feature Branch**: `develop`
+**Date**: 2026-04-08
+
+## Research Tasks
+
+### R1: BoK LLM — three-tier LLM architecture
+
+**Context**: Document summarization and body-of-knowledge summarization have different input size characteristics. Per-document summaries process individual document chunks (small input). BoK summaries aggregate all document summaries (potentially very large input requiring a high-context-window model).
+
+**Findings**:
+
+The existing summarization LLM pattern (synthetic config + `create_llm_adapter`) directly supports adding a third tier. The BoK LLM follows the same creation pattern as the summarize LLM:
+1. Check if all 3 required fields are set (provider, model, api_key)
+2. Build synthetic config mapping `bok_llm_*` to `llm_*` fields
+3. Call `create_llm_adapter()` to create the adapter
+
+The fallback chain in ingest plugins: `self._bok_llm or summary_llm` (where `summary_llm = self._summarize_llm or self._llm`). This gives the 3-tier hierarchy: BoK LLM -> summarize LLM -> main LLM.
+
+**Decision**: Reuse the synthetic-config pattern for BoK LLM. Fallback chain implemented in plugin code.
+**Rationale**: Zero factory changes for creation. Consistent with existing summarize LLM pattern. Fallback chain is a simple `or` expression.
+**Alternatives considered**: (a) Single "ingest LLM" for both document and BoK — rejected (can't use different context-window models). (b) Configure BoK LLM at the pipeline step level — rejected (would require plumbing config through domain layer, violating Simplicity).
+
+---
+
+### R2: Summarize LLM base URL
+
+**Context**: The summarize LLM was missing `base_url` support, meaning it always inherited the main LLM's endpoint. Operators running local model servers for summarization couldn't point the summarize LLM to a different server.
+
+**Findings**:
+
+The synthetic config approach already supports base URL: just map `summarize_llm_base_url` to `llm_base_url` in the synthetic data dict. The only change needed is adding the config field and the mapping line.
+
+**Decision**: Add `summarize_llm_base_url: str | None = None` to config. Map to `llm_base_url` in synthetic config when set.
+**Rationale**: One field, one mapping line. Completes the summarize LLM configuration surface to match main LLM capabilities.
+**Alternatives considered**: None — this is the obvious and minimal approach.
+
+---
+
+### R3: disable_thinking for Qwen3 models
+
+**Context**: Qwen3 models (served via vLLM or similar) produce `<think>...</think>` chain-of-thought blocks by default. For summarization tasks, this wastes tokens and pollutes output. The OpenAI-compatible API supports suppressing thinking via `extra_body`.
+
+**Findings**:
+
+The Qwen3 model's thinking mode can be disabled by sending:
+```json
+{"chat_template_kwargs": {"enable_thinking": false}}
+```
+via the `extra_body` parameter in the LangChain model constructor kwargs.
+
+This is harmless for models that don't support it — unknown `extra_body` fields are ignored by standard OpenAI-compatible APIs.
+
+**Decision**: Add `disable_thinking: bool = False` parameter to `create_llm_adapter`. When True, inject `extra_body` with `enable_thinking: false`. Apply to summarize and BoK LLM creation (both always pass `disable_thinking=True`).
+**Rationale**: Factory-level parameter keeps the concern out of plugin code. Default `False` means no behavioral change for the main LLM.
+**Alternatives considered**: (a) Always disable thinking for all LLMs — rejected (main LLM might benefit from thinking in some scenarios). (b) Per-config field `llm_enable_thinking` — rejected (over-engineering; only needed for summarization/BoK models).
+
+---
+
+### R4: Mistral-only httpx keep-alive disabling
+
+**Context**: The factory previously disabled httpx keep-alive for ALL providers when `base_url` was set. This was incorrect: only `ChatMistralAI` uses an httpx-based `async_client`. `ChatOpenAI` uses a different client that doesn't have the same stale-connection issue.
+
+**Findings**:
+
+1. `ChatMistralAI` creates an internal `httpx.AsyncClient` as `self.async_client`. When connecting to local servers, stale keep-alive connections cause timeouts.
+2. `ChatOpenAI` creates an `openai.AsyncOpenAI` client, not a raw httpx client. Attempting to replace it with an `httpx.AsyncClient` causes errors.
+3. The previous `hasattr(llm, "async_client") and llm.async_client` check was too loose: `ChatOpenAI` also has an `async_client` attribute (the `openai.AsyncOpenAI` instance), but it doesn't have a `headers` attribute compatible with httpx.
+
+**Decision**: Guard with `provider == LLMProvider.mistral` AND `hasattr(llm.async_client, "headers")`.
+**Rationale**: Provider check prevents incorrect patching. The `headers` attribute check is a secondary safety net confirming the client is actually httpx-based.
+**Alternatives considered**: (a) Only provider check — viable but less safe. (b) Try/except around the patching — rejected (masks real errors).
+
+---
+
+## Summary of Decisions
+
+| Topic | Decision | Key Rationale |
+|-------|----------|---------------|
+| BoK LLM creation | Synthetic config + create_llm_adapter | Consistent with summarize LLM pattern |
+| BoK fallback chain | bok_llm or summarize_llm or main_llm | Simple `or` expression in plugin |
+| Summarize base URL | New config field + synthetic mapping | Completes summarize LLM config surface |
+| disable_thinking | Factory parameter, default False | Suppresses Qwen3 CoT for summarization |
+| Mistral keepalive | Provider guard + hasattr(headers) | Prevents incorrect patching of non-Mistral clients |

--- a/specs/010-bok-llm-factory-hardening/spec.md
+++ b/specs/010-bok-llm-factory-hardening/spec.md
@@ -1,0 +1,103 @@
+# Feature Specification: BoK LLM, Summarize Base URL, and LLM Factory Hardening
+
+**Feature Branch**: `develop`
+**Created**: 2026-04-08
+**Status**: Implemented
+**Input**: Retrospec from code changes
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Dedicated LLM for Body-of-Knowledge Summarization (Priority: P1)
+
+As a platform operator, I want to configure a separate LLM for body-of-knowledge (BoK) summarization — distinct from both the main LLM and the document summarization LLM — so that I can use a large-context-window model for BoK summaries (which aggregate all document summaries into one) while keeping a smaller, cheaper model for per-document summarization.
+
+**Why this priority**: BoK summarization processes the concatenation of all document summaries, which can be extremely long. A large-context model (e.g., 128K+ tokens) is needed to avoid truncation, but such models are expensive. Per-document summarization handles much shorter inputs and can use a cheaper model. Separating these allows cost optimization without sacrificing quality.
+
+**Independent Test**: Set `BOK_LLM_PROVIDER`, `BOK_LLM_MODEL`, and `BOK_LLM_API_KEY` to a large-context model. Set `SUMMARIZE_LLM_*` to a cheaper model. Ingest a space with many documents. Verify that per-document summaries use the summarize LLM while the final BoK summary uses the BoK LLM.
+
+**Acceptance Scenarios**:
+
+1. **Given** `BOK_LLM_PROVIDER`, `BOK_LLM_MODEL`, and `BOK_LLM_API_KEY` are all set, **When** a space or website is ingested, **Then** the `BodyOfKnowledgeSummaryStep` uses the configured BoK LLM.
+2. **Given** BoK LLM is not configured but summarize LLM is configured, **When** ingestion runs, **Then** BoK summarization falls back to the summarize LLM.
+3. **Given** neither BoK LLM nor summarize LLM is configured, **When** ingestion runs, **Then** BoK summarization falls back to the main LLM.
+4. **Given** `BOK_LLM_TEMPERATURE=0.2`, **When** the BoK LLM is created, **Then** it uses temperature 0.2.
+5. **Given** `BOK_LLM_TEMPERATURE` is not set, **When** the BoK LLM is created, **Then** it defaults to temperature 0.3.
+6. **Given** `BOK_LLM_BASE_URL=http://localhost:8000/v1`, **When** the BoK LLM is created, **Then** it connects to the specified base URL.
+7. **Given** `BOK_LLM_TIMEOUT=300`, **When** the BoK LLM is created, **Then** it uses a 300-second timeout. **Given** `BOK_LLM_TIMEOUT` is not set, **Then** it falls back to the main `LLM_TIMEOUT`.
+
+---
+
+### User Story 2 — Summarize LLM Base URL Override (Priority: P2)
+
+As a platform operator, I want to configure a base URL for the summarization LLM so that I can point it to a local model server (e.g., vLLM, Ollama) running a cheaper summarization model, without affecting the main LLM endpoint.
+
+**Why this priority**: Local model servers offer cost savings and latency benefits for summarization tasks. Without base URL support, the summarization LLM inherits the main LLM's endpoint, which may be a remote API.
+
+**Independent Test**: Set `SUMMARIZE_LLM_BASE_URL=http://localhost:8000/v1` alongside the other `SUMMARIZE_LLM_*` vars. Verify that summarization calls go to the local server while the main LLM uses its configured endpoint.
+
+**Acceptance Scenarios**:
+
+1. **Given** `SUMMARIZE_LLM_BASE_URL=http://localhost:8000/v1`, **When** the summarization LLM is created, **Then** it connects to the specified base URL instead of the main LLM's base URL.
+2. **Given** `SUMMARIZE_LLM_BASE_URL` is not set, **When** the summarization LLM is created, **Then** it inherits the main LLM's base URL (existing behavior).
+3. **Given** `SUMMARIZE_LLM_BASE_URL` is set, **When** startup logging runs, **Then** the configured base URL is logged at INFO level.
+
+---
+
+### User Story 3 — LLM Factory Hardening for Local Model Backends (Priority: P3)
+
+As a platform operator running local LLM servers (e.g., Qwen3 via vLLM), I want the LLM factory to correctly handle provider-specific behaviors so that summarization and BoK models work reliably with diverse backends.
+
+**Why this priority**: Without these fixes, local models may produce unwanted chain-of-thought output (Qwen3) or trigger errors from incorrect client patching (ChatOpenAI receiving Mistral-specific httpx modifications).
+
+**Independent Test**: Configure a Qwen3 model via `SUMMARIZE_LLM_*` with `SUMMARIZE_LLM_BASE_URL` pointing to a vLLM server. Verify that summarization output does not contain `<think>` tags. Configure an OpenAI-compatible local model and verify no httpx client errors.
+
+**Acceptance Scenarios**:
+
+1. **Given** the summarization or BoK LLM is created, **When** the factory builds the adapter, **Then** `enable_thinking: false` is sent via `extra_body` to suppress Qwen3-style chain-of-thought reasoning.
+2. **Given** the LLM provider is Mistral with a custom `base_url`, **When** the factory builds the adapter, **Then** the httpx keep-alive disabling logic is applied.
+3. **Given** the LLM provider is OpenAI with a custom `base_url`, **When** the factory builds the adapter, **Then** the httpx keep-alive disabling logic is NOT applied (ChatOpenAI uses a different client).
+4. **Given** the LLM provider is Mistral, **When** the factory checks for `async_client`, **Then** it verifies both that `async_client` exists AND that it has a `headers` attribute before attempting to replace it.
+
+---
+
+### Edge Cases
+
+- When only 1 or 2 of the 3 required `BOK_LLM_*` variables are set, the system silently falls back to the summarize LLM (or main LLM). No warning is logged for partial BoK config (unlike summarize LLM, which does warn).
+- When `BOK_LLM_PROVIDER` specifies an unsupported provider, the `LLMProvider` enum validation catches it at config load time.
+- When `disable_thinking` is `True` but the model does not support the `extra_body` parameter, the model backend should ignore the unknown parameter (standard OpenAI-compatible behavior).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST support a separate LLM configuration for BoK summarization via `BOK_LLM_PROVIDER`, `BOK_LLM_MODEL`, `BOK_LLM_API_KEY`, `BOK_LLM_BASE_URL`, `BOK_LLM_TEMPERATURE`, and `BOK_LLM_TIMEOUT` environment variables.
+- **FR-002**: System MUST fall back from BoK LLM to summarize LLM, then to main LLM, when BoK-specific variables are not set.
+- **FR-003**: System MUST support `SUMMARIZE_LLM_BASE_URL` to override the base URL for the summarization LLM independently of the main LLM.
+- **FR-004**: The LLM factory MUST accept a `disable_thinking` parameter that sends `enable_thinking: false` via `extra_body` when creating an adapter, suppressing chain-of-thought reasoning for models like Qwen3.
+- **FR-005**: The LLM factory MUST restrict httpx keep-alive disabling to the Mistral provider only, not applying it to OpenAI or Anthropic providers.
+- **FR-006**: The LLM factory MUST verify that the LangChain model's `async_client` has a `headers` attribute before attempting to replace it.
+- **FR-007**: System MUST log the BoK LLM configuration (provider, model, base URL) at startup when configured.
+- **FR-008**: System MUST log `summarize_llm_base_url` and `bok_llm_*` fields in the startup config log.
+- **FR-009**: The `.env.example` file MUST document all new variables (`BOK_LLM_*`, `SUMMARIZE_LLM_BASE_URL`).
+- **FR-010**: System MUST pass `disable_thinking=True` when creating both the summarization LLM and BoK LLM adapters.
+
+### Key Entities
+
+- **BoK LLM Configuration**: A set of provider, model, API key, base URL, temperature, and timeout settings for the body-of-knowledge summarization model. Falls back to summarize LLM config, then to main LLM config.
+- **Summarize LLM Base URL**: An optional URL override allowing the summarization LLM to connect to a different endpoint than the main LLM.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Operators can configure three independent LLM tiers — main (user-facing), summarize (per-document), and BoK (aggregated summaries) — each with its own provider, model, and endpoint.
+- **SC-002**: Local model backends (vLLM, Ollama) work correctly for summarization and BoK models without chain-of-thought leakage or client errors.
+- **SC-003**: The fallback chain (BoK LLM -> summarize LLM -> main LLM) activates transparently when optional tiers are not configured.
+- **SC-004**: All new environment variables have documented defaults that reproduce current behavior when unset.
+
+## Assumptions
+
+- The existing LLM adapter creation pattern (synthetic `BaseConfig` + `create_llm_adapter`) supports creating multiple independent adapters in the same process.
+- Qwen3 models support the `extra_body.chat_template_kwargs.enable_thinking` parameter via OpenAI-compatible API.
+- The `disable_thinking` parameter is harmless for models that do not support it (standard behavior for unknown extra_body fields).
+- BoK summarization is only relevant for ingest plugins (`ingest-space`, `ingest-website`); non-ingest plugins do not need the BoK LLM.

--- a/specs/010-bok-llm-factory-hardening/tasks.md
+++ b/specs/010-bok-llm-factory-hardening/tasks.md
@@ -1,0 +1,123 @@
+# Tasks: BoK LLM, Summarize Base URL, and LLM Factory Hardening
+
+**Input**: Design documents from `specs/010-bok-llm-factory-hardening/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md
+**Organization**: Tasks grouped by user story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Foundational (Config Fields)
+
+**Purpose**: All new config fields that MUST be in place before user story work begins.
+
+- [X] T001 Add `bok_llm_provider: LLMProvider | None = None`, `bok_llm_model: str | None = None`, `bok_llm_api_key: str | None = None`, `bok_llm_base_url: str | None = None`, `bok_llm_temperature: float | None = None`, `bok_llm_timeout: int | None = None` fields to BaseConfig in core/config.py
+- [X] T002 Add `summarize_llm_base_url: str | None = None` field to BaseConfig in core/config.py
+- [X] T003 [P] Add `bok_llm_provider`, `bok_llm_model`, `bok_llm_api_key`, `bok_llm_base_url` to the `_log_config()` fields list in main.py
+
+**Checkpoint**: Config fields and startup logging in place.
+
+---
+
+## Phase 2: User Story 1 — Dedicated BoK LLM (Priority: P1) MVP
+
+**Goal**: Configure a separate large-context LLM for body-of-knowledge summarization, with fallback to summarize LLM then main LLM.
+
+**Independent Test**: Set `BOK_LLM_*` variables to a large-context model. Ingest a space and verify BoK summary uses the configured model while per-document summaries use the summarize LLM.
+
+### Implementation for User Story 1
+
+- [X] T004 [US1] Create BoK LLM adapter wiring in main.py: check if all three required bok fields are set, build synthetic BaseConfig mapping bok values to llm_* fields, call create_llm_adapter with disable_thinking=True, log BoK LLM config at INFO
+- [X] T005 [P] [US1] Update IngestSpacePlugin to accept optional `bok_llm: LLMPort | None = None` in plugins/ingest_space/plugin.py, store as self._bok_llm, pass `self._bok_llm or summary_llm` to BodyOfKnowledgeSummaryStep
+- [X] T006 [P] [US1] Update IngestWebsitePlugin to accept optional `bok_llm: LLMPort | None = None` in plugins/ingest_website/plugin.py, store as self._bok_llm, pass `self._bok_llm or summary_llm` to BodyOfKnowledgeSummaryStep
+- [X] T007 [US1] Add bok_llm injection in main.py: if "bok_llm" in sig.parameters, inject the bok_llm adapter into plugin deps
+
+**Checkpoint**: BoK LLM is fully configurable with 3-tier fallback chain.
+
+---
+
+## Phase 3: User Story 2 — Summarize LLM Base URL (Priority: P2)
+
+**Goal**: Support base URL override for the summarization LLM to enable local model backends.
+
+**Independent Test**: Set `SUMMARIZE_LLM_BASE_URL=http://localhost:8000/v1` and verify summarization calls route to the local server.
+
+### Implementation for User Story 2
+
+- [X] T008 [US2] Wire summarize_llm_base_url in main.py: in the summarize LLM synthetic config block, map `summarize_llm_base_url` to `llm_base_url` when set; include base_url in INFO log message
+- [X] T009 [P] [US2] Add `summarize_llm_base_url` to the `_log_config()` fields list in main.py (already done in T003 for bok fields — this covers summarize base_url)
+
+**Checkpoint**: Summarization LLM can target a separate endpoint.
+
+---
+
+## Phase 4: User Story 3 — LLM Factory Hardening (Priority: P3)
+
+**Goal**: Harden the LLM factory for correct behavior with diverse model backends.
+
+**Independent Test**: Configure a Qwen3 model and verify no `<think>` tags in output. Configure an OpenAI-compatible local model and verify no httpx errors.
+
+### Implementation for User Story 3
+
+- [X] T010 [US3] Add `disable_thinking: bool = False` parameter to `create_llm_adapter()` in core/provider_factory.py; when True, add `extra_body: {"chat_template_kwargs": {"enable_thinking": False}}` to kwargs
+- [X] T011 [US3] Restrict httpx keep-alive disabling to Mistral provider in core/provider_factory.py: add `provider == LLMProvider.mistral` guard to the if condition
+- [X] T012 [US3] Tighten async_client check in core/provider_factory.py: change from `hasattr(llm, "async_client") and llm.async_client` to `hasattr(llm, "async_client") and hasattr(llm.async_client, "headers")`
+- [X] T013 [US3] Pass `disable_thinking=True` to both summarize and BoK LLM creation calls in main.py
+
+**Checkpoint**: Factory correctly handles Qwen3 thinking suppression and Mistral-specific client patching.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+- [X] T014 [P] Update .env.example with BOK_LLM_PROVIDER, BOK_LLM_MODEL, BOK_LLM_API_KEY, BOK_LLM_BASE_URL, BOK_LLM_TEMPERATURE, BOK_LLM_TIMEOUT, and SUMMARIZE_LLM_BASE_URL with descriptions
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Foundational (Phase 1)**: No dependencies — start immediately
+- **User Story 1 (Phase 2)**: Depends on Phase 1 (config fields) and Phase 4 T010 (disable_thinking param)
+- **User Story 2 (Phase 3)**: Depends on Phase 1 T002 (base_url config field)
+- **User Story 3 (Phase 4)**: No dependencies on other user stories (factory changes)
+- **Polish (Phase 5)**: Depends on all user stories complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Depends on US3 T010 (needs disable_thinking param in factory)
+- **User Story 2 (P2)**: Independent of US1 and US3
+- **User Story 3 (P3)**: Independent of US1 and US2
+
+### Parallel Opportunities
+
+**Phase 1**: T001, T002 sequential (same file). T003 parallel (different file).
+**Phase 2**: T005, T006 parallel (different plugin files). T004 after T005/T006 (main.py wires to updated plugins). T007 after T004.
+**Phase 3**: T008 sequential with Phase 2 main.py work. T009 parallel.
+**Phase 4**: T010, T011, T012 sequential (same file). T013 after T010.
+**Phase 5**: T014 parallel with any phase.
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Config fields
+2. Complete Phase 4 T010: disable_thinking param (prerequisite)
+3. Complete Phase 2: BoK LLM creation + plugin wiring
+4. **STOP and VALIDATE**: Test 3-tier LLM fallback independently
+5. Deploy — BoK summarization can now use a dedicated large-context model
+
+### Incremental Delivery
+
+1. Phase 1 + Phase 4 -> Foundation + factory hardened
+2. Add US1 -> Test independently -> Deploy (3-tier LLM, MVP!)
+3. Add US2 -> Test independently -> Deploy (local model support for summarization)
+4. Phase 5 -> Final polish


### PR DESCRIPTION
## Summary

- Add dedicated BoK LLM tier (`BOK_LLM_*` env vars) for large-context body-of-knowledge summarization, with 3-tier fallback: BoK LLM → summarize LLM → main LLM
- Add `SUMMARIZE_LLM_BASE_URL` to point the summarization LLM to a local model server
- Add `disable_thinking` factory parameter to suppress Qwen3 chain-of-thought for summarization/BoK models
- Fix: restrict httpx keep-alive disabling to Mistral provider only (was incorrectly applied to all providers)
- Fix: tighten `async_client` attribute check to prevent errors with non-Mistral clients

## Test plan

- [x] Set `BOK_LLM_*` to a large-context model, ingest a space, verify BoK summary uses the configured model
- [x] Set only `SUMMARIZE_LLM_*` (no BoK), verify BoK falls back to summarize LLM
- [x] Set `SUMMARIZE_LLM_BASE_URL` to a local vLLM server, verify summarization routes there
- [x] Verify no `<think>` tags in summarization output when using Qwen3 models
- [x] Configure OpenAI provider with `LLM_BASE_URL`, verify no httpx client errors

## SDD Spec

Full spec at `specs/010-bok-llm-factory-hardening/` (spec, plan, research, data-model, quickstart, tasks, checklist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dedicated BoK LLM tier configurable via BOK_LLM_* with fallback to summarization/main LLM.
  * SUMMARIZE_LLM_BASE_URL to route summarization to an alternate endpoint.
  * Summarization factory accepts a disable_thinking option to suppress model chain-of-thought.

* **Configuration**
  * New BoK config fields with validation/warnings and startup logging; optional injection of BoK adapter into ingest pipelines.

* **Documentation**
  * New CLI spec workflow and comprehensive spec/plan/quickstart/research/checklists for these features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->