### PR TITLE
fix: clean up stale summaries on threshold drop and empty corpus

### DIFF
--- a/core/domain/pipeline/steps.py
+++ b/core/domain/pipeline/steps.py
@@ -278,6 +278,23 @@ class DocumentSummaryStep:
             )
         ]
 
+        # Detect stale per-document summaries: changed documents that dropped
+        # below the summary threshold still have a {doc_id}-summary-0 entry
+        # in the store from a previous ingest. Mark it for orphan cleanup.
+        if context.change_detection_ran:
+            for doc_id, doc_chunks in chunks_by_doc.items():
+                if (
+                    doc_id in context.changed_document_ids
+                    and len(doc_chunks) < self._chunk_threshold
+                ):
+                    orphan_id = f"{doc_id}-summary-0"
+                    context.orphan_ids.add(orphan_id)
+                    logger.info(
+                        "Stale summary detected for %s (%d chunks < threshold %d), "
+                        "marking %s for cleanup",
+                        doc_id, len(doc_chunks), self._chunk_threshold, orphan_id,
+                    )
+
         for doc_id, doc_chunks in docs_to_summarize:
             try:
                 logger.info(
@@ -352,6 +369,14 @@ class BodyOfKnowledgeSummaryStep:
                 seen_doc_ids.append(doc_id)
 
         if not seen_doc_ids:
+            # All documents removed: clean up the BoK summary entry
+            if context.removed_document_ids:
+                context.orphan_ids.add("body-of-knowledge-summary-0")
+                logger.info(
+                    "Corpus is empty after removing %d document(s), "
+                    "marking body-of-knowledge-summary-0 for cleanup",
+                    len(context.removed_document_ids),
+                )
             return
 
         # For each doc: prefer document_summaries, else concatenate raw chunk content

--- a/tests/core/domain/test_pipeline_steps.py
+++ b/tests/core/domain/test_pipeline_steps.py
@@ -234,6 +234,48 @@ class TestDocumentSummaryStep:
         await DocumentSummaryStep(llm_port=FailingLLM()).execute(ctx)  # type: ignore[arg-type]
         assert any("DocumentSummaryStep" in e for e in ctx.errors)
 
+    async def test_stale_summary_added_to_orphans(self):
+        """Changed doc below threshold should mark its summary for cleanup."""
+        llm = MockLLMPort()
+        doc = _make_doc(content="Short text.", doc_id="doc-shrunk")
+        ctx = _make_context([doc])
+        await ChunkStep(chunk_size=10000).execute(ctx)
+
+        # Precondition: doc produces fewer than 4 chunks
+        assert len(ctx.chunks) < 4
+
+        # Simulate change detection having run and flagging this doc as changed
+        ctx.change_detection_ran = True
+        ctx.changed_document_ids.add("doc-shrunk")
+
+        chunks_before = len(ctx.chunks)
+        await DocumentSummaryStep(llm_port=llm).execute(ctx)
+
+        # No summary should be generated (below threshold)
+        assert len(ctx.chunks) == chunks_before
+        assert len(llm.calls) == 0
+        # Stale summary should be marked as orphan
+        assert "doc-shrunk-summary-0" in ctx.orphan_ids
+
+    async def test_no_stale_orphan_for_unchanged_document(self):
+        """Unchanged doc below threshold should NOT produce an orphan."""
+        llm = MockLLMPort()
+        doc = _make_doc(content="Short text.", doc_id="doc-stable")
+        ctx = _make_context([doc])
+        await ChunkStep(chunk_size=10000).execute(ctx)
+
+        assert len(ctx.chunks) < 4
+
+        # Change detection ran but this doc is NOT changed
+        ctx.change_detection_ran = True
+
+        chunks_before = len(ctx.chunks)
+        await DocumentSummaryStep(llm_port=llm).execute(ctx)
+
+        assert len(ctx.chunks) == chunks_before
+        assert len(llm.calls) == 0
+        assert len(ctx.orphan_ids) == 0
+
     async def test_step_name(self):
         llm = MockLLMPort()
         assert DocumentSummaryStep(llm_port=llm).name == "document_summary"
@@ -448,6 +490,54 @@ class TestBodyOfKnowledgeSummaryStep:
         # The prompt should mention 2000 (100% budget), not 800 (40%)
         prompt_text = llm.calls[0][1]["content"]
         assert "2000" in prompt_text
+
+    async def test_empty_corpus_adds_bok_orphan(self):
+        """When all docs are removed and corpus is empty, BoK summary is marked for cleanup."""
+        llm = MockLLMPort()
+        ctx = PipelineContext(
+            collection_name="test",
+            documents=[],
+            chunks=[],
+            change_detection_ran=True,
+            removed_document_ids={"doc-1", "doc-2"},
+        )
+
+        await BodyOfKnowledgeSummaryStep(llm_port=llm).execute(ctx)
+
+        # No BoK summary should be generated
+        assert len(ctx.chunks) == 0
+        assert len(llm.calls) == 0
+        # BoK summary entry should be marked as orphan
+        assert "body-of-knowledge-summary-0" in ctx.orphan_ids
+
+    async def test_no_bok_orphan_when_docs_remain(self):
+        """When some docs are removed but others remain, BoK summary regenerates normally."""
+        llm = MockLLMPort(response="Updated BoK overview")
+        ctx = PipelineContext(
+            collection_name="test",
+            documents=[],
+            chunks=[
+                Chunk(
+                    content="remaining doc content",
+                    metadata=DocumentMetadata(
+                        document_id="doc-remaining", source="s", embedding_type="chunk",
+                    ),
+                    chunk_index=0,
+                ),
+            ],
+            change_detection_ran=True,
+            removed_document_ids={"doc-removed"},
+            changed_document_ids=set(),
+        )
+
+        await BodyOfKnowledgeSummaryStep(llm_port=llm).execute(ctx)
+
+        # BoK summary should be regenerated (docs still exist)
+        bok_chunks = [c for c in ctx.chunks if c.metadata.document_id == "body-of-knowledge-summary"]
+        assert len(bok_chunks) == 1
+        assert bok_chunks[0].content == "Updated BoK overview"
+        # No orphan should be added
+        assert "body-of-knowledge-summary-0" not in ctx.orphan_ids
 
     async def test_step_name(self):
         llm = MockLLMPort()


### PR DESCRIPTION
## Summary

Closes #36

- **Stale per-document summaries**: `DocumentSummaryStep` now detects changed documents that dropped below `chunk_threshold` and adds their `{doc_id}-summary-0` entries to `context.orphan_ids` for cleanup by `OrphanCleanupStep`.
- **Empty corpus BoK cleanup**: `BodyOfKnowledgeSummaryStep` now adds `body-of-knowledge-summary-0` to `context.orphan_ids` when all documents have been removed (empty `seen_doc_ids` with non-empty `removed_document_ids`).
- Both fixes leverage the existing `OrphanCleanupStep` deletion mechanism -- no new store calls introduced in summary steps.

## Artifacts

- Spec: `.speckit/story-36/spec.md`
- Plan: `.speckit/story-36/plan.md`
- Tasks: `.speckit/story-36/tasks.md`
- Clarifications: `.speckit/story-36/clarifications.md`

## SDD Loop Counts

- Clarify iterations: 2 (4 clarifications resolved in iteration 1, 0 new in iteration 2)
- Analyze iterations: 2 (0 findings in both iterations)

## Test plan

- [x] New test: `test_stale_summary_added_to_orphans` -- changed doc below threshold marks summary for cleanup
- [x] New test: `test_no_stale_orphan_for_unchanged_document` -- unchanged doc below threshold produces no orphan
- [x] New test: `test_empty_corpus_adds_bok_orphan` -- all docs removed marks BoK summary for cleanup
- [x] New test: `test_no_bok_orphan_when_docs_remain` -- partial removal regenerates BoK normally
- [x] All 336 existing tests pass
- [x] Lint (`ruff check`) passes
- [x] Type check (`pyright`) passes with 0 errors

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved detection and cleanup of outdated document summaries when documents are modified below processing thresholds.
  * Fixed cleanup of knowledge base summary data when the corpus becomes empty after document removals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->