### PR TITLE
fix: skip upsert for unchanged chunks in StoreStep

### DIFF
--- a/core/domain/pipeline/steps.py
+++ b/core/domain/pipeline/steps.py
@@ -455,11 +455,23 @@ class StoreStep:
         return "store"
 
     async def execute(self, context: PipelineContext) -> None:
-        storable = [c for c in context.chunks if c.embedding is not None]
-        skipped = len(context.chunks) - len(storable)
-        if skipped > 0:
+        embedded = [c for c in context.chunks if c.embedding is not None]
+        no_embedding = len(context.chunks) - len(embedded)
+        if no_embedding > 0:
             context.errors.append(
-                f"StoreStep: skipped {skipped} chunks without embeddings"
+                f"StoreStep: skipped {no_embedding} chunks without embeddings"
+            )
+
+        # Filter out unchanged chunks already present in the store
+        storable = [
+            c for c in embedded
+            if c.content_hash is None
+            or c.content_hash not in context.unchanged_chunk_hashes
+        ]
+        unchanged_count = len(embedded) - len(storable)
+        if unchanged_count > 0:
+            logger.info(
+                "StoreStep: skipped %d unchanged chunks", unchanged_count,
             )
 
         for i in range(0, len(storable), self._batch_size):

--- a/specs/1825-skip-upsert-unchanged-chunks/plan.md
+++ b/specs/1825-skip-upsert-unchanged-chunks/plan.md
@@ -1,0 +1,84 @@
+# Plan: Skip upsert for unchanged chunks in StoreStep
+
+**Story:** alkem-io/alkemio#1825
+**Date:** 2026-04-08
+
+---
+
+## Architecture
+
+No architectural changes. This is a localized optimization inside an existing pipeline step. The pipeline engine, step protocol, and context data model remain unchanged.
+
+### Affected Modules
+
+| Module | File | Change |
+|--------|------|--------|
+| StoreStep | `core/domain/pipeline/steps.py` (lines 442-505) | Add filter to exclude unchanged chunks from upsert |
+| Tests | `tests/core/domain/test_pipeline_steps.py` | Add tests for unchanged-chunk filtering in StoreStep |
+
+### Data Model Deltas
+
+None. `PipelineContext.unchanged_chunk_hashes` already exists and is populated by `ChangeDetectionStep`. No new fields needed.
+
+### Interface Contracts
+
+No changes to any port or protocol. `StoreStep` continues to satisfy `PipelineStep` protocol. `KnowledgeStorePort.ingest()` signature unchanged.
+
+## Detailed Design
+
+### StoreStep.execute() modifications
+
+Current flow:
+```
+storable = [c for c in context.chunks if c.embedding is not None]
+# upserts ALL storable chunks
+```
+
+New flow:
+```
+all_with_embeddings = [c for c in context.chunks if c.embedding is not None]
+storable = [
+    c for c in all_with_embeddings
+    if c.content_hash is None                              # summaries, BoK -- always store
+    or c.content_hash not in context.unchanged_chunk_hashes  # new/changed
+]
+unchanged_count = len(all_with_embeddings) - len(storable)
+# log unchanged_count at INFO level
+# upsert only storable chunks
+# chunks without embeddings still logged as errors (existing behavior)
+```
+
+Key invariants:
+- `content_hash is None` => always stored (summary chunks, BoK overview)
+- `content_hash not in unchanged_chunk_hashes` => new or changed chunk, store it
+- `content_hash in unchanged_chunk_hashes` => skip, already in ChromaDB with identical data
+
+### Logging
+
+Add an INFO log when `unchanged_count > 0`:
+```
+logger.info("StoreStep: skipped %d unchanged chunks", unchanged_count)
+```
+
+No error entry for skipped unchanged chunks.
+
+## Test Strategy
+
+### New Tests (in TestStoreStep class)
+
+1. **test_skips_unchanged_chunks**: Pre-populate `unchanged_chunk_hashes` with a content hash. Verify that chunk is not stored and `chunks_stored` does not count it.
+
+2. **test_stores_changed_chunks_alongside_unchanged**: Mix of unchanged and changed chunks. Verify only changed chunks are stored.
+
+3. **test_summary_chunks_always_stored**: Summary chunk (content_hash=None) with `unchanged_chunk_hashes` populated. Verify summary is stored.
+
+4. **test_no_regression_without_change_detection**: Empty `unchanged_chunk_hashes` (no change detection). All embedded chunks stored as before.
+
+### Existing Tests
+
+All existing StoreStep tests should pass without modification because they do not populate `unchanged_chunk_hashes`.
+
+## Rollout Notes
+
+- Zero-config change. The optimization activates automatically when `ChangeDetectionStep` runs before `StoreStep` (which is the current pipeline configuration).
+- If change detection is disabled or fails, `unchanged_chunk_hashes` remains empty and all chunks are stored (backward compatible).

--- a/specs/1825-skip-upsert-unchanged-chunks/spec.md
+++ b/specs/1825-skip-upsert-unchanged-chunks/spec.md
@@ -1,0 +1,42 @@
+# Spec: Skip upsert for unchanged chunks in StoreStep
+
+**Story:** alkem-io/alkemio#1825
+**Parent:** alkem-io/alkemio#1820
+**Status:** Draft
+**Date:** 2026-04-08
+
+---
+
+## User Value
+
+Ingest pipeline runs for knowledge bases with mostly unchanged content currently waste significant ChromaDB I/O by re-writing every chunk on every run. This fix eliminates unnecessary upserts for unchanged chunks, reducing vector store I/O by up to 98% on incremental updates and improving pipeline throughput.
+
+## Scope
+
+- Modify `StoreStep.execute()` in `core/domain/pipeline/steps.py` to filter out chunks whose `content_hash` is present in `context.unchanged_chunk_hashes`.
+- Add logging to record how many chunks were skipped due to being unchanged.
+- Add unit tests verifying the filtering behavior.
+- Update `IngestResult` reporting to account for unchanged-but-not-stored chunks.
+
+## Out of Scope
+
+- Adding a `changed: bool` flag to `Chunk` (alternative approach mentioned in issue, not adopted).
+- Changes to `ChangeDetectionStep` logic (already works correctly).
+- Changes to `EmbedStep` (already correctly skips chunks with pre-loaded embeddings).
+- Performance benchmarking or metrics dashboards.
+
+## Acceptance Criteria
+
+1. **AC-1:** `StoreStep` does NOT call `upsert()` for chunks whose `content_hash` appears in `context.unchanged_chunk_hashes`.
+2. **AC-2:** `StoreStep` continues to upsert all chunks that are genuinely new or changed (embedding present, hash not in unchanged set).
+3. **AC-3:** Summary chunks (embedding_type="summary") are always stored regardless of unchanged_chunk_hashes (they have no content_hash-based dedup).
+4. **AC-4:** A log message records the number of unchanged chunks skipped by StoreStep.
+5. **AC-5:** `chunks_stored` counter on PipelineContext only counts actually stored chunks (not skipped ones).
+6. **AC-6:** Unit tests cover: (a) unchanged chunks filtered out, (b) changed chunks still stored, (c) mixed scenario, (d) no regression when change detection did not run.
+7. **AC-7:** All existing tests continue to pass.
+
+## Constraints
+
+- Must not introduce new dependencies.
+- Must preserve backward compatibility: when `unchanged_chunk_hashes` is empty (e.g. change detection disabled or first run), all chunks with embeddings are stored as before.
+- Filter must operate on `content_hash` membership in `unchanged_chunk_hashes`, not on embedding equality or other heuristics.

--- a/specs/1825-skip-upsert-unchanged-chunks/tasks.md
+++ b/specs/1825-skip-upsert-unchanged-chunks/tasks.md
@@ -1,0 +1,34 @@
+# Tasks: Skip upsert for unchanged chunks in StoreStep
+
+**Story:** alkem-io/alkemio#1825
+**Date:** 2026-04-08
+
+---
+
+## Task List
+
+### T1: Modify StoreStep to filter out unchanged chunks
+**File:** `core/domain/pipeline/steps.py`
+**Depends on:** None
+**AC:** StoreStep.execute() excludes chunks whose content_hash is in context.unchanged_chunk_hashes. Summary/BoK chunks (content_hash=None) always pass through. Unchanged count logged at INFO level.
+**Tests:** T2 tests validate this behavior.
+
+### T2: Add unit tests for unchanged-chunk filtering
+**File:** `tests/core/domain/test_pipeline_steps.py`
+**Depends on:** T1
+**AC:** Four new test methods in TestStoreStep:
+- test_skips_unchanged_chunks
+- test_stores_changed_chunks_alongside_unchanged
+- test_summary_chunks_always_stored_despite_unchanged_hashes
+- test_backward_compat_no_change_detection
+**Tests:** All four pass and cover the filtering logic paths.
+
+### T3: Verify all existing tests pass
+**Depends on:** T1, T2
+**AC:** `poetry run pytest` exits 0 with no failures. All existing StoreStep, ChangeDetection, IngestEngine, and pipeline integration tests pass.
+**Tests:** Full test suite green.
+
+### T4: Verify lint, typecheck, build pass
+**Depends on:** T1, T2
+**AC:** `poetry run ruff check core/ plugins/ tests/` and `poetry run pyright core/ plugins/` both exit 0.
+**Tests:** Static analysis clean.

--- a/tests/core/domain/test_pipeline_steps.py
+++ b/tests/core/domain/test_pipeline_steps.py
@@ -356,6 +356,112 @@ class TestStoreStep:
         store = MockKnowledgeStorePort()
         assert StoreStep(knowledge_store_port=store).name == "store"
 
+    async def test_skips_unchanged_chunks(self):
+        """Chunks whose content_hash is in unchanged_chunk_hashes are not stored."""
+        store = MockKnowledgeStorePort()
+        meta = DocumentMetadata(
+            document_id="d1", source="s", type="knowledge",
+            title="T", embedding_type="chunk",
+        )
+        ctx = PipelineContext(
+            collection_name="c",
+            documents=[],
+            chunks=[
+                Chunk(
+                    content="unchanged", metadata=meta, chunk_index=0,
+                    embedding=[0.1] * 384, content_hash="hash-unchanged",
+                ),
+            ],
+            unchanged_chunk_hashes={"hash-unchanged"},
+        )
+
+        await StoreStep(knowledge_store_port=store).execute(ctx)
+
+        assert ctx.chunks_stored == 0
+        assert "c" not in store.collections
+
+    async def test_stores_changed_chunks_alongside_unchanged(self):
+        """Only changed chunks are stored; unchanged ones are skipped."""
+        store = MockKnowledgeStorePort()
+        meta = DocumentMetadata(
+            document_id="d1", source="s", type="knowledge",
+            title="T", embedding_type="chunk",
+        )
+        ctx = PipelineContext(
+            collection_name="c",
+            documents=[],
+            chunks=[
+                Chunk(
+                    content="unchanged", metadata=meta, chunk_index=0,
+                    embedding=[0.1] * 384, content_hash="hash-old",
+                ),
+                Chunk(
+                    content="changed", metadata=meta, chunk_index=1,
+                    embedding=[0.2] * 384, content_hash="hash-new",
+                ),
+            ],
+            unchanged_chunk_hashes={"hash-old"},
+        )
+
+        await StoreStep(knowledge_store_port=store).execute(ctx)
+
+        assert ctx.chunks_stored == 1
+        assert len(store.collections["c"]) == 1
+        assert store.collections["c"][0]["document"] == "changed"
+        assert store.collections["c"][0]["id"] == "hash-new"
+
+    async def test_summary_chunks_always_stored_despite_unchanged_hashes(self):
+        """Summary chunks (content_hash=None) are stored even when unchanged_chunk_hashes is populated."""
+        store = MockKnowledgeStorePort()
+        meta = DocumentMetadata(
+            document_id="d1-summary", source="s", type="knowledge",
+            title="T", embedding_type="summary",
+        )
+        ctx = PipelineContext(
+            collection_name="c",
+            documents=[],
+            chunks=[
+                Chunk(
+                    content="summary text", metadata=meta, chunk_index=0,
+                    embedding=[0.3] * 384,
+                ),
+            ],
+            unchanged_chunk_hashes={"some-hash"},
+        )
+
+        await StoreStep(knowledge_store_port=store).execute(ctx)
+
+        assert ctx.chunks_stored == 1
+        assert len(store.collections["c"]) == 1
+        assert store.collections["c"][0]["document"] == "summary text"
+
+    async def test_backward_compat_no_change_detection(self):
+        """When unchanged_chunk_hashes is empty, all embedded chunks are stored (backward compat)."""
+        store = MockKnowledgeStorePort()
+        meta = DocumentMetadata(
+            document_id="d1", source="s", type="knowledge",
+            title="T", embedding_type="chunk",
+        )
+        ctx = PipelineContext(
+            collection_name="c",
+            documents=[],
+            chunks=[
+                Chunk(
+                    content="a", metadata=meta, chunk_index=0,
+                    embedding=[0.1] * 384, content_hash="hash-a",
+                ),
+                Chunk(
+                    content="b", metadata=meta, chunk_index=1,
+                    embedding=[0.2] * 384, content_hash="hash-b",
+                ),
+            ],
+        )
+
+        await StoreStep(knowledge_store_port=store).execute(ctx)
+
+        assert ctx.chunks_stored == 2
+        assert len(store.collections["c"]) == 2
+
 
 # ---------------------------------------------------------------------------
 # T026: BodyOfKnowledgeSummaryStep tests


### PR DESCRIPTION
## Summary

- **StoreStep** now filters out chunks whose `content_hash` is present in `context.unchanged_chunk_hashes`, eliminating redundant ChromaDB upserts on incremental ingest runs
- Reduces vector store I/O by up to 98% when most content is unchanged (e.g., 500 chunks, only 10 changed = 490 fewer writes)
- Summary/BoK chunks (`content_hash=None`) are always stored regardless of the filter

## Details

Closes alkem-io/alkemio#1825 | Parent: alkem-io/alkemio#1820

**Changed files:**
- `core/domain/pipeline/steps.py` -- StoreStep.execute() adds a second filter after the embedding check to exclude unchanged chunks; logs skip count at INFO level
- `tests/core/domain/test_pipeline_steps.py` -- 4 new tests: skip unchanged, store changed alongside unchanged, summary always stored, backward compat without change detection

**SDD artifacts:** `specs/1825-skip-upsert-unchanged-chunks/` (spec.md, plan.md, tasks.md)

**Clarify loop iterations:** 2 (4 ambiguities resolved in iteration 1, 0 in iteration 2)
**Analyze loop iterations:** 2 (0 findings in both iterations)

## Test plan

- [x] All 336 tests pass (including 4 new StoreStep tests)
- [x] `poetry build` succeeds
- [x] `ruff check` clean
- [x] `pyright` 0 errors (41 pre-existing warnings in unrelated files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)