### PR TITLE
fix: skip upsert for unchanged chunks in StoreStep

### DIFF
--- a/core/domain/pipeline/steps.py
+++ b/core/domain/pipeline/steps.py
@@ -455,11 +455,26 @@ class StoreStep:
         return "store"
 
     async def execute(self, context: PipelineContext) -> None:
-        storable = [c for c in context.chunks if c.embedding is not None]
-        skipped = len(context.chunks) - len(storable)
-        if skipped > 0:
+        embedded = [c for c in context.chunks if c.embedding is not None]
+        unembedded = len(context.chunks) - len(embedded)
+        if unembedded > 0:
             context.errors.append(
-                f"StoreStep: skipped {skipped} chunks without embeddings"
+                f"StoreStep: skipped {unembedded} chunks without embeddings"
+            )
+
+        # Filter out unchanged content chunks to avoid redundant upserts
+        storable = [
+            c for c in embedded
+            if not (
+                c.metadata.embedding_type == "chunk"
+                and c.content_hash is not None
+                and c.content_hash in context.unchanged_chunk_hashes
+            )
+        ]
+        unchanged_skipped = len(embedded) - len(storable)
+        if unchanged_skipped > 0:
+            logger.info(
+                "StoreStep: skipping %d unchanged chunks", unchanged_skipped,
             )
 
         for i in range(0, len(storable), self._batch_size):

--- a/tests/core/domain/test_pipeline_steps.py
+++ b/tests/core/domain/test_pipeline_steps.py
@@ -765,6 +765,129 @@ class TestStoreStepDedup:
 
 
 # ---------------------------------------------------------------------------
+# Story #1825: StoreStep unchanged-chunk skip tests
+# ---------------------------------------------------------------------------
+
+
+class TestStoreStepUnchangedSkip:
+    async def test_skips_unchanged_content_chunks(self):
+        """Unchanged content chunks (hash in unchanged_chunk_hashes) are not stored."""
+        store = MockKnowledgeStorePort()
+        meta = DocumentMetadata(document_id="doc-1", source="s", type="knowledge", title="T", embedding_type="chunk")
+        chunks = [
+            Chunk(content="changed", metadata=meta, chunk_index=0, embedding=[0.1], content_hash="hash-new"),
+            Chunk(content="unchanged-1", metadata=meta, chunk_index=1, embedding=[0.2], content_hash="hash-old-1"),
+            Chunk(content="unchanged-2", metadata=meta, chunk_index=2, embedding=[0.3], content_hash="hash-old-2"),
+        ]
+
+        ctx = PipelineContext(
+            collection_name="coll",
+            documents=[],
+            chunks=chunks,
+            unchanged_chunk_hashes={"hash-old-1", "hash-old-2"},
+        )
+        await StoreStep(knowledge_store_port=store).execute(ctx)
+
+        assert ctx.chunks_stored == 1
+        assert len(store.collections["coll"]) == 1
+        assert store.collections["coll"][0]["document"] == "changed"
+        assert store.collections["coll"][0]["id"] == "hash-new"
+
+    async def test_stores_summary_chunks_despite_unchanged_hashes(self):
+        """Summary chunks are always stored, even when unchanged_chunk_hashes is populated."""
+        store = MockKnowledgeStorePort()
+        chunk_meta = DocumentMetadata(
+            document_id="doc-1", source="s", type="knowledge", title="T", embedding_type="chunk",
+        )
+        summary_meta = DocumentMetadata(
+            document_id="doc-1-summary", source="s", type="knowledge", title="T", embedding_type="summary",
+        )
+        chunks = [
+            Chunk(content="unchanged", metadata=chunk_meta, chunk_index=0, embedding=[0.1], content_hash="hash-old"),
+            Chunk(content="doc summary", metadata=summary_meta, chunk_index=0, embedding=[0.2]),
+        ]
+
+        ctx = PipelineContext(
+            collection_name="coll",
+            documents=[],
+            chunks=chunks,
+            unchanged_chunk_hashes={"hash-old"},
+        )
+        await StoreStep(knowledge_store_port=store).execute(ctx)
+
+        assert ctx.chunks_stored == 1
+        stored_docs = [it["document"] for it in store.collections["coll"]]
+        assert "doc summary" in stored_docs
+        assert "unchanged" not in stored_docs
+
+    async def test_stores_all_when_unchanged_hashes_empty(self):
+        """When unchanged_chunk_hashes is empty, all embedded chunks are stored (backward compat)."""
+        store = MockKnowledgeStorePort()
+        meta = DocumentMetadata(document_id="doc-1", source="s", type="knowledge", title="T", embedding_type="chunk")
+        chunks = [
+            Chunk(content="a", metadata=meta, chunk_index=0, embedding=[0.1], content_hash="hash-a"),
+            Chunk(content="b", metadata=meta, chunk_index=1, embedding=[0.2], content_hash="hash-b"),
+        ]
+
+        ctx = PipelineContext(
+            collection_name="coll",
+            documents=[],
+            chunks=chunks,
+            # unchanged_chunk_hashes defaults to empty set
+        )
+        await StoreStep(knowledge_store_port=store).execute(ctx)
+
+        assert ctx.chunks_stored == 2
+        assert len(store.collections["coll"]) == 2
+
+    async def test_unchanged_excluded_from_chunks_stored_count(self):
+        """chunks_stored only counts chunks that were actually upserted."""
+        store = MockKnowledgeStorePort()
+        meta = DocumentMetadata(document_id="doc-1", source="s", type="knowledge", title="T", embedding_type="chunk")
+        chunks = [
+            Chunk(content="new", metadata=meta, chunk_index=0, embedding=[0.1], content_hash="hash-new"),
+            Chunk(content="old-1", metadata=meta, chunk_index=1, embedding=[0.2], content_hash="hash-old-1"),
+            Chunk(content="old-2", metadata=meta, chunk_index=2, embedding=[0.3], content_hash="hash-old-2"),
+            Chunk(content="old-3", metadata=meta, chunk_index=3, embedding=[0.4], content_hash="hash-old-3"),
+        ]
+
+        ctx = PipelineContext(
+            collection_name="coll",
+            documents=[],
+            chunks=chunks,
+            unchanged_chunk_hashes={"hash-old-1", "hash-old-2", "hash-old-3"},
+        )
+        await StoreStep(knowledge_store_port=store).execute(ctx)
+
+        assert ctx.chunks_stored == 1  # Only hash-new was stored
+
+    async def test_unchanged_and_unembedded_reported_separately(self):
+        """Unembedded and unchanged are separate categories; error only reports unembedded."""
+        store = MockKnowledgeStorePort()
+        meta = DocumentMetadata(document_id="doc-1", source="s", type="knowledge", title="T", embedding_type="chunk")
+        chunks = [
+            Chunk(content="no-emb", metadata=meta, chunk_index=0),  # no embedding
+            Chunk(content="unchanged", metadata=meta, chunk_index=1, embedding=[0.2], content_hash="hash-old"),
+            Chunk(content="new", metadata=meta, chunk_index=2, embedding=[0.3], content_hash="hash-new"),
+        ]
+
+        ctx = PipelineContext(
+            collection_name="coll",
+            documents=[],
+            chunks=chunks,
+            unchanged_chunk_hashes={"hash-old"},
+        )
+        await StoreStep(knowledge_store_port=store).execute(ctx)
+
+        # Only the unembedded chunk reported as error
+        assert any("skipped 1 chunks without embeddings" in e for e in ctx.errors)
+        # Only the new chunk was stored
+        assert ctx.chunks_stored == 1
+        assert len(store.collections["coll"]) == 1
+        assert store.collections["coll"][0]["document"] == "new"
+
+
+# ---------------------------------------------------------------------------
 # T013: OrphanCleanupStep tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- **StoreStep** now filters out unchanged content chunks (those whose `content_hash` is in `context.unchanged_chunk_hashes`) before calling `ingest()`, avoiding redundant ChromaDB writes on incremental re-ingests
- Summary and BoK chunks are always stored regardless of change detection state
- Adds 5 new unit tests covering the skip-unchanged behavior, backward compatibility, and correct count reporting

Addresses alkem-io/alkemio#1825
Parent epic: alkem-io/alkemio#1820

## Artifacts
- `spec.md` -- specification (in worktree, not committed)
- `plan.md` -- architecture plan (in worktree, not committed)
- `tasks.md` -- task breakdown (in worktree, not committed)
- Clarify loop iterations: 2
- Analyze loop iterations: 1

## Test plan
- [x] All 5 new `TestStoreStepUnchangedSkip` tests pass
- [x] All 67 pipeline step tests pass (including pre-existing)
- [x] Full suite: 337 tests pass, 0 failures
- [x] Ruff lint: 0 errors
- [x] Pyright typecheck: 0 errors (41 pre-existing warnings unchanged)

Generated with [Claude Code](https://claude.com/claude-code)