### PR TITLE
fix: consistent summarization behavior between ingest-website and ingest-space

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -268,6 +268,7 @@ class BaseConfig(BaseSettings):
     batch_size: int = 20
     summary_length: int = 10000
     summarize_concurrency: int = 8
+    summarize_enabled: bool = True
 
     # Health
     health_port: int = 8080

--- a/plugins/ingest_space/plugin.py
+++ b/plugins/ingest_space/plugin.py
@@ -81,20 +81,27 @@ class IngestSpacePlugin:
                 )
 
             # Run ingest pipeline with ingest-space specific settings
+            from core.config import BaseConfig
+            config = BaseConfig()
+
             summary_llm = self._summarize_llm or self._llm
-            engine = IngestEngine(steps=[
+            steps: list = [
                 ChunkStep(chunk_size=9000, chunk_overlap=500),
                 ContentHashStep(),
                 ChangeDetectionStep(knowledge_store_port=self._knowledge_store),
-                DocumentSummaryStep(
+            ]
+            if config.summarize_enabled:
+                concurrency = config.summarize_concurrency if config.summarize_concurrency > 0 else 8
+                steps.append(DocumentSummaryStep(
                     llm_port=summary_llm,
+                    concurrency=concurrency,
                     chunk_threshold=self._chunk_threshold,
-                ),
-                BodyOfKnowledgeSummaryStep(llm_port=self._bok_llm or summary_llm),
-                EmbedStep(embeddings_port=self._embeddings),
-                StoreStep(knowledge_store_port=self._knowledge_store),
-                OrphanCleanupStep(knowledge_store_port=self._knowledge_store),
-            ])
+                ))
+                steps.append(BodyOfKnowledgeSummaryStep(llm_port=self._bok_llm or summary_llm))
+            steps.append(EmbedStep(embeddings_port=self._embeddings))
+            steps.append(StoreStep(knowledge_store_port=self._knowledge_store))
+            steps.append(OrphanCleanupStep(knowledge_store_port=self._knowledge_store))
+            engine = IngestEngine(steps=steps)
             result = await engine.run(documents, collection_name)
 
             return IngestBodyOfKnowledgeResult(

--- a/plugins/ingest_website/plugin.py
+++ b/plugins/ingest_website/plugin.py
@@ -99,10 +99,11 @@ class IngestWebsitePlugin:
                 ContentHashStep(),
                 ChangeDetectionStep(knowledge_store_port=self._knowledge_store),
             ]
-            if config.summarize_concurrency > 0:
+            if config.summarize_enabled:
+                concurrency = config.summarize_concurrency if config.summarize_concurrency > 0 else 8
                 steps.append(DocumentSummaryStep(
                     llm_port=summary_llm,
-                    concurrency=config.summarize_concurrency,
+                    concurrency=concurrency,
                     chunk_threshold=self._chunk_threshold,
                 ))
                 bok_llm = self._bok_llm or summary_llm

--- a/tests/plugins/test_ingest_space.py
+++ b/tests/plugins/test_ingest_space.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, AsyncMock, patch
+
 import pytest
 
+from core.domain.ingest_pipeline import Document, DocumentMetadata
+from core.domain.pipeline import IngestEngine
 from core.events.ingest_space import IngestBodyOfKnowledgeResult
 from plugins.ingest_space.file_parsers import parse_file
 from plugins.ingest_space.plugin import IngestSpacePlugin
@@ -102,3 +106,101 @@ class TestIngestSpacePlugin:
     async def test_startup_shutdown(self, plugin):
         await plugin.startup()
         await plugin.shutdown()
+
+
+class TestIngestSpaceSummarizationToggle:
+    """Tests for the summarize_enabled config flag in ingest-space."""
+
+    @pytest.fixture
+    def plugin(self):
+        mock_graphql = AsyncMock()
+        return IngestSpacePlugin(
+            llm=MockLLMPort(),
+            embeddings=MockEmbeddingsPort(),
+            knowledge_store=MockKnowledgeStorePort(),
+            graphql_client=mock_graphql,
+        )
+
+    def _make_documents(self):
+        return [
+            Document(
+                content="Test document content for pipeline test.",
+                metadata=DocumentMetadata(
+                    document_id="doc-1",
+                    source="space-1",
+                    type="knowledge",
+                    title="Test Doc",
+                ),
+            )
+        ]
+
+    async def test_pipeline_includes_summary_steps_when_enabled(self, plugin):
+        """When summarize_enabled=True, pipeline includes both summary steps."""
+        event = make_ingest_body_of_knowledge()
+
+        mock_config = MagicMock()
+        mock_config.summarize_enabled = True
+        mock_config.summarize_concurrency = 8
+
+        captured_steps = []
+
+        def capture_engine_init(self_engine, steps, **kwargs):
+            captured_steps.extend(steps)
+            self_engine._steps = steps
+
+        with patch("plugins.ingest_space.space_reader.read_space_tree", return_value=self._make_documents()), \
+             patch("core.config.BaseConfig", return_value=mock_config), \
+             patch.object(IngestEngine, "__init__", capture_engine_init), \
+             patch.object(IngestEngine, "run", return_value=MagicMock(success=True, errors=[])):
+            await plugin.handle(event)
+
+        step_names = [type(s).__name__ for s in captured_steps]
+        assert "DocumentSummaryStep" in step_names
+        assert "BodyOfKnowledgeSummaryStep" in step_names
+
+    async def test_pipeline_excludes_summary_steps_when_disabled(self, plugin):
+        """When summarize_enabled=False, pipeline omits both summary steps."""
+        event = make_ingest_body_of_knowledge()
+
+        mock_config = MagicMock()
+        mock_config.summarize_enabled = False
+
+        captured_steps = []
+
+        def capture_engine_init(self_engine, steps, **kwargs):
+            captured_steps.extend(steps)
+            self_engine._steps = steps
+
+        with patch("plugins.ingest_space.space_reader.read_space_tree", return_value=self._make_documents()), \
+             patch("core.config.BaseConfig", return_value=mock_config), \
+             patch.object(IngestEngine, "__init__", capture_engine_init), \
+             patch.object(IngestEngine, "run", return_value=MagicMock(success=True, errors=[])):
+            await plugin.handle(event)
+
+        step_names = [type(s).__name__ for s in captured_steps]
+        assert "DocumentSummaryStep" not in step_names
+        assert "BodyOfKnowledgeSummaryStep" not in step_names
+
+    async def test_pipeline_coerces_zero_concurrency(self, plugin):
+        """When summarize_concurrency=0 and summarize_enabled=True, concurrency defaults to 8."""
+        event = make_ingest_body_of_knowledge()
+
+        mock_config = MagicMock()
+        mock_config.summarize_enabled = True
+        mock_config.summarize_concurrency = 0
+
+        captured_steps = []
+
+        def capture_engine_init(self_engine, steps, **kwargs):
+            captured_steps.extend(steps)
+            self_engine._steps = steps
+
+        with patch("plugins.ingest_space.space_reader.read_space_tree", return_value=self._make_documents()), \
+             patch("core.config.BaseConfig", return_value=mock_config), \
+             patch.object(IngestEngine, "__init__", capture_engine_init), \
+             patch.object(IngestEngine, "run", return_value=MagicMock(success=True, errors=[])):
+            await plugin.handle(event)
+
+        doc_summary_steps = [s for s in captured_steps if type(s).__name__ == "DocumentSummaryStep"]
+        assert len(doc_summary_steps) == 1
+        assert doc_summary_steps[0]._concurrency == 8

--- a/tests/plugins/test_ingest_website.py
+++ b/tests/plugins/test_ingest_website.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
+from core.domain.pipeline import IngestEngine
 from core.events.ingest_website import IngestWebsiteResult
 from plugins.ingest_website.crawler import _is_same_domain, _normalize_url, _should_skip_url, crawl
 from plugins.ingest_website.html_parser import extract_text, extract_title
@@ -162,7 +163,7 @@ class TestIngestWebsitePlugin:
         mock_pages = [{"url": "https://example.com", "html": "<p>Content for ingestion test.</p>"}]
 
         mock_config = MagicMock()
-        mock_config.summarize_concurrency = 0
+        mock_config.summarize_enabled = False
 
         with patch("plugins.ingest_website.plugin.crawl", return_value=mock_pages), \
              patch("core.config.BaseConfig", return_value=mock_config):
@@ -178,6 +179,80 @@ class TestIngestWebsitePlugin:
         with patch("plugins.ingest_website.plugin.crawl", return_value=[]):
             result = await plugin.handle(event)
         assert result.result == "success"
+
+    async def test_pipeline_includes_summary_steps_when_enabled(self, plugin):
+        """When summarize_enabled=True, pipeline includes both summary steps."""
+        event = make_ingest_website()
+        mock_pages = [{"url": "https://example.com", "html": "<p>Content for summarization test.</p>"}]
+
+        mock_config = MagicMock()
+        mock_config.summarize_enabled = True
+        mock_config.summarize_concurrency = 8
+
+        captured_steps = []
+
+        def capture_engine_init(self_engine, steps, **kwargs):
+            captured_steps.extend(steps)
+            self_engine._steps = steps
+
+        with patch("plugins.ingest_website.plugin.crawl", return_value=mock_pages), \
+             patch("core.config.BaseConfig", return_value=mock_config), \
+             patch.object(IngestEngine, "__init__", capture_engine_init), \
+             patch.object(IngestEngine, "run", return_value=MagicMock(success=True, errors=[])):
+            await plugin.handle(event)
+
+        step_names = [type(s).__name__ for s in captured_steps]
+        assert "DocumentSummaryStep" in step_names
+        assert "BodyOfKnowledgeSummaryStep" in step_names
+
+    async def test_pipeline_excludes_summary_steps_when_disabled(self, plugin):
+        """When summarize_enabled=False, pipeline omits both summary steps."""
+        event = make_ingest_website()
+        mock_pages = [{"url": "https://example.com", "html": "<p>Content for summarization test.</p>"}]
+
+        mock_config = MagicMock()
+        mock_config.summarize_enabled = False
+
+        captured_steps = []
+
+        def capture_engine_init(self_engine, steps, **kwargs):
+            captured_steps.extend(steps)
+            self_engine._steps = steps
+
+        with patch("plugins.ingest_website.plugin.crawl", return_value=mock_pages), \
+             patch("core.config.BaseConfig", return_value=mock_config), \
+             patch.object(IngestEngine, "__init__", capture_engine_init), \
+             patch.object(IngestEngine, "run", return_value=MagicMock(success=True, errors=[])):
+            await plugin.handle(event)
+
+        step_names = [type(s).__name__ for s in captured_steps]
+        assert "DocumentSummaryStep" not in step_names
+        assert "BodyOfKnowledgeSummaryStep" not in step_names
+
+    async def test_pipeline_coerces_zero_concurrency(self, plugin):
+        """When summarize_concurrency=0 and summarize_enabled=True, concurrency defaults to 8."""
+        event = make_ingest_website()
+        mock_pages = [{"url": "https://example.com", "html": "<p>Content for concurrency test.</p>"}]
+
+        mock_config = MagicMock()
+        mock_config.summarize_enabled = True
+        mock_config.summarize_concurrency = 0
+
+        captured_steps = []
+
+        def capture_engine_init(self_engine, steps, **kwargs):
+            captured_steps.extend(steps)
+            self_engine._steps = steps
+
+        with patch("plugins.ingest_website.plugin.crawl", return_value=mock_pages), \
+             patch("core.config.BaseConfig", return_value=mock_config), \
+             patch.object(IngestEngine, "__init__", capture_engine_init), \
+             patch.object(IngestEngine, "run", return_value=MagicMock(success=True, errors=[])):
+            await plugin.handle(event)
+
+        doc_summary_steps = [s for s in captured_steps if type(s).__name__ == "DocumentSummaryStep"]
+        assert len(doc_summary_steps) == 1
+        assert doc_summary_steps[0]._concurrency == 8
 
     async def test_startup_shutdown(self, plugin):
         await plugin.startup()

--- a/tests/test_config_summarize_enabled.py
+++ b/tests/test_config_summarize_enabled.py
@@ -1,0 +1,21 @@
+"""Tests for the summarize_enabled config flag."""
+
+from __future__ import annotations
+
+from core.config import BaseConfig
+
+
+class TestSummarizeEnabled:
+    """Verify the summarize_enabled config flag defaults and behavior."""
+
+    def test_summarize_enabled_defaults_to_true(self) -> None:
+        config = BaseConfig(llm_api_key="test-key")
+        assert config.summarize_enabled is True
+
+    def test_summarize_enabled_can_be_set_false(self) -> None:
+        config = BaseConfig(llm_api_key="test-key", summarize_enabled=False)
+        assert config.summarize_enabled is False
+
+    def test_summarize_enabled_can_be_set_true(self) -> None:
+        config = BaseConfig(llm_api_key="test-key", summarize_enabled=True)
+        assert config.summarize_enabled is True


### PR DESCRIPTION
## Summary

- Introduces a dedicated `SUMMARIZE_ENABLED` boolean config flag (default `True`) to control whether summarization pipeline steps are included, replacing the overloaded `summarize_concurrency > 0` gate in `ingest-website`
- Aligns `ingest-space` to conditionally include/exclude `DocumentSummaryStep` and `BodyOfKnowledgeSummaryStep` based on the same flag, and to read `summarize_concurrency` from config instead of relying on the step's default
- Both plugins now coerce `summarize_concurrency == 0` to the default (8) to prevent `asyncio.Semaphore(0)` deadlock

Addresses alkem-io/alkemio#1827
Parent epic: alkem-io/alkemio#1820

### SDD Artifacts

- `.speckit/spec.md` -- specification
- `.speckit/plan.md` -- architecture plan
- `.speckit/tasks.md` -- task breakdown
- `.speckit/clarifications.md` -- clarify loop (2 iterations)

### Loop Counts

- Clarify iterations: 2 (iteration 2 produced zero new ambiguities)
- Analyze iterations: 2 (iteration 2 produced zero findings)

## Test plan

- [x] New config default test: `summarize_enabled` defaults to `True`
- [x] ingest-website: pipeline includes summary steps when `summarize_enabled=True`
- [x] ingest-website: pipeline excludes summary steps when `summarize_enabled=False`
- [x] ingest-website: `summarize_concurrency=0` coerced to 8
- [x] ingest-space: pipeline includes summary steps when `summarize_enabled=True`
- [x] ingest-space: pipeline excludes summary steps when `summarize_enabled=False`
- [x] ingest-space: `summarize_concurrency=0` coerced to 8
- [x] Full test suite: 341 passed, 0 failed
- [x] Lint: ruff clean
- [x] Typecheck: pyright 0 errors (41 pre-existing warnings)

Generated with [Claude Code](https://claude.com/claude-code)