### PR TITLE
feat: incremental embedding during summarization

### DIFF
--- a/core/domain/pipeline/steps.py
+++ b/core/domain/pipeline/steps.py
@@ -239,7 +239,13 @@ class ChangeDetectionStep:
 # ---------------------------------------------------------------------------
 
 class DocumentSummaryStep:
-    """Generate per-document summaries for docs with >= chunk_threshold chunks."""
+    """Generate per-document summaries for docs with >= chunk_threshold chunks.
+
+    When an ``embeddings_port`` is provided, each document's content chunks and
+    summary chunk are embedded immediately after the summary is produced
+    (incremental embedding).  This overlaps LLM-bound summarization I/O with
+    GPU-bound embedding I/O, reducing total pipeline wall-clock time.
+    """
 
     def __init__(
         self,
@@ -247,6 +253,8 @@ class DocumentSummaryStep:
         summary_length: int = 10000,
         concurrency: int = 8,
         chunk_threshold: int = 4,
+        embeddings_port: EmbeddingsPort | None = None,
+        embed_batch_size: int = 50,
     ) -> None:
         if chunk_threshold < 1:
             raise ValueError("chunk_threshold must be >= 1")
@@ -254,6 +262,8 @@ class DocumentSummaryStep:
         self._summary_length = summary_length
         self._concurrency = concurrency
         self._chunk_threshold = chunk_threshold
+        self._embeddings = embeddings_port
+        self._embed_batch_size = embed_batch_size
         self._model_name = getattr(
             getattr(llm_port, "_llm", None), "model", "unknown"
         )
@@ -261,6 +271,36 @@ class DocumentSummaryStep:
     @property
     def name(self) -> str:
         return "document_summary"
+
+    async def _embed_chunks(
+        self,
+        chunks: list[Chunk],
+        context: PipelineContext,
+    ) -> None:
+        """Embed a list of chunks incrementally using the embeddings port.
+
+        Chunks that already have an embedding (e.g. from change detection) are
+        skipped.  Errors are recorded in ``context.errors`` without aborting.
+        """
+        if self._embeddings is None:
+            return
+
+        to_embed = [c for c in chunks if c.embedding is None]
+        if not to_embed:
+            return
+
+        for i in range(0, len(to_embed), self._embed_batch_size):
+            batch = to_embed[i : i + self._embed_batch_size]
+            texts = [c.content for c in batch]
+            try:
+                embeddings = await self._embeddings.embed(texts)
+                for chunk, embedding in zip(batch, embeddings):
+                    chunk.embedding = embedding
+            except Exception as exc:
+                context.errors.append(
+                    f"DocumentSummaryStep(embed): embedding failed for batch "
+                    f"{i // self._embed_batch_size}: {exc}"
+                )
 
     async def execute(self, context: PipelineContext) -> None:
         # Group chunks by document_id
@@ -302,10 +342,17 @@ class DocumentSummaryStep:
                     title=source_meta.title,
                     embedding_type="summary",
                 )
-                context.chunks.append(
-                    Chunk(content=summary, metadata=summary_meta, chunk_index=0)
+                summary_chunk = Chunk(
+                    content=summary, metadata=summary_meta, chunk_index=0,
                 )
+                context.chunks.append(summary_chunk)
                 logger.info("Summarized document %s", doc_id)
+
+                # Incremental embedding: embed this document's chunks + summary
+                # immediately so they don't idle while remaining docs summarize.
+                await self._embed_chunks(
+                    doc_chunks + [summary_chunk], context,
+                )
             except Exception as exc:
                 logger.warning("Summarization failed for %s: %s", doc_id, exc)
                 context.errors.append(

--- a/plugins/ingest_space/plugin.py
+++ b/plugins/ingest_space/plugin.py
@@ -89,6 +89,7 @@ class IngestSpacePlugin:
                 DocumentSummaryStep(
                     llm_port=summary_llm,
                     chunk_threshold=self._chunk_threshold,
+                    embeddings_port=self._embeddings,
                 ),
                 BodyOfKnowledgeSummaryStep(llm_port=self._bok_llm or summary_llm),
                 EmbedStep(embeddings_port=self._embeddings),

--- a/plugins/ingest_website/plugin.py
+++ b/plugins/ingest_website/plugin.py
@@ -104,6 +104,7 @@ class IngestWebsitePlugin:
                     llm_port=summary_llm,
                     concurrency=config.summarize_concurrency,
                     chunk_threshold=self._chunk_threshold,
+                    embeddings_port=self._embeddings,
                 ))
                 bok_llm = self._bok_llm or summary_llm
                 steps.append(BodyOfKnowledgeSummaryStep(llm_port=bok_llm))

--- a/specs/011-incremental-embedding/clarifications.md
+++ b/specs/011-incremental-embedding/clarifications.md
@@ -1,0 +1,17 @@
+# Clarifications -- Incremental Embedding
+
+## Iteration 1
+
+| # | Ambiguity | Chosen Resolution | Rationale |
+|---|-----------|-------------------|-----------|
+| C-1 | Should the summary chunk produced per document also be embedded immediately, or only the content chunks? | Embed both content chunks AND the summary chunk immediately after each document's summary completes. | The summary chunk is ready at the same time; deferring it to EmbedStep adds no benefit and complicates the "already embedded" bookkeeping. |
+| C-2 | Should `DocumentSummaryStep` use the same `batch_size` parameter as `EmbedStep` for embedding? | Yes, accept an optional `embed_batch_size` parameter (default 50) matching EmbedStep's default. | Consistency with EmbedStep behavior. A single document typically has 5-50 chunks, so 50 is a safe single-batch default. |
+| C-3 | What happens when `embeddings_port` is None (backward compat)? Should the step raise, warn, or silently skip embedding? | Silently skip incremental embedding; behave exactly as current code. No warning needed. | This is the backward-compatibility path. The trailing EmbedStep handles all embedding in that case. |
+| C-4 | How should embedding errors during DocumentSummaryStep be reported? Via `context.errors` like other steps, or silently? | Append to `context.errors` with prefix `DocumentSummaryStep(embed)` so operators can distinguish summarization errors from embedding errors. | Consistent with existing error reporting pattern. Does not abort the summarization loop. |
+| C-5 | The issue mentions Option A "per-document embed after summary." Should we also embed the BoK summary chunk inside BodyOfKnowledgeSummaryStep? | No. The BoK summary is a single chunk produced at the end. The trailing EmbedStep handles it. Adding embed logic to BodyOfKnowledgeSummaryStep would violate single-responsibility with minimal benefit. | BoK summary is one chunk; the overhead of a separate embed call vs batch in EmbedStep is negligible. Keeps the change focused. |
+| C-6 | Should we embed chunks for documents that are unchanged (change_detection preloaded their embeddings)? | No. The existing logic in DocumentSummaryStep already skips unchanged documents. Incremental embedding only runs for documents that are actually summarized. | Unchanged chunks already have embeddings from ChangeDetectionStep; re-embedding would waste resources. |
+| C-7 | The `DocumentSummaryStep` currently processes documents sequentially in a for loop. Should incremental embedding happen inside that same loop iteration? | Yes. After `_refine_summarize` completes for a document, embed that document's chunks plus its summary chunk in the same iteration, before moving to the next document. | This is the simplest implementation of Option A. It overlaps the embedding I/O of doc N with the LLM start-up of doc N+1 at the async level. |
+
+## Iteration 2
+
+No new ambiguities found. All questions from Iteration 1 are resolved. Clean pass.

--- a/specs/011-incremental-embedding/plan.md
+++ b/specs/011-incremental-embedding/plan.md
@@ -1,0 +1,100 @@
+# Plan: Incremental Embedding
+
+**Story:** alkem-io/alkemio#1826
+
+---
+
+## Architecture
+
+The change follows **Option A** from the issue: per-document embedding after summary. No new classes, no new pipeline steps, no new ports. The modification is entirely within `DocumentSummaryStep` which gains an optional `EmbeddingsPort` dependency.
+
+### Current Flow
+
+```
+ChunkStep -> ContentHashStep -> ChangeDetectionStep -> DocumentSummaryStep -> BodyOfKnowledgeSummaryStep -> EmbedStep -> StoreStep -> OrphanCleanupStep
+```
+
+Each step runs to completion before the next starts. DocumentSummaryStep summarizes all documents sequentially, then EmbedStep embeds all chunks in batch.
+
+### New Flow
+
+```
+ChunkStep -> ContentHashStep -> ChangeDetectionStep -> DocumentSummaryStep(*) -> BodyOfKnowledgeSummaryStep -> EmbedStep(**) -> StoreStep -> OrphanCleanupStep
+```
+
+(*) DocumentSummaryStep now: for each document, (1) summarize, (2) embed that document's content chunks + summary chunk immediately.
+
+(**) EmbedStep unchanged but naturally skips all already-embedded chunks (existing behavior at line 423).
+
+---
+
+## Affected Modules
+
+| Module | Change Type | Description |
+|--------|-------------|-------------|
+| `core/domain/pipeline/steps.py` | Modify | `DocumentSummaryStep.__init__` gains `embeddings_port: EmbeddingsPort | None = None` and `embed_batch_size: int = 50`. `execute()` embeds each document's chunks after summarization. |
+| `plugins/ingest_space/plugin.py` | Modify | Pass `embeddings_port=self._embeddings` to `DocumentSummaryStep`. |
+| `plugins/ingest_website/plugin.py` | Modify | Pass `embeddings_port=self._embeddings` to `DocumentSummaryStep`. |
+| `tests/core/domain/test_pipeline_steps.py` | Modify | Add tests for incremental embedding in `TestDocumentSummaryStep`. |
+
+---
+
+## Data Model Deltas
+
+None. `Chunk.embedding` already supports `list[float] | None`. No new fields, no schema changes.
+
+---
+
+## Interface Contracts
+
+### DocumentSummaryStep.__init__ (updated)
+
+```python
+def __init__(
+    self,
+    llm_port: LLMPort,
+    summary_length: int = 10000,
+    concurrency: int = 8,
+    chunk_threshold: int = 4,
+    embeddings_port: EmbeddingsPort | None = None,   # NEW
+    embed_batch_size: int = 50,                        # NEW
+) -> None:
+```
+
+- `embeddings_port=None`: backward compatible. When None, no incremental embedding occurs (existing behavior).
+- `embed_batch_size=50`: matches EmbedStep default.
+
+### _embed_document_chunks (new private helper)
+
+```python
+async def _embed_document_chunks(
+    self,
+    chunks: list[Chunk],
+    context: PipelineContext,
+) -> None:
+```
+
+Embeds a list of chunks using `self._embeddings`, batched by `self._embed_batch_size`. Errors are appended to `context.errors` without aborting.
+
+---
+
+## Test Strategy
+
+| Test ID | Description | Type |
+|---------|-------------|------|
+| T-IE-1 | DocumentSummaryStep with embeddings_port embeds content chunks after each document summary | Unit |
+| T-IE-2 | DocumentSummaryStep with embeddings_port embeds the summary chunk itself | Unit |
+| T-IE-3 | DocumentSummaryStep without embeddings_port (None) does not embed -- backward compat | Unit |
+| T-IE-4 | EmbedStep skips all chunks already embedded by DocumentSummaryStep | Unit (existing test covers this) |
+| T-IE-5 | Embedding failure during DocumentSummaryStep does not prevent next document summarization | Unit |
+| T-IE-6 | Below-threshold documents are not touched by DocumentSummaryStep incremental embedding | Unit |
+| T-IE-7 | Full pipeline integration: chunks embedded exactly once across DocumentSummaryStep + EmbedStep | Integration |
+
+---
+
+## Rollout Notes
+
+- Feature is automatically active when plugins pass `embeddings_port` to `DocumentSummaryStep`.
+- No configuration flag needed; the feature activates by construction in the plugin wiring.
+- Backward compatible: any external caller that does not pass `embeddings_port` gets existing behavior.
+- No migration, no database changes, no new environment variables.

--- a/specs/011-incremental-embedding/spec.md
+++ b/specs/011-incremental-embedding/spec.md
@@ -1,0 +1,55 @@
+# Spec: Incremental Embedding -- Embed Documents as They Finish Summarization
+
+**Story:** alkem-io/alkemio#1826
+**Epic:** alkem-io/alkemio#1820
+
+---
+
+## User Value
+
+Pipeline operators and end-users experience 20+ minutes of unnecessary idle time during ingestion because all documents must finish summarization before any embedding begins. By interleaving embedding with summarization -- embedding each document's chunks immediately after its summary completes -- we overlap LLM-bound (summarization) and GPU-bound (embedding) I/O, reducing total wall-clock ingest time significantly.
+
+---
+
+## Scope
+
+### In Scope
+
+1. Modify `DocumentSummaryStep` to accept an `EmbeddingsPort` and embed each document's chunks immediately after its summary is produced.
+2. Update `EmbedStep` to skip chunks that were already embedded during the summarization phase (incremental embedding).
+3. Update both ingest plugins (`ingest_space`, `ingest_website`) to pass `EmbeddingsPort` to `DocumentSummaryStep`.
+4. Preserve existing change-detection optimization: chunks with pre-loaded embeddings from `ChangeDetectionStep` are still skipped.
+5. Ensure `BodyOfKnowledgeSummaryStep` summary chunks (produced after all document summaries) are still embedded by the trailing `EmbedStep`.
+6. Unit tests covering incremental embedding behavior, skip logic, and error isolation.
+
+### Out of Scope
+
+- Concurrent (parallel) document summarization (that is story #1823).
+- Streaming pipeline engine redesign (Option C from the issue).
+- Background async embedding worker with a queue (Option B from the issue).
+- Changes to `StoreStep`, `OrphanCleanupStep`, or `ChangeDetectionStep` internals.
+- Performance benchmarking or metrics dashboards.
+
+---
+
+## Acceptance Criteria
+
+| # | Criterion | Verification |
+|---|-----------|--------------|
+| AC-1 | After each document summary completes, that document's content chunks are embedded immediately (before summarization of the next document begins). | Unit test: mock EmbeddingsPort records embed calls interleaved with LLM invoke calls. |
+| AC-2 | The document's summary chunk itself is also embedded immediately after summarization. | Unit test: summary chunk has a non-None embedding after DocumentSummaryStep completes. |
+| AC-3 | `EmbedStep` skips all chunks that already have embeddings (from incremental embedding or change detection). | Unit test: EmbedStep with pre-embedded chunks produces zero embed calls. |
+| AC-4 | Chunks from documents below the chunk_threshold (not summarized) are still embedded by the trailing `EmbedStep`. | Unit test: below-threshold document chunks get embeddings from EmbedStep. |
+| AC-5 | Embedding failure for one document's chunks during summarization does not prevent summarization of remaining documents. | Unit test: FailingEmbeddings on first doc, second doc still summarized and embedded. |
+| AC-6 | Both ingest plugins pass `EmbeddingsPort` to `DocumentSummaryStep`. | Code inspection + integration-level pipeline tests. |
+| AC-7 | Full existing test suite passes without modification (backward compatible). | CI gate. |
+
+---
+
+## Constraints
+
+- Python 3.12, async/await throughout.
+- No new dependencies; `EmbeddingsPort` is an existing port.
+- `DocumentSummaryStep.__init__` signature change must be backward-compatible: `embeddings_port` defaults to `None` so existing callers without it still work (they just skip incremental embedding).
+- The pipeline step protocol (`PipelineStep`) is unchanged.
+- All embedding uses `chunk.content` as the text to embed (consistent with current `EmbedStep` behavior).

--- a/specs/011-incremental-embedding/tasks.md
+++ b/specs/011-incremental-embedding/tasks.md
@@ -1,0 +1,78 @@
+# Tasks: Incremental Embedding
+
+**Story:** alkem-io/alkemio#1826
+
+---
+
+## Task List
+
+### T1: Add incremental embedding to DocumentSummaryStep
+
+**File:** `core/domain/pipeline/steps.py`
+**Depends on:** None
+**Acceptance criteria:**
+- `DocumentSummaryStep.__init__` accepts `embeddings_port: EmbeddingsPort | None = None` and `embed_batch_size: int = 50`.
+- A new private method `_embed_chunks` embeds a list of chunks in batches, appending errors to context.
+- In `execute()`, after each document's summary is produced, all of that document's content chunks (that lack embeddings) plus the new summary chunk are embedded immediately.
+- When `embeddings_port is None`, no embedding occurs (backward compatibility).
+- Errors during embedding are appended to `context.errors` with `DocumentSummaryStep(embed):` prefix and do not abort the loop.
+
+**Tests proving done:** T-IE-1, T-IE-2, T-IE-3, T-IE-5, T-IE-6
+
+---
+
+### T2: Update ingest_space plugin to pass embeddings_port
+
+**File:** `plugins/ingest_space/plugin.py`
+**Depends on:** T1
+**Acceptance criteria:**
+- `DocumentSummaryStep` constructor call includes `embeddings_port=self._embeddings`.
+
+**Tests proving done:** Code inspection, T-IE-7 (integration)
+
+---
+
+### T3: Update ingest_website plugin to pass embeddings_port
+
+**File:** `plugins/ingest_website/plugin.py`
+**Depends on:** T1
+**Acceptance criteria:**
+- `DocumentSummaryStep` constructor call includes `embeddings_port=self._embeddings`.
+
+**Tests proving done:** Code inspection, T-IE-7 (integration)
+
+---
+
+### T4: Write unit tests for incremental embedding
+
+**File:** `tests/core/domain/test_pipeline_steps.py`
+**Depends on:** T1
+**Acceptance criteria:**
+- T-IE-1: With embeddings_port, content chunks have embeddings after DocumentSummaryStep.
+- T-IE-2: Summary chunk has embedding after DocumentSummaryStep.
+- T-IE-3: Without embeddings_port (None), no embeddings set -- backward compat.
+- T-IE-5: Embedding failure on one document does not block next document.
+- T-IE-6: Below-threshold documents' chunks have no embeddings after DocumentSummaryStep.
+
+**Tests proving done:** All listed tests pass.
+
+---
+
+### T5: Write integration test for full pipeline with incremental embedding
+
+**File:** `tests/core/domain/test_pipeline_steps.py`
+**Depends on:** T1, T4
+**Acceptance criteria:**
+- T-IE-7: Full pipeline (Chunk -> ContentHash -> ChangeDetection -> DocumentSummary(with embed) -> BoKSummary -> Embed -> Store) produces correct results. EmbedStep makes zero calls for already-embedded chunks. Store receives all chunks with embeddings.
+
+**Tests proving done:** T-IE-7 passes.
+
+---
+
+### T6: Verify exit gates
+
+**Depends on:** T1, T2, T3, T4, T5
+**Acceptance criteria:**
+- `poetry run pytest` -- all tests pass.
+- `poetry run ruff check core/ plugins/ tests/` -- clean.
+- `poetry run pyright core/ plugins/` -- clean.

--- a/tests/core/domain/test_pipeline_steps.py
+++ b/tests/core/domain/test_pipeline_steps.py
@@ -1117,3 +1117,192 @@ class TestPipelineIntegration:
         remaining_doc_ids = {it["metadata"].get("documentId") for it in remaining}
         assert "doc-b" not in remaining_doc_ids
         assert "doc-a" in remaining_doc_ids
+
+
+# ---------------------------------------------------------------------------
+# Incremental embedding tests (story #1826)
+# ---------------------------------------------------------------------------
+
+
+class TestDocumentSummaryStepIncrementalEmbedding:
+    """Tests for incremental embedding inside DocumentSummaryStep."""
+
+    async def test_content_chunks_embedded_after_summary(self):
+        """T-IE-1: Content chunks have embeddings after DocumentSummaryStep with embeddings_port."""
+        llm = MockLLMPort(response="Generated summary")
+        embeddings = MockEmbeddingsPort()
+        ctx = _make_context()
+        await ChunkStep(chunk_size=100, chunk_overlap=10).execute(ctx)
+        assert len(ctx.chunks) > 3
+
+        await DocumentSummaryStep(
+            llm_port=llm, embeddings_port=embeddings,
+        ).execute(ctx)
+
+        content_chunks = [c for c in ctx.chunks if c.metadata.embedding_type == "chunk"]
+        assert all(c.embedding is not None for c in content_chunks)
+
+    async def test_summary_chunk_embedded_after_summary(self):
+        """T-IE-2: Summary chunk has an embedding after DocumentSummaryStep."""
+        llm = MockLLMPort(response="Generated summary")
+        embeddings = MockEmbeddingsPort()
+        ctx = _make_context()
+        await ChunkStep(chunk_size=100, chunk_overlap=10).execute(ctx)
+
+        await DocumentSummaryStep(
+            llm_port=llm, embeddings_port=embeddings,
+        ).execute(ctx)
+
+        summary_chunks = [c for c in ctx.chunks if c.metadata.embedding_type == "summary"]
+        assert len(summary_chunks) == 1
+        assert summary_chunks[0].embedding is not None
+
+    async def test_no_embedding_without_embeddings_port(self):
+        """T-IE-3: Without embeddings_port (None), no embeddings are set -- backward compat."""
+        llm = MockLLMPort(response="Generated summary")
+        ctx = _make_context()
+        await ChunkStep(chunk_size=100, chunk_overlap=10).execute(ctx)
+
+        await DocumentSummaryStep(llm_port=llm).execute(ctx)
+
+        content_chunks = [c for c in ctx.chunks if c.metadata.embedding_type == "chunk"]
+        assert all(c.embedding is None for c in content_chunks)
+        summary_chunks = [c for c in ctx.chunks if c.metadata.embedding_type == "summary"]
+        assert all(c.embedding is None for c in summary_chunks)
+
+    async def test_embedding_failure_does_not_block_next_document(self):
+        """T-IE-5: Embedding failure on one doc does not prevent next doc from being summarized."""
+        call_count = 0
+
+        class FailOnceEmbeddings:
+            def __init__(self):
+                self.calls: list[list[str]] = []
+
+            async def embed(self, texts: list[str]) -> list[list[float]]:
+                nonlocal call_count
+                call_count += 1
+                self.calls.append(texts)
+                if call_count == 1:
+                    raise RuntimeError("Embedding service down")
+                return [[0.1] * 384 for _ in texts]
+
+        llm = MockLLMPort(response="Summary text")
+        embeddings = FailOnceEmbeddings()
+
+        doc_a = _make_doc(content="Content A. " * 100, doc_id="doc-a")
+        doc_b = _make_doc(content="Content B. " * 100, doc_id="doc-b")
+        ctx = _make_context([doc_a, doc_b])
+        await ChunkStep(chunk_size=100, chunk_overlap=10).execute(ctx)
+
+        await DocumentSummaryStep(
+            llm_port=llm, embeddings_port=embeddings,
+        ).execute(ctx)
+
+        # Both documents should have summaries despite embedding failure on first
+        assert "doc-a" in ctx.document_summaries
+        assert "doc-b" in ctx.document_summaries
+        # Error should be recorded
+        assert any("DocumentSummaryStep(embed)" in e for e in ctx.errors)
+
+    async def test_below_threshold_chunks_not_embedded(self):
+        """T-IE-6: Below-threshold documents' chunks have no embeddings from DocumentSummaryStep."""
+        llm = MockLLMPort(response="Summary")
+        embeddings = MockEmbeddingsPort()
+
+        # Create a short document that will produce few chunks (below threshold)
+        short_doc = _make_doc(content="Short text.", doc_id="short-doc")
+        ctx = _make_context([short_doc])
+        await ChunkStep(chunk_size=10000).execute(ctx)
+
+        # Should be below the default chunk_threshold of 4
+        assert len(ctx.chunks) < 4
+
+        await DocumentSummaryStep(
+            llm_port=llm, embeddings_port=embeddings,
+        ).execute(ctx)
+
+        # No embeddings should have been set
+        assert all(c.embedding is None for c in ctx.chunks)
+        # No embed calls made
+        assert len(embeddings.calls) == 0
+
+    async def test_skips_chunks_with_preloaded_embeddings(self):
+        """Chunks with pre-loaded embeddings (from change detection) are skipped during incremental embedding."""
+        llm = MockLLMPort(response="Summary")
+        embeddings = MockEmbeddingsPort()
+
+        ctx = _make_context()
+        await ChunkStep(chunk_size=100, chunk_overlap=10).execute(ctx)
+        assert len(ctx.chunks) > 3
+
+        # Pre-load embeddings on all existing content chunks (simulating change detection)
+        for chunk in ctx.chunks:
+            chunk.embedding = [9.9] * 384
+
+        await DocumentSummaryStep(
+            llm_port=llm, embeddings_port=embeddings,
+        ).execute(ctx)
+
+        # Content chunks should keep their original embeddings
+        content_chunks = [c for c in ctx.chunks if c.metadata.embedding_type == "chunk"]
+        assert all(c.embedding == [9.9] * 384 for c in content_chunks)
+
+        # But summary chunk should have been embedded (it's new)
+        summary_chunks = [c for c in ctx.chunks if c.metadata.embedding_type == "summary"]
+        assert len(summary_chunks) == 1
+        assert summary_chunks[0].embedding is not None
+        # Only summary was sent for embedding
+        assert len(embeddings.calls) == 1
+        assert len(embeddings.calls[0]) == 1  # one text (the summary)
+
+    async def test_embed_step_skips_already_embedded_chunks(self):
+        """T-IE-4/T-IE-7: EmbedStep makes zero calls when all chunks are already embedded."""
+        llm = MockLLMPort(response="Summary")
+        doc_summary_embeddings = MockEmbeddingsPort()
+        embed_step_embeddings = MockEmbeddingsPort()
+
+        ctx = _make_context()
+        await ChunkStep(chunk_size=100, chunk_overlap=10).execute(ctx)
+
+        # Incremental embedding during summarization
+        await DocumentSummaryStep(
+            llm_port=llm, embeddings_port=doc_summary_embeddings,
+        ).execute(ctx)
+
+        # All chunks should already have embeddings
+        assert all(c.embedding is not None for c in ctx.chunks)
+
+        # Now run EmbedStep -- it should skip everything
+        await EmbedStep(embeddings_port=embed_step_embeddings).execute(ctx)
+
+        assert len(embed_step_embeddings.calls) == 0
+
+    async def test_full_pipeline_integration_with_incremental_embedding(self):
+        """T-IE-7: Full pipeline produces correct results with incremental embedding."""
+        llm = MockLLMPort(response="Summary")
+        embeddings = MockEmbeddingsPort()
+        store = MockKnowledgeStorePort()
+
+        engine = IngestEngine(steps=[
+            ChunkStep(chunk_size=100, chunk_overlap=10),
+            ContentHashStep(),
+            ChangeDetectionStep(knowledge_store_port=store),
+            DocumentSummaryStep(
+                llm_port=llm,
+                embeddings_port=embeddings,
+            ),
+            BodyOfKnowledgeSummaryStep(llm_port=llm),
+            EmbedStep(embeddings_port=embeddings),
+            StoreStep(knowledge_store_port=store),
+            OrphanCleanupStep(knowledge_store_port=store),
+        ])
+
+        doc = _make_doc(content="Test content sentence. " * 100)
+        result = await engine.run([doc], "incr-embed-test")
+
+        assert result.success
+        assert result.chunks_stored > 0
+        # All stored chunks have embeddings
+        stored = store.collections.get("incr-embed-test", [])
+        assert len(stored) > 0
+        assert all(item.get("embedding") is not None for item in stored)


### PR DESCRIPTION
## Summary

- **DocumentSummaryStep** now accepts an optional `EmbeddingsPort` and embeds each document's content chunks plus its summary chunk immediately after summarization completes, overlapping LLM-bound (summarization) and GPU-bound (embedding) I/O
- **EmbedStep** naturally skips already-embedded chunks (existing behavior, no changes needed)
- Both **ingest_space** and **ingest_website** plugins pass `embeddings_port` to DocumentSummaryStep

Addresses alkem-io/alkemio#1826
Parent epic: alkem-io/alkemio#1820

## Spec artifacts

- `specs/011-incremental-embedding/spec.md`
- `specs/011-incremental-embedding/clarifications.md`
- `specs/011-incremental-embedding/plan.md`
- `specs/011-incremental-embedding/tasks.md`

## SDD loop counts

- Clarify iterations: 2 (1 with findings, 1 clean pass)
- Analyze iterations: 2 (1 review, 1 clean pass)

## Test plan

- [x] 8 new unit/integration tests for incremental embedding (T-IE-1 through T-IE-7)
- [x] Full test suite: 340 tests pass
- [x] Ruff lint: clean
- [x] Pyright type check: 0 errors (41 pre-existing warnings unchanged)

Generated with [Claude Code](https://claude.ai/code)