### PR TITLE
fix: clean up stale summaries and BoK on edge cases

### DIFF
--- a/core/domain/pipeline/steps.py
+++ b/core/domain/pipeline/steps.py
@@ -278,6 +278,22 @@ class DocumentSummaryStep:
             )
         ]
 
+        # Mark stale summaries for cleanup: changed documents that dropped
+        # below the summary threshold no longer qualify for summarization,
+        # so their existing summary entry must be orphaned.
+        if context.change_detection_ran:
+            for doc_id, doc_chunks in chunks_by_doc.items():
+                if (
+                    doc_id in context.changed_document_ids
+                    and len(doc_chunks) < self._chunk_threshold
+                ):
+                    stale_id = f"{doc_id}-summary-0"
+                    context.orphan_ids.add(stale_id)
+                    logger.info(
+                        "Marking stale summary %s for cleanup (doc has %d chunks, threshold %d)",
+                        stale_id, len(doc_chunks), self._chunk_threshold,
+                    )
+
         for doc_id, doc_chunks in docs_to_summarize:
             try:
                 logger.info(
@@ -352,6 +368,14 @@ class BodyOfKnowledgeSummaryStep:
                 seen_doc_ids.append(doc_id)
 
         if not seen_doc_ids:
+            # Corpus is empty: if documents were removed, the existing BoK
+            # summary is stale and must be cleaned up.
+            if context.removed_document_ids:
+                context.orphan_ids.add("body-of-knowledge-summary-0")
+                logger.info(
+                    "Corpus empty after removing %d documents; marking BoK summary for cleanup",
+                    len(context.removed_document_ids),
+                )
             return
 
         # For each doc: prefer document_summaries, else concatenate raw chunk content

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,75 @@
+# Plan: Summary Lifecycle Management -- Clean Up Stale Summaries and BoK on Edge Cases
+
+**Story:** alkem-io/virtual-contributor#36
+**Date:** 2026-04-08
+
+## Architecture
+
+No architectural changes. This is a targeted bug fix within existing pipeline steps.
+
+## Affected Modules
+
+| Module | Change |
+|--------|--------|
+| `core/domain/pipeline/steps.py` | `DocumentSummaryStep.execute()` -- add stale summary detection; `BodyOfKnowledgeSummaryStep.execute()` -- add empty-corpus BoK cleanup |
+| `tests/core/domain/test_pipeline_steps.py` | Add test cases for both edge cases |
+
+## Data Model Deltas
+
+None. Uses existing `PipelineContext.orphan_ids` set and `PipelineContext.changed_document_ids` set.
+
+## Interface Contracts
+
+No changes. Both steps already conform to the `PipelineStep` protocol. The only change is internal behavior within `execute()`.
+
+## Detailed Design
+
+### 1. DocumentSummaryStep -- Stale summary cleanup
+
+**Location**: `DocumentSummaryStep.execute()`, after computing `chunks_by_doc` and `docs_to_summarize`.
+
+**Logic**: After computing `docs_to_summarize`, iterate over all documents in `chunks_by_doc`. For each document where:
+- `context.change_detection_ran` is True
+- `doc_id` is in `context.changed_document_ids`
+- `len(doc_chunks) < self._chunk_threshold`
+
+Add `f"{doc_id}-summary-0"` to `context.orphan_ids`.
+
+**Rationale**: A changed document that no longer meets the threshold had a prior ingest cycle where it did meet the threshold. Its summary entry `{doc_id}-summary-0` is now stale. Adding it to `orphan_ids` lets the existing `OrphanCleanupStep` handle deletion.
+
+### 2. BodyOfKnowledgeSummaryStep -- Empty corpus cleanup
+
+**Location**: `BodyOfKnowledgeSummaryStep.execute()`, before the early return on empty `seen_doc_ids`.
+
+**Logic**: After computing `seen_doc_ids`, check:
+- `not seen_doc_ids` (no content chunks remain)
+- `context.removed_document_ids` is non-empty (documents were actively removed)
+
+When both conditions hold, add `"body-of-knowledge-summary-0"` to `context.orphan_ids` and return early.
+
+**Rationale**: When the entire corpus is empty due to removal, the BoK summary is stale. Adding it to orphan_ids lets OrphanCleanupStep handle deletion consistently.
+
+## Test Strategy
+
+| Test | Covers |
+|------|--------|
+| `test_stale_summary_added_to_orphans` | AC-1: changed doc drops below threshold, summary ID added to orphan_ids |
+| `test_no_stale_summary_for_unchanged_doc` | Guard: unchanged doc below threshold does NOT get orphaned |
+| `test_no_stale_summary_when_above_threshold` | Guard: changed doc still above threshold does NOT get orphaned |
+| `test_empty_corpus_bok_orphaned` | AC-2: all docs removed, BoK summary ID added to orphan_ids |
+| `test_non_empty_corpus_bok_not_orphaned` | Guard: partial removal does NOT orphan BoK |
+| Existing tests | AC-4: all existing tests still pass |
+
+## Rollout Notes
+
+- No configuration changes.
+- No migration needed.
+- The fix is purely additive to orphan_ids; OrphanCleanupStep already handles deletion.
+- Risk: minimal. The change only adds IDs to the orphan set under very specific conditions.
+
+## Clarifications Applied
+
+1. Stale summary detection only fires when change_detection_ran is True.
+2. Only documents in changed_document_ids are candidates for stale summary cleanup.
+3. The empty-corpus BoK check is placed before the existing early return on empty seen_doc_ids.
+4. Partial removal (some docs removed) does NOT trigger BoK cleanup.

--- a/spec.md
+++ b/spec.md
@@ -1,0 +1,36 @@
+# Spec: Summary Lifecycle Management -- Clean Up Stale Summaries and BoK on Edge Cases
+
+**Story:** alkem-io/virtual-contributor#36
+**Epic:** alkem-io/alkemio#1820
+**Date:** 2026-04-08
+
+## User Value
+
+Prevent orphaned summary entries from accumulating in the knowledge store, which could degrade RAG retrieval quality by surfacing stale or phantom summaries that no longer correspond to current documents.
+
+## Scope
+
+1. **Stale per-document summary cleanup**: When a document drops below the summary threshold (currently 4 chunks) after re-chunking, the existing `{doc_id}-summary-0` entry must be added to `context.orphan_ids` so `OrphanCleanupStep` deletes it.
+2. **Empty corpus BoK cleanup**: When all documents are removed from the source (seen_doc_ids is empty and removed_document_ids is non-empty), `body-of-knowledge-summary-0` must be added to `context.orphan_ids` so `OrphanCleanupStep` deletes it.
+
+## Out of Scope
+
+- Changes to the summary threshold value itself.
+- Changes to `OrphanCleanupStep` logic (it already handles `orphan_ids` correctly).
+- Changes to `ChangeDetectionStep` logic.
+- Changes to the `StoreStep` or `EmbedStep`.
+- Multi-chunk summary entries (the system currently only produces index-0 summaries).
+
+## Acceptance Criteria
+
+1. **AC-1**: Given a document that previously had >3 chunks (triggering summary generation) and after re-ingest has <=3 chunks, when `DocumentSummaryStep.execute()` runs, then `f"{doc_id}-summary-0"` is added to `context.orphan_ids`.
+2. **AC-2**: Given that ALL documents have been removed from the source, when `BodyOfKnowledgeSummaryStep.execute()` runs, then `"body-of-knowledge-summary-0"` is added to `context.orphan_ids`.
+3. **AC-3**: Both cleanup paths are covered by unit tests that verify orphan IDs are correctly populated.
+4. **AC-4**: Existing tests continue to pass (no regressions).
+
+## Constraints
+
+- Only `core/domain/pipeline/steps.py` should be modified for production code.
+- Tests go in `tests/core/domain/test_pipeline_steps.py`.
+- No new dependencies required.
+- The fix must not alter behavior when documents are above threshold or when the corpus is non-empty.

--- a/tasks.md
+++ b/tasks.md
@@ -1,0 +1,37 @@
+# Tasks: Summary Lifecycle Management -- Clean Up Stale Summaries and BoK on Edge Cases
+
+**Story:** alkem-io/virtual-contributor#36
+**Date:** 2026-04-08
+
+## Task List
+
+### T1: Add stale per-document summary cleanup to DocumentSummaryStep
+
+**File:** `core/domain/pipeline/steps.py`
+**Depends on:** None
+**AC:** After `DocumentSummaryStep.execute()` runs, any document in `changed_document_ids` with fewer than `chunk_threshold` chunks has `f"{doc_id}-summary-0"` added to `context.orphan_ids`.
+**Tests:**
+- `test_stale_summary_added_to_orphans`: Changed doc with <=3 chunks => summary ID in orphan_ids
+- `test_no_stale_summary_for_unchanged_doc`: Unchanged doc below threshold => no orphan
+- `test_no_stale_summary_when_above_threshold`: Changed doc above threshold => no orphan
+- `test_no_stale_summary_without_change_detection`: change_detection_ran is False => no orphan cleanup logic fires
+
+### T2: Add empty corpus BoK cleanup to BodyOfKnowledgeSummaryStep
+
+**File:** `core/domain/pipeline/steps.py`
+**Depends on:** None
+**AC:** When `seen_doc_ids` is empty and `removed_document_ids` is non-empty, `"body-of-knowledge-summary-0"` is added to `context.orphan_ids`.
+**Tests:**
+- `test_empty_corpus_bok_orphaned`: All docs removed => BoK ID in orphan_ids
+- `test_non_empty_corpus_bok_not_orphaned`: Some docs remain => BoK ID NOT in orphan_ids
+
+### T3: Write unit tests for T1 and T2
+
+**File:** `tests/core/domain/test_pipeline_steps.py`
+**Depends on:** T1, T2
+**AC:** All new tests pass. All existing tests continue to pass.
+
+### T4: Run full test suite, lint, and typecheck
+
+**Depends on:** T3
+**AC:** `poetry run pytest` passes. `poetry run ruff check core/ plugins/ tests/` passes. `poetry run pyright core/ plugins/` passes (or matches baseline).

--- a/tests/core/domain/test_pipeline_steps.py
+++ b/tests/core/domain/test_pipeline_steps.py
@@ -1022,6 +1022,153 @@ class TestBoKSummaryStepDedup:
 
 
 # ---------------------------------------------------------------------------
+# T036: Stale document summary cleanup tests
+# ---------------------------------------------------------------------------
+
+
+class TestStaleSummaryCleanup:
+    async def test_stale_summary_added_to_orphans(self):
+        """Changed doc that dropped below threshold has its summary orphaned."""
+        llm = MockLLMPort(response="Summary")
+        meta = DocumentMetadata(document_id="doc-1", source="s", type="knowledge", title="T", embedding_type="chunk")
+        # Document now has only 2 chunks (below default threshold of 4)
+        ctx = PipelineContext(
+            collection_name="test",
+            documents=[],
+            chunks=[
+                Chunk(content="chunk 1", metadata=meta, chunk_index=0),
+                Chunk(content="chunk 2", metadata=meta, chunk_index=1),
+            ],
+        )
+        ctx.change_detection_ran = True
+        ctx.changed_document_ids = {"doc-1"}
+
+        await DocumentSummaryStep(llm_port=llm).execute(ctx)
+
+        assert "doc-1-summary-0" in ctx.orphan_ids
+        # Should NOT have generated a new summary (below threshold)
+        assert len(llm.calls) == 0
+
+    async def test_no_stale_summary_for_unchanged_doc(self):
+        """Unchanged doc below threshold does NOT get its summary orphaned."""
+        llm = MockLLMPort(response="Summary")
+        meta = DocumentMetadata(document_id="doc-1", source="s", type="knowledge", title="T", embedding_type="chunk")
+        ctx = PipelineContext(
+            collection_name="test",
+            documents=[],
+            chunks=[
+                Chunk(content="chunk 1", metadata=meta, chunk_index=0),
+                Chunk(content="chunk 2", metadata=meta, chunk_index=1),
+            ],
+        )
+        ctx.change_detection_ran = True
+        # doc-1 is NOT in changed_document_ids
+
+        await DocumentSummaryStep(llm_port=llm).execute(ctx)
+
+        assert "doc-1-summary-0" not in ctx.orphan_ids
+
+    async def test_no_stale_summary_when_above_threshold(self):
+        """Changed doc still above threshold does NOT get its summary orphaned."""
+        llm = MockLLMPort(response="Summary for changed doc")
+        ctx = _make_context()
+        await ChunkStep(chunk_size=100, chunk_overlap=10).execute(ctx)
+        assert len(ctx.chunks) >= 4, "Test doc should produce >= 4 chunks"
+
+        ctx.change_detection_ran = True
+        ctx.changed_document_ids = {"doc-1"}
+
+        await DocumentSummaryStep(llm_port=llm).execute(ctx)
+
+        # Summary should have been generated, not orphaned
+        assert "doc-1-summary-0" not in ctx.orphan_ids
+        summary_chunks = [c for c in ctx.chunks if c.metadata.embedding_type == "summary"]
+        assert len(summary_chunks) == 1
+
+    async def test_no_stale_summary_without_change_detection(self):
+        """When change_detection_ran is False, stale summary cleanup does not fire."""
+        llm = MockLLMPort(response="Summary")
+        meta = DocumentMetadata(document_id="doc-1", source="s", type="knowledge", title="T", embedding_type="chunk")
+        ctx = PipelineContext(
+            collection_name="test",
+            documents=[],
+            chunks=[
+                Chunk(content="chunk 1", metadata=meta, chunk_index=0),
+                Chunk(content="chunk 2", metadata=meta, chunk_index=1),
+            ],
+        )
+        # change_detection_ran is False (default)
+        assert ctx.change_detection_ran is False
+        ctx.changed_document_ids = {"doc-1"}  # irrelevant when detection didn't run
+
+        await DocumentSummaryStep(llm_port=llm).execute(ctx)
+
+        assert "doc-1-summary-0" not in ctx.orphan_ids
+
+
+# ---------------------------------------------------------------------------
+# T036: Empty corpus BoK cleanup tests
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyCorpusBoKCleanup:
+    async def test_empty_corpus_bok_orphaned(self):
+        """When all docs are removed, BoK summary is added to orphan_ids."""
+        llm = MockLLMPort(response="BoK overview")
+        ctx = PipelineContext(
+            collection_name="test",
+            documents=[],
+            chunks=[],  # No content chunks remain
+        )
+        ctx.change_detection_ran = True
+        ctx.removed_document_ids = {"doc-1", "doc-2"}
+
+        await BodyOfKnowledgeSummaryStep(llm_port=llm).execute(ctx)
+
+        assert "body-of-knowledge-summary-0" in ctx.orphan_ids
+        # No LLM calls should have been made (nothing to summarize)
+        assert len(llm.calls) == 0
+
+    async def test_non_empty_corpus_bok_not_orphaned(self):
+        """When some docs remain after removal, BoK summary is NOT orphaned."""
+        llm = MockLLMPort(response="Updated BoK")
+        ctx = PipelineContext(
+            collection_name="test",
+            documents=[],
+            chunks=[
+                Chunk(
+                    content="remaining text",
+                    metadata=DocumentMetadata(document_id="doc-1", source="s", embedding_type="chunk"),
+                    chunk_index=0,
+                ),
+            ],
+        )
+        ctx.change_detection_ran = True
+        ctx.removed_document_ids = {"doc-2"}
+
+        await BodyOfKnowledgeSummaryStep(llm_port=llm).execute(ctx)
+
+        assert "body-of-knowledge-summary-0" not in ctx.orphan_ids
+        # BoK should have been regenerated
+        bok = [c for c in ctx.chunks if c.metadata.document_id == "body-of-knowledge-summary"]
+        assert len(bok) == 1
+
+    async def test_empty_corpus_no_removals_no_orphan(self):
+        """When corpus is empty but no removals occurred, BoK is NOT orphaned."""
+        llm = MockLLMPort(response="BoK overview")
+        ctx = PipelineContext(
+            collection_name="test",
+            documents=[],
+            chunks=[],
+        )
+        # No removed_document_ids either
+
+        await BodyOfKnowledgeSummaryStep(llm_port=llm).execute(ctx)
+
+        assert "body-of-knowledge-summary-0" not in ctx.orphan_ids
+
+
+# ---------------------------------------------------------------------------
 # T017: Integration tests — full pipeline with dedup
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Stale per-document summaries are now marked for cleanup when a changed document drops below the summary threshold (<=3 chunks) after re-chunking
- The body-of-knowledge summary entry is now marked for cleanup when the entire corpus becomes empty due to document removal
- Both cleanup paths use the existing `OrphanCleanupStep` via `context.orphan_ids` -- no new deletion mechanisms needed

Closes alkem-io/virtual-contributor#36
Parent: alkem-io/alkemio#1820

## Artifacts

- `spec.md` -- specification
- `plan.md` -- architecture and design plan
- `tasks.md` -- task breakdown

**Clarify loop iterations:** 2 (1 productive + 1 clean pass)
**Analyze loop iterations:** 2 (1 productive + 1 clean pass)

## Changed Files

| File | Change |
|------|--------|
| `core/domain/pipeline/steps.py` | Added stale summary detection in `DocumentSummaryStep.execute()` and empty-corpus BoK cleanup in `BodyOfKnowledgeSummaryStep.execute()` |
| `tests/core/domain/test_pipeline_steps.py` | 7 new tests covering both edge cases and guard conditions |

## Test plan

- [x] All 339 existing tests pass (0 regressions)
- [x] 7 new tests cover both edge cases and guard conditions
- [x] `ruff check` passes clean
- [x] `pyright` reports 0 errors (41 pre-existing warnings, all in unrelated files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic detection and cleanup of stale summaries when documents fall below generation thresholds during re-ingestion.
  * Automatic orphaning of corpus-level summaries when the knowledge base becomes empty after document removals.

* **Documentation**
  * Added specification and planning documents detailing summary lifecycle management behavior.

* **Tests**
  * Added comprehensive test coverage for stale summary and empty corpus cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->