### PR TITLE
fix: run cleanup pipeline on empty corpus re-ingestion

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,78 @@
+# Plan: Handle Empty Corpus Re-ingestion
+
+**Story**: alkem-io/virtual-contributor#35
+**Spec**: spec.md
+**Date**: 2026-04-08
+
+## Architecture
+
+No new modules, adapters, or ports are introduced. The change is localized to two plugin files, replacing their early-return-on-empty paths with a cleanup-only pipeline invocation.
+
+### Affected Modules
+
+| Module | Change |
+|--------|--------|
+| `plugins/ingest_space/plugin.py` | Replace empty-document early-return with cleanup-only pipeline (ChangeDetectionStep + OrphanCleanupStep) |
+| `plugins/ingest_website/plugin.py` | Same treatment for the post-crawl empty-document path |
+| `tests/plugins/test_ingest_space.py` | Add tests for empty-corpus cleanup behavior |
+| `tests/plugins/test_ingest_website.py` | Add tests for empty-corpus cleanup behavior |
+
+### Data Model Deltas
+
+None. The `PipelineContext`, `IngestResult`, `Document`, `Chunk`, and event models are unchanged.
+
+### Interface Contracts
+
+No changes to any port protocol or plugin contract. The `IngestEngine.run()` signature is unchanged -- it already accepts an empty document list.
+
+## Design
+
+### Cleanup-Only Pipeline Pattern
+
+When a fetch succeeds but returns zero documents, both plugins will construct and run a minimal pipeline consisting of only:
+
+1. `ChangeDetectionStep(knowledge_store_port=self._knowledge_store)`
+2. `OrphanCleanupStep(knowledge_store_port=self._knowledge_store)`
+
+This pipeline receives an empty `documents` list. The `ChangeDetectionStep._detect()` method will:
+- Find `current_doc_ids = {}` (empty, since no chunks exist)
+- Fetch all `existing_doc_ids` from the store
+- Compute `removed_document_ids = existing_doc_ids - current_doc_ids = existing_doc_ids` (all existing docs are "removed")
+
+The `OrphanCleanupStep.execute()` will then delete all chunks for each removed document ID.
+
+### Error Handling
+
+- Fetch failure (exception in `read_space_tree()` or `crawl()`): preserved as-is, caught by the outer `except` block, returns failure result.
+- Cleanup pipeline failure: any errors from `ChangeDetectionStep` or `OrphanCleanupStep` are captured in `IngestResult.errors`. The plugin returns success/failure based on the result.
+
+### Result Messages
+
+- IngestSpacePlugin: Returns `result="success"` after cleanup, consistent with existing behavior.
+- IngestWebsitePlugin: Returns `result=IngestionResult.SUCCESS` with empty error string (not `"No content extracted"` -- the cleanup is useful work, not an error).
+
+### Logging
+
+Both plugins log at INFO level when entering the cleanup-only path, e.g.:
+```
+"Source returned zero documents for collection %s; running cleanup pipeline"
+```
+
+## Test Strategy
+
+### Unit Tests (new)
+
+1. **test_empty_corpus_cleanup_deletes_existing_chunks** (ingest_space): Seed MockKnowledgeStorePort with pre-existing chunks. Mock `read_space_tree` to return empty list. Verify chunks are deleted after handle().
+2. **test_empty_corpus_cleanup_deletes_existing_chunks** (ingest_website): Same pattern with mocked crawl returning pages but no extractable text.
+3. **test_crawl_failure_preserves_existing_chunks** (ingest_website): Mock crawl to raise exception. Verify chunks are NOT deleted.
+
+### Existing Tests
+
+All existing tests must continue to pass unchanged. The normal (non-empty) ingestion path is not modified.
+
+## Rollout Notes
+
+- No configuration changes required.
+- No database migrations.
+- Backward compatible -- existing behavior for non-empty ingestion is preserved.
+- The change is safe to deploy incrementally since it only affects the empty-document code path that previously did nothing useful.

--- a/plugins/ingest_space/plugin.py
+++ b/plugins/ingest_space/plugin.py
@@ -72,12 +72,25 @@ class IngestSpacePlugin:
             documents = await read_space_tree(self._graphql_client, bok_id)
 
             if not documents:
+                # Fetch succeeded but returned zero documents — run cleanup
+                # so previously-stored chunks are identified as removed and deleted.
+                logger.info(
+                    "Source returned zero documents for collection %s; running cleanup pipeline",
+                    collection_name,
+                )
+                cleanup_engine = IngestEngine(steps=[
+                    ChangeDetectionStep(knowledge_store_port=self._knowledge_store),
+                    OrphanCleanupStep(knowledge_store_port=self._knowledge_store),
+                ])
+                cleanup_result = await cleanup_engine.run([], collection_name)
+
                 return IngestBodyOfKnowledgeResult(
                     body_of_knowledge_id=bok_id,
                     type=event.type,
                     purpose=event.purpose,
                     persona_id=event.persona_id,
-                    result="success",
+                    result="success" if cleanup_result.success else "failure",
+                    error=ErrorDetail(message="; ".join(cleanup_result.errors)) if cleanup_result.errors else None,
                 )
 
             # Run ingest pipeline with ingest-space specific settings

--- a/plugins/ingest_website/plugin.py
+++ b/plugins/ingest_website/plugin.py
@@ -85,9 +85,21 @@ class IngestWebsitePlugin:
                 documents.append(doc)
 
             if not documents:
+                # Crawl succeeded but produced zero documents — run cleanup
+                # so previously-stored chunks are identified as removed and deleted.
+                logger.info(
+                    "Source returned zero documents for collection %s; running cleanup pipeline",
+                    collection_name,
+                )
+                cleanup_engine = IngestEngine(steps=[
+                    ChangeDetectionStep(knowledge_store_port=self._knowledge_store),
+                    OrphanCleanupStep(knowledge_store_port=self._knowledge_store),
+                ])
+                cleanup_result = await cleanup_engine.run([], collection_name)
+
                 return IngestWebsiteResult(
-                    result=IngestionResult.SUCCESS,
-                    error="No content extracted",
+                    result=IngestionResult.SUCCESS if cleanup_result.success else IngestionResult.FAILURE,
+                    error="; ".join(cleanup_result.errors) if cleanup_result.errors else "",
                 )
 
             # Run ingest pipeline

--- a/spec.md
+++ b/spec.md
@@ -1,0 +1,50 @@
+# Specification: Handle Empty Corpus Re-ingestion
+
+**Story**: alkem-io/virtual-contributor#35
+**Epic**: alkem-io/alkemio#1820
+**Date**: 2026-04-08
+
+## User Value
+
+When a body of knowledge or website that previously had content is re-ingested and the source now legitimately returns zero documents, the system must clean up all previously-stored chunks so that stale data does not remain queryable. Without this, users querying the knowledge base get answers sourced from content that no longer exists.
+
+## Scope
+
+1. **IngestSpacePlugin** (`plugins/ingest_space/plugin.py`): Modify the empty-document early-return path to distinguish "fetch succeeded, empty result" from "fetch failed", and run a cleanup-only pipeline on successful-but-empty fetch.
+2. **IngestWebsitePlugin** (`plugins/ingest_website/plugin.py`): Same treatment for the crawl-then-extract path.
+3. **Pipeline integration**: The cleanup-only pipeline consists of `ChangeDetectionStep` + `OrphanCleanupStep` running against an empty document list, so all existing chunks are identified as belonging to removed documents and deleted.
+4. **Tests**: New unit tests covering the empty-corpus cleanup path for both plugins, verifying that previously-stored chunks are deleted.
+
+## Out of Scope
+
+- Changes to `ChangeDetectionStep` or `OrphanCleanupStep` internal logic (they already handle empty document lists correctly -- all existing doc IDs will appear in `removed_document_ids`).
+- Changes to the `IngestEngine` or `PipelineContext`.
+- Changes to the pipeline step ordering for normal (non-empty) ingestion flows.
+- Fetch failure handling changes (existing early-return-on-error behavior is preserved).
+
+## Acceptance Criteria
+
+1. When `read_space_tree()` succeeds but returns an empty list, the plugin runs `ChangeDetectionStep` + `OrphanCleanupStep` against the empty list, causing all previously-stored chunks to be deleted.
+2. When crawl + extract produces zero documents (successful fetch, no content), the website plugin runs the same cleanup pipeline.
+3. When the fetch itself fails (exception), both plugins preserve existing early-return/error behavior -- no cleanup is performed.
+4. Both plugins return a success result after cleanup-only runs.
+5. Unit tests verify that previously-stored chunks are removed after an empty-corpus re-ingestion for both plugins.
+
+## Constraints
+
+- Must not break existing non-empty ingestion flows.
+- Must not call `delete_collection()` -- the content-hash dedup approach (ADR 0006) uses per-chunk cleanup, not collection-level deletion.
+- The cleanup-only pipeline must not include `ChunkStep`, `ContentHashStep`, `EmbedStep`, `StoreStep`, or summarization steps -- only `ChangeDetectionStep` + `OrphanCleanupStep`.
+- The fix must be backward-compatible with the existing plugin contract (duck-typed `PluginContract` protocol).
+
+## Clarifications
+
+**Iteration 1** (5 ambiguities resolved, 0 remaining):
+
+| # | Ambiguity | Resolution | Rationale |
+|---|-----------|------------|-----------|
+| 1 | Should IngestWebsitePlugin distinguish "crawl returned zero pages" from "pages returned but all empty text"? | Treat both as successful-but-empty. | The current code already filters empty-text pages before the `if not documents` check. Both cases mean "no content to ingest". |
+| 2 | Should cleanup-only pipeline return a different status than normal ingestion? | Return "success". | The operation completed as intended. Logging distinguishes the two paths. |
+| 3 | Should IngestWebsitePlugin cleanup use the same collection_name derivation? | Yes, same `{netloc}-knowledge` formula. | Cleanup must target the same collection where chunks were stored. |
+| 4 | If GraphQL client is not configured in IngestSpacePlugin, should we attempt cleanup? | No. Preserve existing RuntimeError path. | Cannot distinguish "source empty" from "config broken" without a working client. |
+| 5 | Should cleanup actions be logged? | Yes, info-level log when running cleanup-only pipeline. | Observability for operators when a corpus is emptied. |

--- a/tasks.md
+++ b/tasks.md
@@ -1,0 +1,69 @@
+# Tasks: Handle Empty Corpus Re-ingestion
+
+**Story**: alkem-io/virtual-contributor#35
+**Plan**: plan.md
+**Date**: 2026-04-08
+
+## Task List
+
+### Task 1: Modify IngestSpacePlugin empty-document path
+
+**File**: `plugins/ingest_space/plugin.py`
+**Depends on**: None
+**Acceptance criteria**:
+- The `if not documents:` block at lines 74-81 is replaced with a cleanup-only pipeline invocation.
+- The cleanup pipeline consists of `ChangeDetectionStep` + `OrphanCleanupStep` with an empty document list.
+- An INFO log message is emitted when entering the cleanup path.
+- The plugin returns the appropriate success/failure result based on the cleanup pipeline outcome.
+- The fetch-failure path (RuntimeError from missing GraphQL client, or exception from `read_space_tree()`) is unchanged.
+**Test**: Task 3 - `test_empty_corpus_cleanup_deletes_existing_chunks`
+
+### Task 2: Modify IngestWebsitePlugin empty-document path
+
+**File**: `plugins/ingest_website/plugin.py`
+**Depends on**: None
+**Acceptance criteria**:
+- The `if not documents:` block at lines 87-91 is replaced with a cleanup-only pipeline invocation.
+- The cleanup pipeline consists of `ChangeDetectionStep` + `OrphanCleanupStep` with an empty document list.
+- An INFO log message is emitted when entering the cleanup path.
+- The plugin returns the appropriate success/failure result based on the cleanup pipeline outcome.
+- The crawl-failure path (exception from `crawl()`) is unchanged.
+**Test**: Task 4 - `test_empty_corpus_cleanup_deletes_existing_chunks`
+
+### Task 3: Add IngestSpacePlugin empty-corpus tests
+
+**File**: `tests/plugins/test_ingest_space.py`
+**Depends on**: Task 1
+**Acceptance criteria**:
+- New test `test_empty_corpus_cleanup_deletes_existing_chunks`: Seeds MockKnowledgeStorePort with pre-existing chunks under the expected collection name. Mocks `read_space_tree` to return `[]`. Asserts that after `handle()`, the pre-seeded chunks are deleted from the mock store.
+- Existing tests pass unchanged.
+
+### Task 4: Add IngestWebsitePlugin empty-corpus tests
+
+**File**: `tests/plugins/test_ingest_website.py`
+**Depends on**: Task 2
+**Acceptance criteria**:
+- New test `test_empty_corpus_cleanup_deletes_existing_chunks`: Seeds MockKnowledgeStorePort with pre-existing chunks under the expected collection name (`example.com-knowledge`). Mocks `crawl` to return `[]`. Asserts that after `handle()`, the pre-seeded chunks are deleted.
+- New test `test_crawl_failure_preserves_existing_chunks`: Seeds mock store with chunks. Mocks `crawl` to raise an exception. Asserts chunks are NOT deleted and result is failure.
+- Existing tests pass unchanged.
+
+### Task 5: Run full test suite and verify green
+
+**Depends on**: Tasks 1-4
+**Acceptance criteria**:
+- `poetry run pytest` passes with zero failures.
+- `poetry run ruff check core/ plugins/ tests/` passes.
+- `poetry run pyright core/ plugins/` passes (or matches pre-existing baseline).
+
+## Dependency Order
+
+```
+Task 1 ──┐
+          ├── Task 3 ──┐
+Task 2 ──┤             ├── Task 5
+          └── Task 4 ──┘
+```
+
+Tasks 1 and 2 are independent and can be executed in parallel.
+Tasks 3 and 4 are independent and can be executed in parallel (after their respective dependency).
+Task 5 is the final gate.

--- a/tests/plugins/test_ingest_space.py
+++ b/tests/plugins/test_ingest_space.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
 from core.events.ingest_space import IngestBodyOfKnowledgeResult
@@ -102,3 +104,80 @@ class TestIngestSpacePlugin:
     async def test_startup_shutdown(self, plugin):
         await plugin.startup()
         await plugin.shutdown()
+
+    async def test_empty_corpus_cleanup_deletes_existing_chunks(self):
+        """When read_space_tree returns [], previously-stored chunks are deleted."""
+        store = MockKnowledgeStorePort()
+        collection_name = "bok-123-knowledge"
+
+        # Seed the store with pre-existing chunks
+        await store.ingest(
+            collection=collection_name,
+            documents=["old content 1", "old content 2"],
+            metadatas=[
+                {"documentId": "doc-1", "source": "s", "type": "knowledge",
+                 "title": "t", "embeddingType": "chunk", "chunkIndex": 0},
+                {"documentId": "doc-1", "source": "s", "type": "knowledge",
+                 "title": "t", "embeddingType": "chunk", "chunkIndex": 1},
+            ],
+            ids=["hash-aaa", "hash-bbb"],
+            embeddings=[[0.1] * 384, [0.2] * 384],
+        )
+        assert len(store.collections[collection_name]) == 2
+
+        plugin = IngestSpacePlugin(
+            llm=MockLLMPort(),
+            embeddings=MockEmbeddingsPort(),
+            knowledge_store=store,
+            graphql_client=object(),  # non-None so the client check passes
+        )
+
+        event = make_ingest_body_of_knowledge()
+        with patch(
+            "plugins.ingest_space.space_reader.read_space_tree",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            result = await plugin.handle(event)
+
+        assert isinstance(result, IngestBodyOfKnowledgeResult)
+        assert result.result == "success"
+        # All previously-stored chunks should be deleted
+        assert len(store.collections.get(collection_name, [])) == 0
+
+    async def test_fetch_failure_preserves_existing_chunks(self):
+        """When read_space_tree raises, existing chunks are NOT deleted."""
+        store = MockKnowledgeStorePort()
+        collection_name = "bok-123-knowledge"
+
+        # Seed the store with pre-existing chunks
+        await store.ingest(
+            collection=collection_name,
+            documents=["old content"],
+            metadatas=[
+                {"documentId": "doc-1", "source": "s", "type": "knowledge",
+                 "title": "t", "embeddingType": "chunk", "chunkIndex": 0},
+            ],
+            ids=["hash-aaa"],
+            embeddings=[[0.1] * 384],
+        )
+        assert len(store.collections[collection_name]) == 1
+
+        plugin = IngestSpacePlugin(
+            llm=MockLLMPort(),
+            embeddings=MockEmbeddingsPort(),
+            knowledge_store=store,
+            graphql_client=object(),
+        )
+
+        event = make_ingest_body_of_knowledge()
+        with patch(
+            "plugins.ingest_space.space_reader.read_space_tree",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("GraphQL timeout"),
+        ):
+            result = await plugin.handle(event)
+
+        assert result.result == "failure"
+        # Chunks must be preserved on fetch failure
+        assert len(store.collections[collection_name]) == 1

--- a/tests/plugins/test_ingest_website.py
+++ b/tests/plugins/test_ingest_website.py
@@ -172,7 +172,7 @@ class TestIngestWebsitePlugin:
         assert plugin._knowledge_store.deleted == []
         assert "example.com-knowledge" in plugin._knowledge_store.collections
 
-    async def test_unsupported_content_skip(self, plugin):
+    async def test_empty_crawl_still_succeeds(self, plugin):
         """Empty crawl results should still succeed."""
         event = make_ingest_website()
         with patch("plugins.ingest_website.plugin.crawl", return_value=[]):
@@ -182,3 +182,70 @@ class TestIngestWebsitePlugin:
     async def test_startup_shutdown(self, plugin):
         await plugin.startup()
         await plugin.shutdown()
+
+    async def test_empty_corpus_cleanup_deletes_existing_chunks(self):
+        """When crawl returns [] and no documents are produced, previously-stored chunks are deleted."""
+        store = MockKnowledgeStorePort()
+        collection_name = "example.com-knowledge"
+
+        # Seed the store with pre-existing chunks
+        await store.ingest(
+            collection=collection_name,
+            documents=["old web content 1", "old web content 2"],
+            metadatas=[
+                {"documentId": "https://example.com/page1", "source": "https://example.com/page1",
+                 "type": "knowledge", "title": "Page 1", "embeddingType": "chunk", "chunkIndex": 0},
+                {"documentId": "https://example.com/page2", "source": "https://example.com/page2",
+                 "type": "knowledge", "title": "Page 2", "embeddingType": "chunk", "chunkIndex": 0},
+            ],
+            ids=["hash-aaa", "hash-bbb"],
+            embeddings=[[0.1] * 384, [0.2] * 384],
+        )
+        assert len(store.collections[collection_name]) == 2
+
+        plugin = IngestWebsitePlugin(
+            llm=MockLLMPort(),
+            embeddings=MockEmbeddingsPort(),
+            knowledge_store=store,
+        )
+
+        event = make_ingest_website()
+        with patch("plugins.ingest_website.plugin.crawl", return_value=[]):
+            result = await plugin.handle(event)
+
+        assert isinstance(result, IngestWebsiteResult)
+        assert result.result == "success"
+        # All previously-stored chunks should be deleted
+        assert len(store.collections.get(collection_name, [])) == 0
+
+    async def test_crawl_failure_preserves_existing_chunks(self):
+        """When crawl() raises an exception, existing chunks are NOT deleted."""
+        store = MockKnowledgeStorePort()
+        collection_name = "example.com-knowledge"
+
+        # Seed the store with pre-existing chunks
+        await store.ingest(
+            collection=collection_name,
+            documents=["old web content"],
+            metadatas=[
+                {"documentId": "https://example.com/page1", "source": "https://example.com/page1",
+                 "type": "knowledge", "title": "Page 1", "embeddingType": "chunk", "chunkIndex": 0},
+            ],
+            ids=["hash-aaa"],
+            embeddings=[[0.1] * 384],
+        )
+        assert len(store.collections[collection_name]) == 1
+
+        plugin = IngestWebsitePlugin(
+            llm=MockLLMPort(),
+            embeddings=MockEmbeddingsPort(),
+            knowledge_store=store,
+        )
+
+        event = make_ingest_website()
+        with patch("plugins.ingest_website.plugin.crawl", side_effect=RuntimeError("Connection failed")):
+            result = await plugin.handle(event)
+
+        assert result.result == "failure"
+        # Chunks must be preserved on crawl failure
+        assert len(store.collections[collection_name]) == 1


### PR DESCRIPTION
## Summary

- When a fetch succeeds but returns zero documents, both `IngestSpacePlugin` and `IngestWebsitePlugin` now run `ChangeDetectionStep` + `OrphanCleanupStep` so that all previously-stored chunks are identified as removed and deleted
- On fetch failure (exception), existing early-return behavior is preserved -- no cleanup is performed, existing chunks remain intact
- Added tests verifying both cleanup-on-empty and preservation-on-failure for both plugins

Closes alkem-io/virtual-contributor#35
Parent epic: alkem-io/alkemio#1820

## Artifacts

- `spec.md` -- specification with clarifications
- `plan.md` -- architecture and test strategy
- `tasks.md` -- task breakdown with dependency order

## SDD Metrics

- Clarify loop iterations: 2 (1 with findings, 1 clean pass)
- Analyze loop iterations: 2 (1 with findings, 1 clean pass)

## Test plan

- [x] `test_empty_corpus_cleanup_deletes_existing_chunks` (ingest_space) -- seeds store, mocks empty fetch, verifies deletion
- [x] `test_fetch_failure_preserves_existing_chunks` (ingest_space) -- seeds store, mocks fetch exception, verifies preservation
- [x] `test_empty_corpus_cleanup_deletes_existing_chunks` (ingest_website) -- seeds store, mocks empty crawl, verifies deletion
- [x] `test_crawl_failure_preserves_existing_chunks` (ingest_website) -- seeds store, mocks crawl exception, verifies preservation
- [x] Full test suite: 336 passed, 0 failed
- [x] Lint: ruff check passed
- [x] Type check: pyright 0 errors (41 pre-existing warnings)

Generated with [Claude Code](https://claude.com/claude-code)