### PR TITLE
feat: incremental embedding during summarization

### DIFF
--- a/core/domain/pipeline/steps.py
+++ b/core/domain/pipeline/steps.py
@@ -239,7 +239,15 @@ class ChangeDetectionStep:
 # ---------------------------------------------------------------------------
 
 class DocumentSummaryStep:
-    """Generate per-document summaries for docs with >= chunk_threshold chunks."""
+    """Generate per-document summaries for docs with >= chunk_threshold chunks.
+
+    When ``embeddings_port`` is provided, each document's content chunks and its
+    newly-created summary chunk are embedded immediately after summarization
+    completes, overlapping LLM-bound summarization I/O with GPU-bound embedding
+    I/O.  Chunks that already carry an embedding (e.g. pre-loaded by
+    ``ChangeDetectionStep``) are skipped.  If incremental embedding fails the
+    error is recorded and the chunks are left for ``EmbedStep`` to retry.
+    """
 
     def __init__(
         self,
@@ -247,6 +255,8 @@ class DocumentSummaryStep:
         summary_length: int = 10000,
         concurrency: int = 8,
         chunk_threshold: int = 4,
+        embeddings_port: EmbeddingsPort | None = None,
+        embed_batch_size: int = 50,
     ) -> None:
         if chunk_threshold < 1:
             raise ValueError("chunk_threshold must be >= 1")
@@ -254,6 +264,8 @@ class DocumentSummaryStep:
         self._summary_length = summary_length
         self._concurrency = concurrency
         self._chunk_threshold = chunk_threshold
+        self._embeddings = embeddings_port
+        self._embed_batch_size = embed_batch_size
         self._model_name = getattr(
             getattr(llm_port, "_llm", None), "model", "unknown"
         )
@@ -261,6 +273,31 @@ class DocumentSummaryStep:
     @property
     def name(self) -> str:
         return "document_summary"
+
+    async def _embed_chunks(
+        self,
+        chunks: list[Chunk],
+        context: PipelineContext,
+        doc_id: str,
+    ) -> None:
+        """Embed a list of chunks in batches using the embeddings port."""
+        assert self._embeddings is not None
+        to_embed = [c for c in chunks if c.embedding is None]
+        if not to_embed:
+            return
+
+        for i in range(0, len(to_embed), self._embed_batch_size):
+            batch = to_embed[i : i + self._embed_batch_size]
+            texts = [c.content for c in batch]
+            try:
+                embeddings = await self._embeddings.embed(texts)
+                for chunk, embedding in zip(batch, embeddings):
+                    chunk.embedding = embedding
+            except Exception as exc:
+                context.errors.append(
+                    f"DocumentSummaryStep: incremental embedding failed for "
+                    f"{doc_id} batch {i // self._embed_batch_size}: {exc}"
+                )
 
     async def execute(self, context: PipelineContext) -> None:
         # Group chunks by document_id
@@ -302,10 +339,16 @@ class DocumentSummaryStep:
                     title=source_meta.title,
                     embedding_type="summary",
                 )
-                context.chunks.append(
-                    Chunk(content=summary, metadata=summary_meta, chunk_index=0)
+                summary_chunk = Chunk(
+                    content=summary, metadata=summary_meta, chunk_index=0,
                 )
+                context.chunks.append(summary_chunk)
                 logger.info("Summarized document %s", doc_id)
+
+                # Incremental embedding: embed this document's chunks + summary
+                if self._embeddings is not None:
+                    embed_targets = list(doc_chunks) + [summary_chunk]
+                    await self._embed_chunks(embed_targets, context, doc_id)
             except Exception as exc:
                 logger.warning("Summarization failed for %s: %s", doc_id, exc)
                 context.errors.append(

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,70 @@
+# Plan: Incremental Embedding -- Embed Documents as They Finish Summarization
+
+**Story:** alkem-io/alkemio#1826
+**Date:** 2026-04-08
+
+## Architecture
+
+Option A from the issue: per-document embed after summary. No pipeline engine changes. The optimization is contained within `DocumentSummaryStep`.
+
+### Affected Modules
+
+| Module | Change |
+|--------|--------|
+| `core/domain/pipeline/steps.py` | `DocumentSummaryStep.__init__` gains optional `embeddings_port` and `embed_batch_size`. `execute()` embeds a document's chunks + summary chunk immediately after summarizing that document. |
+| `plugins/ingest_space/plugin.py` | Pass `embeddings_port=self._embeddings` to `DocumentSummaryStep`. |
+| `plugins/ingest_website/plugin.py` | Pass `embeddings_port=self._embeddings` to `DocumentSummaryStep`. |
+| `tests/core/domain/test_pipeline_steps.py` | New tests for incremental embedding behavior. |
+
+### No Changes Required
+
+- `core/domain/pipeline/engine.py` -- step execution model unchanged.
+- `core/domain/pipeline/__init__.py` -- no new exports.
+- `core/domain/ingest_pipeline.py` -- no model changes.
+- `core/ports/embeddings.py` -- port protocol unchanged.
+- `EmbedStep` -- unchanged; its `c.embedding is None` filter naturally skips pre-embedded chunks.
+- `StoreStep`, `OrphanCleanupStep`, `ChangeDetectionStep` -- unchanged.
+
+## Data Model Deltas
+
+None. `Chunk.embedding` is already `list[float] | None`; it simply gets populated earlier.
+
+## Interface Contracts
+
+### DocumentSummaryStep.__init__ (updated)
+
+```python
+def __init__(
+    self,
+    llm_port: LLMPort,
+    summary_length: int = 10000,
+    concurrency: int = 8,
+    chunk_threshold: int = 4,
+    embeddings_port: EmbeddingsPort | None = None,  # NEW
+    embed_batch_size: int = 50,                      # NEW
+) -> None:
+```
+
+When `embeddings_port` is not None, after summarizing each document:
+1. Collect that document's content chunks (where `embedding is None`).
+2. Collect the newly-created summary chunk.
+3. Embed them all in batches of `embed_batch_size`.
+4. On failure, log error to `context.errors`; leave chunks unembedded for `EmbedStep` fallback.
+
+## Test Strategy
+
+| Test | Purpose |
+|------|---------|
+| `test_incremental_embed_after_summary` | Given embeddings_port, after execute(), summarized documents' chunks have embeddings set. |
+| `test_incremental_embed_summary_chunk` | The summary chunk itself is also embedded. |
+| `test_no_embed_when_port_is_none` | Without embeddings_port, chunks remain unembedded (backward compat). |
+| `test_incremental_embed_skips_preloaded` | Chunks with pre-loaded embeddings (from ChangeDetection) are not re-embedded. |
+| `test_incremental_embed_error_recorded` | Embedding failure is recorded in context.errors; chunks left for EmbedStep retry. |
+| `test_embed_step_skips_incrementally_embedded` | Integration: EmbedStep receives no work for already-embedded chunks. |
+| `test_below_threshold_not_embedded_by_summary_step` | Documents below chunk_threshold are not embedded by DocumentSummaryStep. |
+
+## Rollout Notes
+
+- No configuration changes needed. The optimization activates when plugins pass `embeddings_port`.
+- No migration needed. The pipeline output is identical.
+- Performance: wall-clock improvement is proportional to the number of documents summarized. Each document's chunks start embedding as soon as its summary is done instead of waiting for all summaries.

--- a/plugins/ingest_space/plugin.py
+++ b/plugins/ingest_space/plugin.py
@@ -89,6 +89,7 @@ class IngestSpacePlugin:
                 DocumentSummaryStep(
                     llm_port=summary_llm,
                     chunk_threshold=self._chunk_threshold,
+                    embeddings_port=self._embeddings,
                 ),
                 BodyOfKnowledgeSummaryStep(llm_port=self._bok_llm or summary_llm),
                 EmbedStep(embeddings_port=self._embeddings),

--- a/plugins/ingest_website/plugin.py
+++ b/plugins/ingest_website/plugin.py
@@ -104,6 +104,7 @@ class IngestWebsitePlugin:
                     llm_port=summary_llm,
                     concurrency=config.summarize_concurrency,
                     chunk_threshold=self._chunk_threshold,
+                    embeddings_port=self._embeddings,
                 ))
                 bok_llm = self._bok_llm or summary_llm
                 steps.append(BodyOfKnowledgeSummaryStep(llm_port=bok_llm))

--- a/spec.md
+++ b/spec.md
@@ -1,0 +1,41 @@
+# Spec: Incremental Embedding -- Embed Documents as They Finish Summarization
+
+**Story:** alkem-io/alkemio#1826
+**Date:** 2026-04-08
+
+## User Value
+
+Reduce ingest pipeline wall-clock time by overlapping summarization I/O (LLM-bound) with embedding I/O (GPU-bound). Currently, all chunks sit idle after their document's summary completes, waiting for every other document to finish summarization before embedding begins. Incremental embedding eliminates this idle time.
+
+## Scope
+
+- Modify `DocumentSummaryStep` to accept an `EmbeddingsPort` and embed each document's chunks immediately after that document's summary completes.
+- The BoK summary chunk and any other summary chunks produced during summarization are also embedded incrementally within the same step.
+- `EmbedStep` continues to exist and runs after `BodyOfKnowledgeSummaryStep` to embed any remaining chunks that were not embedded incrementally (e.g., chunks from documents below the summarization threshold, the BoK summary chunk itself, or documents that were skipped by change detection).
+- No changes to the pipeline engine (`IngestEngine`) -- the step sequence remains ordered; the optimization is within `DocumentSummaryStep`.
+- No changes to `PipelineContext`, `Chunk`, or `IngestResult` data models.
+- No changes to `StoreStep`, `OrphanCleanupStep`, or `ChangeDetectionStep`.
+
+## Out of Scope
+
+- Streaming pipeline redesign (Option C from the issue).
+- Background embedding worker / async queue (Option B from the issue).
+- Concurrent summarization (covered by sibling story #1823).
+- Changes to the pipeline engine's step execution model (remains sequential).
+
+## Acceptance Criteria
+
+1. After `DocumentSummaryStep` finishes summarizing a document, that document's content chunks and its summary chunk have embeddings set (not `None`).
+2. `EmbedStep` skips chunks that already have embeddings (existing behavior), so no double-embedding occurs.
+3. Pipeline produces identical final output (stored chunks, embeddings, summaries) as the current sequential approach.
+4. Documents below the chunk threshold (not summarized) still get embedded by `EmbedStep` as before.
+5. If embedding fails for a document's chunks during `DocumentSummaryStep`, the error is recorded in `context.errors` and the chunks are left without embeddings for `EmbedStep` to retry.
+6. All existing tests continue to pass.
+7. New tests cover the incremental embedding path: embedding happens per-document after summarization, EmbedStep correctly skips pre-embedded chunks.
+
+## Constraints
+
+- Must follow Option A (per-document embed after summary) as stated in the issue.
+- Must maintain backward compatibility: `DocumentSummaryStep` with no `embeddings_port` argument must work identically to today (no embedding performed).
+- Must preserve the duck-typed `PipelineStep` protocol -- no base class changes.
+- Must not alter the `EmbeddingsPort` protocol.

--- a/tasks.md
+++ b/tasks.md
@@ -1,0 +1,81 @@
+# Tasks: Incremental Embedding -- Embed Documents as They Finish Summarization
+
+**Story:** alkem-io/alkemio#1826
+**Date:** 2026-04-08
+
+## Task List (dependency-ordered)
+
+### T1: Add optional `embeddings_port` and `embed_batch_size` to `DocumentSummaryStep.__init__`
+
+**File:** `core/domain/pipeline/steps.py`
+**Depends on:** none
+**Acceptance criteria:**
+- `DocumentSummaryStep` accepts optional `embeddings_port: EmbeddingsPort | None = None` and `embed_batch_size: int = 50`.
+- Stored as instance attributes `_embeddings` and `_embed_batch_size`.
+- Existing constructor calls (without these args) continue to work.
+**Test:** `test_no_embed_when_port_is_none` -- instantiate without embeddings_port, verify chunks have no embeddings after execute.
+
+### T2: Implement per-document incremental embedding in `DocumentSummaryStep.execute`
+
+**File:** `core/domain/pipeline/steps.py`
+**Depends on:** T1
+**Acceptance criteria:**
+- After each document's summary is produced and appended to `context.chunks`, if `self._embeddings` is not None:
+  1. Collect the document's content chunks where `embedding is None`.
+  2. Collect the just-appended summary chunk.
+  3. Embed all collected chunks in batches via `self._embeddings.embed()`.
+  4. Assign embeddings to chunks.
+- On embedding failure, append error to `context.errors` with prefix `DocumentSummaryStep`, and leave chunks unembedded.
+**Tests:**
+- `test_incremental_embed_after_summary`
+- `test_incremental_embed_summary_chunk`
+- `test_incremental_embed_skips_preloaded`
+- `test_incremental_embed_error_recorded`
+- `test_below_threshold_not_embedded_by_summary_step`
+
+### T3: Update `ingest_space` plugin to pass `embeddings_port`
+
+**File:** `plugins/ingest_space/plugin.py`
+**Depends on:** T1
+**Acceptance criteria:**
+- `DocumentSummaryStep` constructor call includes `embeddings_port=self._embeddings`.
+**Test:** Existing integration tests pass; no new test needed (plugin wiring is covered by existing test_ingest_space.py).
+
+### T4: Update `ingest_website` plugin to pass `embeddings_port`
+
+**File:** `plugins/ingest_website/plugin.py`
+**Depends on:** T1
+**Acceptance criteria:**
+- `DocumentSummaryStep` constructor call includes `embeddings_port=self._embeddings`.
+**Test:** Existing integration tests pass; no new test needed.
+
+### T5: Write new unit tests for incremental embedding
+
+**File:** `tests/core/domain/test_pipeline_steps.py`
+**Depends on:** T2
+**Acceptance criteria:**
+- All tests from the Test Strategy in plan.md are implemented and pass.
+- Tests use `MockEmbeddingsPort` and `MockLLMPort` from conftest.
+**Tests:**
+- `test_incremental_embed_after_summary`
+- `test_incremental_embed_summary_chunk`
+- `test_no_embed_when_port_is_none`
+- `test_incremental_embed_skips_preloaded`
+- `test_incremental_embed_error_recorded`
+- `test_below_threshold_not_embedded_by_summary_step`
+
+### T6: Write integration test for EmbedStep skip behavior
+
+**File:** `tests/core/domain/test_pipeline_steps.py`
+**Depends on:** T2, T5
+**Acceptance criteria:**
+- `test_embed_step_skips_incrementally_embedded`: Run DocumentSummaryStep with embeddings_port, then run EmbedStep. Verify EmbedStep's embeddings port receives zero calls for already-embedded chunks.
+**Test:** `test_embed_step_skips_incrementally_embedded`
+
+### T7: Verify all existing tests pass
+
+**Depends on:** T1-T6
+**Acceptance criteria:**
+- `poetry run pytest` passes with zero failures.
+- `poetry run ruff check core/ plugins/ tests/` passes.
+- `poetry run pyright core/ plugins/` passes.

--- a/tests/core/domain/test_pipeline_steps.py
+++ b/tests/core/domain/test_pipeline_steps.py
@@ -1117,3 +1117,202 @@ class TestPipelineIntegration:
         remaining_doc_ids = {it["metadata"].get("documentId") for it in remaining}
         assert "doc-b" not in remaining_doc_ids
         assert "doc-a" in remaining_doc_ids
+
+
+# ---------------------------------------------------------------------------
+# Incremental embedding tests (story #1826)
+# ---------------------------------------------------------------------------
+
+
+class TestDocumentSummaryStepIncrementalEmbed:
+    """Tests for per-document incremental embedding within DocumentSummaryStep."""
+
+    async def test_incremental_embed_after_summary(self):
+        """When embeddings_port is provided, summarized documents' content chunks
+        have embeddings set after execute()."""
+        llm = MockLLMPort(response="Generated summary")
+        embeddings = MockEmbeddingsPort()
+        ctx = _make_context()
+        await ChunkStep(chunk_size=100, chunk_overlap=10).execute(ctx)
+        assert len(ctx.chunks) > 3
+
+        step = DocumentSummaryStep(
+            llm_port=llm,
+            embeddings_port=embeddings,
+        )
+        await step.execute(ctx)
+
+        # All content chunks for doc-1 should now have embeddings
+        content_chunks = [
+            c for c in ctx.chunks
+            if c.metadata.document_id == "doc-1"
+            and c.metadata.embedding_type == "chunk"
+        ]
+        assert len(content_chunks) > 0
+        assert all(c.embedding is not None for c in content_chunks)
+
+    async def test_incremental_embed_summary_chunk(self):
+        """The summary chunk itself is also embedded incrementally."""
+        llm = MockLLMPort(response="Generated summary")
+        embeddings = MockEmbeddingsPort()
+        ctx = _make_context()
+        await ChunkStep(chunk_size=100, chunk_overlap=10).execute(ctx)
+
+        step = DocumentSummaryStep(
+            llm_port=llm,
+            embeddings_port=embeddings,
+        )
+        await step.execute(ctx)
+
+        summary_chunks = [
+            c for c in ctx.chunks if c.metadata.embedding_type == "summary"
+        ]
+        assert len(summary_chunks) == 1
+        assert summary_chunks[0].embedding is not None
+
+    async def test_no_embed_when_port_is_none(self):
+        """Without embeddings_port, chunks remain unembedded (backward compat)."""
+        llm = MockLLMPort(response="Generated summary")
+        ctx = _make_context()
+        await ChunkStep(chunk_size=100, chunk_overlap=10).execute(ctx)
+
+        step = DocumentSummaryStep(llm_port=llm)
+        await step.execute(ctx)
+
+        content_chunks = [
+            c for c in ctx.chunks if c.metadata.embedding_type == "chunk"
+        ]
+        assert all(c.embedding is None for c in content_chunks)
+
+    async def test_incremental_embed_skips_preloaded(self):
+        """Chunks with pre-loaded embeddings (e.g. from ChangeDetection) are not
+        re-embedded by incremental embedding."""
+        llm = MockLLMPort(response="Summary text")
+        embeddings = MockEmbeddingsPort()
+
+        meta = DocumentMetadata(
+            document_id="doc-1", source="s", type="knowledge",
+            title="T", embedding_type="chunk",
+        )
+        # Create 5 chunks, pre-load embedding on first 2
+        chunks = []
+        for i in range(5):
+            c = Chunk(content=f"chunk content {i}", metadata=meta, chunk_index=i)
+            if i < 2:
+                c.embedding = [99.0] * 384  # pre-loaded
+            chunks.append(c)
+
+        ctx = PipelineContext(
+            collection_name="test", documents=[], chunks=chunks,
+        )
+
+        step = DocumentSummaryStep(
+            llm_port=llm,
+            embeddings_port=embeddings,
+            chunk_threshold=4,
+        )
+        await step.execute(ctx)
+
+        # Pre-loaded chunks keep their original embeddings
+        assert chunks[0].embedding == [99.0] * 384
+        assert chunks[1].embedding == [99.0] * 384
+        # Non-pre-loaded chunks got new embeddings
+        assert chunks[2].embedding is not None
+        assert chunks[2].embedding != [99.0] * 384
+        # Summary chunk also embedded
+        summary_chunks = [
+            c for c in ctx.chunks if c.metadata.embedding_type == "summary"
+        ]
+        assert len(summary_chunks) == 1
+        assert summary_chunks[0].embedding is not None
+
+        # Verify embed was called only with the 3 non-preloaded content chunks + 1 summary = 4 texts
+        all_embed_texts = [text for call in embeddings.calls for text in call]
+        assert len(all_embed_texts) == 4
+
+    async def test_incremental_embed_error_recorded(self):
+        """Embedding failure is recorded in context.errors; chunks left for
+        EmbedStep retry."""
+        llm = MockLLMPort(response="Summary text")
+
+        class FailingEmbeddings:
+            async def embed(self, texts):
+                raise RuntimeError("GPU out of memory")
+
+        meta = DocumentMetadata(
+            document_id="doc-1", source="s", type="knowledge",
+            title="T", embedding_type="chunk",
+        )
+        chunks = [
+            Chunk(content=f"chunk {i}", metadata=meta, chunk_index=i)
+            for i in range(5)
+        ]
+        ctx = PipelineContext(
+            collection_name="test", documents=[], chunks=chunks,
+        )
+
+        step = DocumentSummaryStep(
+            llm_port=llm,
+            embeddings_port=FailingEmbeddings(),  # type: ignore[arg-type]
+            chunk_threshold=4,
+        )
+        await step.execute(ctx)
+
+        # Error should be recorded
+        embed_errors = [e for e in ctx.errors if "incremental embedding" in e]
+        assert len(embed_errors) > 0
+        assert "GPU out of memory" in embed_errors[0]
+        # Chunks should remain unembedded (available for EmbedStep retry)
+        content_chunks = [
+            c for c in ctx.chunks if c.metadata.embedding_type == "chunk"
+        ]
+        assert all(c.embedding is None for c in content_chunks)
+
+    async def test_below_threshold_not_embedded_by_summary_step(self):
+        """Documents below chunk_threshold are not summarized and therefore
+        not embedded by DocumentSummaryStep."""
+        llm = MockLLMPort(response="Summary")
+        embeddings = MockEmbeddingsPort()
+
+        doc = _make_doc(content="Short text.")
+        ctx = _make_context([doc])
+        await ChunkStep(chunk_size=10000).execute(ctx)
+        assert len(ctx.chunks) <= 3
+
+        step = DocumentSummaryStep(
+            llm_port=llm,
+            embeddings_port=embeddings,
+        )
+        await step.execute(ctx)
+
+        # No embedding calls should have been made
+        assert len(embeddings.calls) == 0
+        assert all(c.embedding is None for c in ctx.chunks)
+
+    async def test_embed_step_skips_incrementally_embedded(self):
+        """Integration: run DocumentSummaryStep with embeddings_port, then run
+        EmbedStep. EmbedStep should only embed chunks not already handled."""
+        llm = MockLLMPort(response="Summary text")
+        summary_embeddings = MockEmbeddingsPort()
+        embed_step_embeddings = MockEmbeddingsPort()
+
+        ctx = _make_context()
+        await ChunkStep(chunk_size=100, chunk_overlap=10).execute(ctx)
+        assert len(ctx.chunks) > 3
+
+        # Run DocumentSummaryStep with incremental embedding
+        await DocumentSummaryStep(
+            llm_port=llm,
+            embeddings_port=summary_embeddings,
+        ).execute(ctx)
+
+        # All chunks from doc-1 + summary should already be embedded
+        chunks_after_summary = len(ctx.chunks)
+        embedded_count = sum(1 for c in ctx.chunks if c.embedding is not None)
+        assert embedded_count == chunks_after_summary
+
+        # Now run EmbedStep — it should have nothing to embed
+        await EmbedStep(embeddings_port=embed_step_embeddings).execute(ctx)
+
+        # EmbedStep's port should have received zero embed calls
+        assert len(embed_step_embeddings.calls) == 0


### PR DESCRIPTION
## Summary

- **DocumentSummaryStep** now accepts an optional `embeddings_port` parameter. When provided, each document's content chunks and its summary chunk are embedded immediately after that document's summarization completes, overlapping LLM-bound summarization I/O with GPU-bound embedding I/O.
- Both `ingest_space` and `ingest_website` plugins pass `embeddings_port` to activate the optimization.
- `EmbedStep` continues to serve as a fallback for remaining unembedded chunks (below-threshold docs, BoK summary).

Closes alkem-io/alkemio#1826
Parent: alkem-io/alkemio#1820

## Artifacts

- `spec.md` -- specification
- `plan.md` -- architecture and test strategy
- `tasks.md` -- task breakdown

## SDD Loop Counts

- Clarify iterations: 2
- Analyze iterations: 2

## Changed Files

| File | Change |
|------|--------|
| `core/domain/pipeline/steps.py` | Added optional `embeddings_port`/`embed_batch_size` to `DocumentSummaryStep`; added `_embed_chunks` helper; embed per-document after summarization |
| `plugins/ingest_space/plugin.py` | Pass `embeddings_port=self._embeddings` to `DocumentSummaryStep` |
| `plugins/ingest_website/plugin.py` | Pass `embeddings_port=self._embeddings` to `DocumentSummaryStep` |
| `tests/core/domain/test_pipeline_steps.py` | 7 new tests covering incremental embedding, backward compat, skip preloaded, error handling, EmbedStep integration |

## Test plan

- [x] All 339 existing tests pass (0 failures)
- [x] 7 new incremental embedding tests pass
- [x] Ruff lint: clean
- [x] Pyright: 0 errors (41 pre-existing warnings, none new)
- [ ] Manual verification with real ingest pipeline (staging environment)

Generated with [Claude Code](https://claude.com/claude-code)