### PR TITLE
feat: implement actual concurrency in DocumentSummaryStep

### DIFF
--- a/core/domain/pipeline/steps.py
+++ b/core/domain/pipeline/steps.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import logging
-from dataclasses import replace
+from dataclasses import dataclass, replace
 
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 
@@ -278,39 +279,65 @@ class DocumentSummaryStep:
             )
         ]
 
-        for doc_id, doc_chunks in docs_to_summarize:
-            try:
-                logger.info(
-                    "Summarizing document %s (%d chunks) [model=%s]",
-                    doc_id, len(doc_chunks), self._model_name,
-                )
-                summary = await _refine_summarize(
-                    [c.content for c in doc_chunks],
-                    self._llm.invoke,
-                    self._summary_length,
-                    DOCUMENT_REFINE_SYSTEM,
-                    DOCUMENT_REFINE_INITIAL,
-                    DOCUMENT_REFINE_SUBSEQUENT,
-                )
-                context.document_summaries[doc_id] = summary
+        if not docs_to_summarize:
+            return
 
-                source_meta = doc_chunks[0].metadata
-                summary_meta = DocumentMetadata(
-                    document_id=f"{doc_id}-summary",
-                    source=source_meta.source,
-                    type=source_meta.type,
-                    title=source_meta.title,
-                    embedding_type="summary",
-                )
-                context.chunks.append(
-                    Chunk(content=summary, metadata=summary_meta, chunk_index=0)
-                )
-                logger.info("Summarized document %s", doc_id)
-            except Exception as exc:
-                logger.warning("Summarization failed for %s: %s", doc_id, exc)
-                context.errors.append(
-                    f"DocumentSummaryStep: summarization failed for {doc_id}: {exc}"
-                )
+        @dataclass
+        class _DocResult:
+            doc_id: str
+            summary: str
+            chunk: Chunk
+
+        sem = asyncio.Semaphore(self._concurrency)
+
+        async def _summarize_one(
+            doc_id: str, doc_chunks: list[Chunk],
+        ) -> _DocResult | str:
+            """Summarize a single document. Returns _DocResult on success, error string on failure."""
+            async with sem:
+                try:
+                    logger.info(
+                        "Summarizing document %s (%d chunks) [model=%s]",
+                        doc_id, len(doc_chunks), self._model_name,
+                    )
+                    summary = await _refine_summarize(
+                        [c.content for c in doc_chunks],
+                        self._llm.invoke,
+                        self._summary_length,
+                        DOCUMENT_REFINE_SYSTEM,
+                        DOCUMENT_REFINE_INITIAL,
+                        DOCUMENT_REFINE_SUBSEQUENT,
+                    )
+                    source_meta = doc_chunks[0].metadata
+                    summary_meta = DocumentMetadata(
+                        document_id=f"{doc_id}-summary",
+                        source=source_meta.source,
+                        type=source_meta.type,
+                        title=source_meta.title,
+                        embedding_type="summary",
+                    )
+                    summary_chunk = Chunk(
+                        content=summary, metadata=summary_meta, chunk_index=0,
+                    )
+                    logger.info("Summarized document %s", doc_id)
+                    return _DocResult(
+                        doc_id=doc_id, summary=summary, chunk=summary_chunk,
+                    )
+                except Exception as exc:
+                    logger.warning("Summarization failed for %s: %s", doc_id, exc)
+                    return f"DocumentSummaryStep: summarization failed for {doc_id}: {exc}"
+
+        outcomes = await asyncio.gather(
+            *[_summarize_one(d, c) for d, c in docs_to_summarize],
+        )
+
+        # Batch-apply results to context after all coroutines complete
+        for outcome in outcomes:
+            if isinstance(outcome, str):
+                context.errors.append(outcome)
+            else:
+                context.document_summaries[outcome.doc_id] = outcome.summary
+                context.chunks.append(outcome.chunk)
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/ingest_space/plugin.py
+++ b/plugins/ingest_space/plugin.py
@@ -81,6 +81,8 @@ class IngestSpacePlugin:
                 )
 
             # Run ingest pipeline with ingest-space specific settings
+            from core.config import BaseConfig
+            config = BaseConfig()
             summary_llm = self._summarize_llm or self._llm
             engine = IngestEngine(steps=[
                 ChunkStep(chunk_size=9000, chunk_overlap=500),
@@ -88,6 +90,7 @@ class IngestSpacePlugin:
                 ChangeDetectionStep(knowledge_store_port=self._knowledge_store),
                 DocumentSummaryStep(
                     llm_port=summary_llm,
+                    concurrency=config.summarize_concurrency,
                     chunk_threshold=self._chunk_threshold,
                 ),
                 BodyOfKnowledgeSummaryStep(llm_port=self._bok_llm or summary_llm),

--- a/specs/011-concurrent-document-summary/plan.md
+++ b/specs/011-concurrent-document-summary/plan.md
@@ -1,0 +1,92 @@
+# Plan: Implement Actual Concurrency in DocumentSummaryStep
+
+**Story:** alkem-io/alkemio#1823
+**Spec:** spec.md
+**Date:** 2026-04-08
+
+---
+
+## Architecture
+
+The change is localized to `DocumentSummaryStep.execute()` in `core/domain/pipeline/steps.py`. The sequential `for` loop (lines 281-313) is replaced with a concurrent pattern:
+
+1. A per-document inner coroutine `_summarize_one(doc_id, doc_chunks)` that:
+   - Acquires the semaphore
+   - Calls `_refine_summarize()`
+   - Returns a structured result (success data or error message)
+2. `asyncio.gather()` dispatches all coroutines
+3. After gather completes, results are batch-applied to `context.chunks`, `context.document_summaries`, and `context.errors`
+
+This pattern avoids interleaved mutation of shared state and is idiomatic for asyncio concurrency.
+
+## Affected Modules
+
+| Module | Change |
+|--------|--------|
+| `core/domain/pipeline/steps.py` | Rewrite `DocumentSummaryStep.execute()` to use `asyncio.Semaphore` + `asyncio.gather` |
+| `plugins/ingest_space/plugin.py` | Pass `concurrency=` to `DocumentSummaryStep` for config consistency |
+| `tests/core/domain/test_pipeline_steps.py` | Add concurrency-specific tests |
+
+## Data Model Deltas
+
+None. `PipelineContext` and `Chunk` are unchanged.
+
+## Interface Contracts
+
+`DocumentSummaryStep.__init__` signature is unchanged. The `concurrency` parameter already exists and is already wired from `SUMMARIZE_CONCURRENCY` config. The `execute()` method signature is unchanged (still `async def execute(self, context: PipelineContext) -> None`).
+
+## Implementation Detail
+
+```
+# Pseudocode for the new execute() method:
+
+async def execute(self, context):
+    # 1. Build list of (doc_id, doc_chunks) to summarize (unchanged filter logic)
+    docs_to_summarize = [...]
+
+    # 2. Define result type
+    @dataclass
+    class _SummaryResult:
+        doc_id: str
+        summary: str
+        summary_chunk: Chunk
+    
+    # 3. Define per-doc coroutine with semaphore
+    sem = asyncio.Semaphore(self._concurrency)
+    results: list[_SummaryResult] = []
+    errors: list[str] = []
+
+    async def _summarize_one(doc_id, doc_chunks):
+        async with sem:
+            summary = await _refine_summarize(...)
+            return _SummaryResult(doc_id, summary, Chunk(...))
+
+    # 4. Gather with per-coroutine error handling
+    tasks = [_summarize_one(d, c) for d, c in docs_to_summarize]
+    outcomes = await asyncio.gather(*tasks, return_exceptions=True)
+    
+    # 5. Batch-apply results
+    for outcome in outcomes:
+        if isinstance(outcome, Exception):
+            context.errors.append(...)
+        else:
+            context.document_summaries[outcome.doc_id] = outcome.summary
+            context.chunks.append(outcome.summary_chunk)
+```
+
+Note: Using `return_exceptions=True` in gather so that one doc failure does not cancel others. Each coroutine still has its own try/except for logging, but `return_exceptions=True` provides a safety net.
+
+## Test Strategy
+
+1. **Existing tests pass unchanged:** The 6 existing `TestDocumentSummaryStep` tests must pass without modification.
+2. **New concurrency tests:**
+   - `test_concurrent_multiple_documents`: 3+ documents processed, all get summaries
+   - `test_concurrent_error_isolation`: One document fails, others succeed
+   - `test_concurrency_parameter_respected`: Verify semaphore limits concurrent access
+   - `test_concurrent_results_applied_to_context`: Verify `document_summaries` dict and `chunks` list are correctly populated
+
+## Rollout Notes
+
+- No config changes needed -- `SUMMARIZE_CONCURRENCY` already exists (default 8).
+- No migration needed -- this is a pure behavioral change (sequential -> concurrent).
+- Backward compatible -- `concurrency=1` yields sequential behavior.

--- a/specs/011-concurrent-document-summary/spec.md
+++ b/specs/011-concurrent-document-summary/spec.md
@@ -1,0 +1,46 @@
+# Spec: Implement Actual Concurrency in DocumentSummaryStep
+
+**Story:** alkem-io/alkemio#1823
+**Parent:** alkem-io/alkemio#1820
+**Status:** Draft
+**Author:** SDD Agent
+**Date:** 2026-04-08
+
+---
+
+## User Value
+
+Website and space ingestion currently takes 300-450 seconds for 15+ document summarizations because `DocumentSummaryStep.execute()` processes documents sequentially. Implementing semaphore-bounded `asyncio.gather` concurrency will reduce this to 30-60 seconds (5-10x improvement), directly reducing the risk of hitting RabbitMQ `consumer_timeout` and eliminating the need for the 2-hour timeout workaround.
+
+## Scope
+
+1. Replace the sequential `for` loop in `DocumentSummaryStep.execute()` with `asyncio.Semaphore`-bounded `asyncio.gather()`.
+2. Ensure thread-safe updates to `context.chunks` (list append) and `context.document_summaries` (dict update) during concurrent execution.
+3. Ensure thread-safe collection of per-document errors during concurrent execution.
+4. Wire the existing `self._concurrency` parameter (already accepted in `__init__`, already configured via `SUMMARIZE_CONCURRENCY` env var) through to the semaphore.
+5. Write unit tests proving concurrent execution, correctness of results, and proper error isolation.
+
+## Out of Scope
+
+- Changing the `_refine_summarize` helper itself (it is correct as-is).
+- Adding concurrency to `BodyOfKnowledgeSummaryStep` (single sequential call by design).
+- Modifying RabbitMQ timeout configuration.
+- Changing the `PipelineContext` dataclass structure.
+- Concurrency in other pipeline steps (EmbedStep, StoreStep).
+
+## Acceptance Criteria
+
+1. **AC-1:** `DocumentSummaryStep.execute()` uses `asyncio.gather()` with `asyncio.Semaphore(self._concurrency)` to process documents concurrently.
+2. **AC-2:** `context.chunks`, `context.document_summaries`, and `context.errors` are updated safely -- no race conditions, no lost data.
+3. **AC-3:** The `concurrency` parameter (default 8, from `SUMMARIZE_CONCURRENCY` config) controls the semaphore limit.
+4. **AC-4:** Per-document error handling is preserved -- a failure in one document does not abort other documents.
+5. **AC-5:** All existing `TestDocumentSummaryStep` tests continue to pass without modification.
+6. **AC-6:** New tests verify concurrent execution (multiple documents processed), error isolation, and correct semaphore bounding.
+7. **AC-7:** Lint, typecheck, and full test suite pass clean.
+
+## Constraints
+
+- Python 3.12, asyncio only (no threading, no multiprocessing).
+- Must not change the `PipelineStep` protocol or `PipelineContext` dataclass.
+- Must preserve the existing public interface of `DocumentSummaryStep.__init__`.
+- Collect results from `asyncio.gather` and batch-apply to context after gather completes (avoids interleaved mutation).

--- a/specs/011-concurrent-document-summary/tasks.md
+++ b/specs/011-concurrent-document-summary/tasks.md
@@ -1,0 +1,52 @@
+# Tasks: Implement Actual Concurrency in DocumentSummaryStep
+
+**Story:** alkem-io/alkemio#1823
+**Plan:** plan.md
+**Date:** 2026-04-08
+
+---
+
+## Task List
+
+### T1: Rewrite DocumentSummaryStep.execute() with asyncio concurrency
+
+**File:** `core/domain/pipeline/steps.py`
+**Depends on:** None
+**Acceptance criteria:**
+- The sequential `for doc_id, doc_chunks in docs_to_summarize:` loop is replaced with `asyncio.gather()`
+- An `asyncio.Semaphore(self._concurrency)` bounds parallel execution
+- Per-document results (summary text + summary Chunk) are collected in a list
+- After gather, results are batch-applied to `context.document_summaries` and `context.chunks`
+- Errors are collected per-document and batch-appended to `context.errors` after gather
+- `import asyncio` is added at the top of the file
+- Logging is preserved (info log before and after each doc summarization)
+**Tests:** All existing `TestDocumentSummaryStep` tests pass. New tests in T3.
+
+### T2: Wire concurrency parameter in ingest-space plugin
+
+**File:** `plugins/ingest_space/plugin.py`
+**Depends on:** None (can be done in parallel with T1)
+**Acceptance criteria:**
+- `DocumentSummaryStep` instantiation passes `concurrency=` from config, matching ingest-website plugin pattern
+- Config is read from `BaseConfig().summarize_concurrency`
+**Tests:** Existing plugin tests pass.
+
+### T3: Add concurrency-specific unit tests
+
+**File:** `tests/core/domain/test_pipeline_steps.py`
+**Depends on:** T1
+**Acceptance criteria:**
+- `test_concurrent_multiple_documents`: Creates 3+ documents that each produce enough chunks to trigger summarization. Verifies all documents get summaries in `context.document_summaries` and corresponding summary chunks in `context.chunks`.
+- `test_concurrent_error_isolation`: One document's LLM call raises an exception; other documents succeed. Verifies errors list contains the failure, and successful documents have their summaries.
+- `test_concurrency_semaphore_bounds`: Uses a tracking LLM to record peak concurrency. Verifies peak does not exceed the configured `concurrency` parameter.
+- `test_concurrent_change_detection_respected`: When `change_detection_ran=True`, only documents in `changed_document_ids` are summarized (existing behavior preserved under concurrency).
+**Tests:** Self-referential -- these ARE the tests.
+
+### T4: Verify all exit gates pass
+
+**Depends on:** T1, T2, T3
+**Acceptance criteria:**
+- `poetry run pytest` passes with zero failures
+- `poetry run ruff check core/ plugins/ tests/` passes clean
+- `poetry run pyright core/ plugins/` passes clean
+**Tests:** Gate verification.

--- a/tests/core/domain/test_pipeline_steps.py
+++ b/tests/core/domain/test_pipeline_steps.py
@@ -240,6 +240,183 @@ class TestDocumentSummaryStep:
 
 
 # ---------------------------------------------------------------------------
+# T024b: DocumentSummaryStep concurrency tests
+# ---------------------------------------------------------------------------
+
+class TestDocumentSummaryConcurrency:
+    async def test_concurrent_multiple_documents(self):
+        """Multiple documents are all summarized when processed concurrently."""
+        llm = MockLLMPort(response="Concurrent summary")
+        docs = [
+            _make_doc(content="Test content. " * 100, doc_id=f"doc-{i}")
+            for i in range(4)
+        ]
+        ctx = _make_context(docs)
+        await ChunkStep(chunk_size=100, chunk_overlap=10).execute(ctx)
+
+        # All 4 docs should have enough chunks
+        chunks_by_doc = {}
+        for c in ctx.chunks:
+            chunks_by_doc.setdefault(c.metadata.document_id, []).append(c)
+        assert all(len(v) >= 4 for v in chunks_by_doc.values())
+
+        await DocumentSummaryStep(llm_port=llm, concurrency=4).execute(ctx)
+
+        # All 4 documents should have summaries
+        assert len(ctx.document_summaries) == 4
+        for i in range(4):
+            assert f"doc-{i}" in ctx.document_summaries
+            assert ctx.document_summaries[f"doc-{i}"] == "Concurrent summary"
+
+        # 4 summary chunks should be appended
+        summary_chunks = [c for c in ctx.chunks if c.metadata.embedding_type == "summary"]
+        assert len(summary_chunks) == 4
+        summary_doc_ids = {c.metadata.document_id for c in summary_chunks}
+        assert summary_doc_ids == {f"doc-{i}-summary" for i in range(4)}
+
+    async def test_concurrent_error_isolation(self):
+        """A failure in one document does not prevent others from succeeding."""
+        call_count = 0
+
+        class SelectiveFailLLM:
+            async def invoke(self, messages):
+                nonlocal call_count
+                call_count += 1
+                # Fail on every call that includes doc-1 content
+                # (check if "doc-1" is referenced via the system being called)
+                # We use a simpler approach: fail on the second document by tracking calls
+                return "Good summary"
+
+        # We need a more targeted approach: fail for a specific doc
+        class DocFailLLM:
+            def __init__(self):
+                self.calls = []
+                self.fail_doc_id = "doc-fail"
+
+            async def invoke(self, messages):
+                self.calls.append(messages)
+                # The content for each doc is different, but we can't easily detect
+                # which doc is being summarized from messages alone.
+                # Instead, we'll use a pattern where we raise on the known content.
+                human_msg = messages[-1]["content"]
+                if "FAIL_MARKER" in human_msg:
+                    raise RuntimeError("LLM unavailable for this doc")
+                return "Good summary"
+
+        llm = DocFailLLM()
+        docs = [
+            _make_doc(content="Normal content. " * 100, doc_id="doc-ok-1"),
+            _make_doc(content="FAIL_MARKER content. " * 100, doc_id="doc-fail"),
+            _make_doc(content="More normal content. " * 100, doc_id="doc-ok-2"),
+        ]
+        ctx = _make_context(docs)
+        await ChunkStep(chunk_size=100, chunk_overlap=10).execute(ctx)
+
+        await DocumentSummaryStep(llm_port=llm, concurrency=4).execute(ctx)  # type: ignore[arg-type]
+
+        # The failing doc should be in errors
+        assert any("doc-fail" in e for e in ctx.errors)
+        assert any("DocumentSummaryStep" in e for e in ctx.errors)
+
+        # The successful docs should have summaries
+        assert "doc-ok-1" in ctx.document_summaries
+        assert "doc-ok-2" in ctx.document_summaries
+        assert "doc-fail" not in ctx.document_summaries
+
+    async def test_concurrency_semaphore_bounds(self):
+        """The semaphore limits peak concurrency to the configured value."""
+        import asyncio
+
+        peak_concurrent = 0
+        current_concurrent = 0
+        lock = asyncio.Lock()
+
+        class TrackingLLM:
+            async def invoke(self, messages):
+                nonlocal peak_concurrent, current_concurrent
+                async with lock:
+                    current_concurrent += 1
+                    if current_concurrent > peak_concurrent:
+                        peak_concurrent = current_concurrent
+                # Yield control so other coroutines can run
+                await asyncio.sleep(0.01)
+                async with lock:
+                    current_concurrent -= 1
+                return "Summary"
+
+        docs = [
+            _make_doc(content="Test content. " * 100, doc_id=f"doc-{i}")
+            for i in range(6)
+        ]
+        ctx = _make_context(docs)
+        await ChunkStep(chunk_size=100, chunk_overlap=10).execute(ctx)
+
+        await DocumentSummaryStep(
+            llm_port=TrackingLLM(), concurrency=2,  # type: ignore[arg-type]
+        ).execute(ctx)
+
+        assert peak_concurrent <= 2
+        # All docs should still get summaries
+        assert len(ctx.document_summaries) == 6
+
+    async def test_concurrent_change_detection_respected(self):
+        """With change_detection_ran=True, only changed docs get summarized."""
+        llm = MockLLMPort(response="Changed summary")
+        docs = [
+            _make_doc(content="Test content. " * 100, doc_id=f"doc-{i}")
+            for i in range(3)
+        ]
+        ctx = _make_context(docs)
+        await ChunkStep(chunk_size=100, chunk_overlap=10).execute(ctx)
+
+        # Simulate change detection: only doc-1 changed
+        ctx.change_detection_ran = True
+        ctx.changed_document_ids = {"doc-1"}
+
+        await DocumentSummaryStep(llm_port=llm, concurrency=4).execute(ctx)
+
+        # Only doc-1 should have a summary
+        assert len(ctx.document_summaries) == 1
+        assert "doc-1" in ctx.document_summaries
+        assert "doc-0" not in ctx.document_summaries
+        assert "doc-2" not in ctx.document_summaries
+
+    async def test_concurrency_one_is_sequential(self):
+        """concurrency=1 should process documents one at a time."""
+        import asyncio
+
+        peak_concurrent = 0
+        current_concurrent = 0
+        lock = asyncio.Lock()
+
+        class TrackingLLM:
+            async def invoke(self, messages):
+                nonlocal peak_concurrent, current_concurrent
+                async with lock:
+                    current_concurrent += 1
+                    if current_concurrent > peak_concurrent:
+                        peak_concurrent = current_concurrent
+                await asyncio.sleep(0.01)
+                async with lock:
+                    current_concurrent -= 1
+                return "Summary"
+
+        docs = [
+            _make_doc(content="Test content. " * 100, doc_id=f"doc-{i}")
+            for i in range(3)
+        ]
+        ctx = _make_context(docs)
+        await ChunkStep(chunk_size=100, chunk_overlap=10).execute(ctx)
+
+        await DocumentSummaryStep(
+            llm_port=TrackingLLM(), concurrency=1,  # type: ignore[arg-type]
+        ).execute(ctx)
+
+        assert peak_concurrent == 1
+        assert len(ctx.document_summaries) == 3
+
+
+# ---------------------------------------------------------------------------
 # T025: StoreStep tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Replace sequential for-loop in `DocumentSummaryStep.execute()` with `asyncio.Semaphore`-bounded `asyncio.gather()` for concurrent document summarization during ingest
- Collect results into local list and batch-apply to context after gather completes, avoiding interleaved mutation of shared state
- Wire `SUMMARIZE_CONCURRENCY` config through to ingest-space plugin for consistency with ingest-website

Closes alkem-io/alkemio#1823
Parent: alkem-io/alkemio#1820

## Spec artifacts

- `specs/011-concurrent-document-summary/spec.md`
- `specs/011-concurrent-document-summary/plan.md`
- `specs/011-concurrent-document-summary/tasks.md`

## SDD metrics

- Clarify loop iterations: 3 (0 new ambiguities on iteration 3)
- Analyze loop iterations: 2 (0 findings on iteration 2)

## Test plan

- [x] All 6 existing `TestDocumentSummaryStep` tests pass unchanged
- [x] New `test_concurrent_multiple_documents`: 4 documents all get summaries
- [x] New `test_concurrent_error_isolation`: one doc fails, others succeed
- [x] New `test_concurrency_semaphore_bounds`: peak concurrency stays within limit
- [x] New `test_concurrent_change_detection_respected`: only changed docs summarized
- [x] New `test_concurrency_one_is_sequential`: concurrency=1 behaves sequentially
- [x] Full test suite: 337 passed, 0 failures
- [x] Lint: ruff clean
- [x] Typecheck: pyright 0 errors

Generated with [Claude Code](https://claude.com/claude-code)