### PR TITLE
feat: formalize destructive pipeline step handling

### DIFF
--- a/core/domain/pipeline/engine.py
+++ b/core/domain/pipeline/engine.py
@@ -14,6 +14,20 @@ logger = logging.getLogger(__name__)
 
 @runtime_checkable
 class PipelineStep(Protocol):
+    """A single stage in the ingestion pipeline.
+
+    Required members:
+        name: Human-readable step identifier used in logs and metrics.
+        execute: Async method that receives the shared PipelineContext.
+
+    Optional class attribute:
+        destructive (bool): Set to ``True`` on steps that delete or remove
+        data from the knowledge store (e.g. OrphanCleanupStep).  The engine
+        will skip destructive steps when prior steps have recorded errors in
+        ``context.errors``, preventing data loss after partial write failures.
+        Steps that do not declare this attribute are treated as non-destructive.
+    """
+
     @property
     def name(self) -> str: ...
 
@@ -65,6 +79,23 @@ class IngestEngine:
         for step in self._steps:
             items_before = len(context.chunks)
             errors_before = len(context.errors)
+
+            # Gate destructive steps on prior errors to prevent data loss.
+            if getattr(step, "destructive", False) and context.errors:
+                msg = (
+                    f"{step.name}: skipped (destructive step gated by "
+                    f"{len(context.errors)} prior error(s))"
+                )
+                context.errors.append(msg)
+                logger.warning(msg)
+                context.metrics[step.name] = StepMetrics(
+                    duration=0.0,
+                    items_in=items_before,
+                    items_out=items_before,
+                    error_count=1,
+                )
+                continue
+
             start = time.monotonic()
 
             try:

--- a/core/domain/pipeline/steps.py
+++ b/core/domain/pipeline/steps.py
@@ -510,7 +510,14 @@ class StoreStep:
 
 
 class OrphanCleanupStep:
-    """Delete orphaned chunks and chunks from removed documents."""
+    """Delete orphaned chunks and chunks from removed documents.
+
+    Declares ``destructive = True`` so the engine skips this step when
+    prior steps have recorded errors, preventing data loss after partial
+    write failures.
+    """
+
+    destructive = True
 
     def __init__(self, knowledge_store_port: KnowledgeStorePort) -> None:
         self._store = knowledge_store_port
@@ -520,12 +527,6 @@ class OrphanCleanupStep:
         return "orphan_cleanup"
 
     async def execute(self, context: PipelineContext) -> None:
-        if any(e.startswith("StoreStep:") for e in context.errors):
-            context.errors.append(
-                "OrphanCleanupStep: skipped cleanup because earlier storage writes failed"
-            )
-            return
-
         deleted = 0
 
         # Delete orphan chunk IDs

--- a/specs/037-pipeline-engine-destructive-step-safety/clarifications.md
+++ b/specs/037-pipeline-engine-destructive-step-safety/clarifications.md
@@ -1,0 +1,55 @@
+# Clarifications
+
+**Story**: #37  
+**Iteration**: 1  
+
+---
+
+## Resolved Ambiguities
+
+### C1: How should the optional `destructive` property work with the Protocol?
+
+**Question**: Python `Protocol` classes require all declared members to be present for `isinstance()` checks. If we add `destructive` to `PipelineStep`, existing steps (and test doubles) without it will fail `isinstance(step, PipelineStep)`.
+
+**Chosen Answer**: Do NOT add `destructive` to the `PipelineStep` protocol definition. Instead, use `getattr(step, "destructive", False)` in `IngestEngine.run()` to check for the property at runtime. This keeps the protocol backward-compatible. Steps that want to be destructive add `destructive = True` as a class attribute.
+
+**Rationale**: The codebase already uses `@runtime_checkable` Protocol with duck typing. Adding an optional attribute to the protocol would break the contract. Using `getattr` with a default is the standard Python duck-typing pattern and is consistent with how the codebase handles optional attributes elsewhere (e.g., `getattr(getattr(llm_port, "_llm", None), "model", "unknown")` in DocumentSummaryStep).
+
+### C2: Should the skip message be appended as an error or handled differently?
+
+**Question**: When a destructive step is skipped, should the skip notification be appended to `context.errors` (making `IngestResult.success=False`) or tracked separately?
+
+**Chosen Answer**: Append to `context.errors`. The skip itself is a consequence of earlier errors, and the pipeline already has errors. The message serves as an audit trail explaining why cleanup did not happen. Since `success` is already `False` due to the triggering errors, this does not change the result status.
+
+**Rationale**: Keeping it in `context.errors` is consistent with how OrphanCleanupStep currently records its skip message. It also ensures operators see the skip in the standard error report without needing a separate field.
+
+### C3: What format should the skip message use?
+
+**Question**: What prefix/format should the engine-level skip message follow?
+
+**Chosen Answer**: Use the format `"{step.name}: skipped (destructive step gated by {N} prior error(s))"` where N is `len(context.errors)`. This follows the existing convention of `"{StepName}: description"` prefixes used throughout steps.py.
+
+**Rationale**: Consistent with existing error message format (`StoreStep: storage failed...`, `EmbedStep: embedding failed...`). Including the error count gives operators actionable context.
+
+### C4: Should `StepMetrics` be recorded for skipped destructive steps?
+
+**Question**: When a destructive step is skipped, should the engine still record `StepMetrics` for it?
+
+**Chosen Answer**: Yes. Record `StepMetrics` with `duration=0.0`, `items_in` and `items_out` equal to the current chunk count, and `error_count=1` (the skip message). This ensures metrics remain complete for monitoring/debugging.
+
+**Rationale**: The engine currently records metrics for every step, including those that raise exceptions. Skipped steps should be equally visible in the metrics dict.
+
+### C5: Should the `destructive` property also be exposed as a Protocol documentation or only engine behavior?
+
+**Question**: Should we document the `destructive` concept in the PipelineStep Protocol docstring even though it is not a protocol member?
+
+**Chosen Answer**: Yes. Add a docstring note to the `PipelineStep` Protocol class explaining that steps can optionally declare `destructive = True` as a class attribute, and that the engine will gate them on prior errors.
+
+**Rationale**: Protocol documentation is the natural place for pipeline authors to learn about available step behaviors. Without this documentation, the feature is invisible to future contributors.
+
+---
+
+## Iteration Summary
+
+- 5 ambiguities identified and resolved.
+- No remaining unknowns.

--- a/specs/037-pipeline-engine-destructive-step-safety/plan.md
+++ b/specs/037-pipeline-engine-destructive-step-safety/plan.md
@@ -1,0 +1,61 @@
+# Plan: Pipeline Engine Safety -- Formalize Destructive Step Handling
+
+**Story**: #37  
+**Status**: Draft  
+**Date**: 2026-04-08  
+
+---
+
+## Architecture
+
+The change is localized to the pipeline engine layer. No new modules, ports, adapters, or dependencies are introduced.
+
+### Design
+
+The `IngestEngine.run()` loop gains a pre-execution check: before calling `step.execute(context)`, it inspects `getattr(step, "destructive", False)`. If `True` and `context.errors` is non-empty, the step is skipped, a message is appended to `context.errors`, and `StepMetrics` are recorded with `error_count=1`.
+
+`OrphanCleanupStep` gains a class-level `destructive = True` attribute and its `execute()` method loses the `any(e.startswith("StoreStep:") ...)` guard.
+
+### Affected Modules
+
+| Module | Change |
+|--------|--------|
+| `core/domain/pipeline/engine.py` | Add destructive-step gating logic to `IngestEngine.run()`. Add docstring to `PipelineStep` protocol. |
+| `core/domain/pipeline/steps.py` | Add `destructive = True` to `OrphanCleanupStep`. Remove string-matching guard from `execute()`. |
+| `tests/core/domain/test_pipeline_steps.py` | Update `test_skips_cleanup_on_store_step_errors` to test via engine. Add new `TestDestructiveStepGating` class with engine-level tests. |
+
+### Data Model Deltas
+
+None. No changes to `PipelineContext`, `StepMetrics`, `IngestResult`, or any domain models.
+
+### Interface Contracts
+
+**PipelineStep protocol** -- no formal change to the protocol definition. The `destructive` attribute is opt-in via duck typing (checked with `getattr`).
+
+**IngestEngine.run()** -- behavior change: destructive steps are now conditionally skipped. This is backward-compatible because:
+- Steps without `destructive` attribute default to `False` (non-destructive).
+- The skip behavior only activates when `context.errors` is non-empty.
+- The IngestResult contract is unchanged.
+
+### Test Strategy
+
+1. **Unit tests (engine level)**: New `TestDestructiveStepGating` class with test doubles:
+   - Destructive step skipped when errors exist
+   - Destructive step runs when no errors exist
+   - Non-destructive steps still run when errors exist
+   - Multiple destructive steps -- all skipped when errors exist
+   - Metrics recorded for skipped destructive steps
+   - Steps without `destructive` attribute treated as non-destructive
+
+2. **Unit tests (step level)**: Update `TestOrphanCleanupStep`:
+   - `test_skips_cleanup_on_store_step_errors`: Rewrite to test via engine integration (errors from any step gate OrphanCleanupStep)
+   - Verify `destructive` attribute is `True` on the class
+   - Verify `execute()` no longer contains string-matching guard (tested indirectly: even non-StoreStep errors cause skip when routed through engine)
+
+3. **Integration tests**: Existing `TestPipelineIntegration` tests continue to pass unchanged (they use full pipelines with OrphanCleanupStep).
+
+### Rollout Notes
+
+- Zero-downtime: No config changes, no migration, no wire-format changes.
+- Backward-compatible: Existing pipelines work identically. Only behavior change is that OrphanCleanupStep skip is now engine-driven rather than self-driven.
+- The string-matching guard removal means that if someone calls `OrphanCleanupStep.execute()` directly (outside the engine) with prior errors, cleanup will no longer be self-guarded. This is acceptable because the engine is the only execution path.

--- a/specs/037-pipeline-engine-destructive-step-safety/spec.md
+++ b/specs/037-pipeline-engine-destructive-step-safety/spec.md
@@ -1,0 +1,49 @@
+# Spec: Pipeline Engine Safety -- Formalize Destructive Step Handling
+
+**Story**: #37  
+**Status**: Draft  
+**Author**: SDD Agent  
+**Date**: 2026-04-08  
+
+---
+
+## User Value
+
+Pipeline authors and operators gain confidence that destructive steps (e.g., OrphanCleanupStep) will never execute when earlier write steps had partial failures. Today, this safety depends on a fragile string-matching guard inside OrphanCleanupStep that checks for a `StoreStep:` prefix in `context.errors`. This story replaces that ad-hoc guard with a first-class, engine-level mechanism that generalizes to any current or future destructive step.
+
+## Scope
+
+1. Extend the `PipelineStep` protocol with an optional `destructive: bool` property (defaulting to `False`) so steps can self-declare as destructive.
+2. Update `IngestEngine.run()` to check `context.errors` before executing any step whose `destructive` property is `True`, and skip it with a logged warning and recorded error when errors exist.
+3. Update `OrphanCleanupStep` to declare `destructive = True` and remove the current string-matching guard from its `execute()` method.
+4. Add/update tests covering the new engine-level gating behavior.
+
+## Out of Scope
+
+- Phase-based execution grouping (analyze/write/cleanup phases) -- more complex than needed for the current requirement.
+- Automatic rollback of partially written data on step failure.
+- Changes to any step other than `OrphanCleanupStep` (no other step is currently destructive).
+- Changes to the plugin assembly code in `ingest_website` or `ingest_space` plugins (no changes needed since the behavior is engine-level).
+
+## Acceptance Criteria
+
+1. **AC1**: `PipelineStep` protocol has an optional `destructive` property. Steps not declaring it are treated as non-destructive (`False`).
+2. **AC2**: `IngestEngine.run()` skips any step with `destructive=True` when `context.errors` is non-empty, appends a skip message to `context.errors`, and logs at WARNING level.
+3. **AC3**: `OrphanCleanupStep` declares `destructive = True` as a class-level attribute and no longer contains string-matching logic against `context.errors`.
+4. **AC4**: Existing tests for OrphanCleanupStep that validated the string-matching guard (`test_skips_cleanup_on_store_step_errors`) are updated to validate engine-level gating instead.
+5. **AC5**: New engine-level tests verify: (a) destructive steps are skipped when errors exist, (b) destructive steps run normally when no errors exist, (c) non-destructive steps still run even when errors exist, (d) metrics are recorded for skipped destructive steps.
+6. **AC6**: All existing tests continue to pass without modification (except those testing the removed string-matching guard).
+7. **AC7**: `IngestResult.success` remains `False` when errors exist, regardless of whether destructive steps were skipped.
+
+## Constraints
+
+- The `PipelineStep` protocol must remain `@runtime_checkable` and duck-typed. The `destructive` property must be optional -- steps without it must not break.
+- No changes to `PipelineContext` fields.
+- The skip message appended to `context.errors` must clearly identify the skipped step and the reason.
+- The solution must work with the existing `RecordingStep` and other test doubles that do not declare `destructive`.
+
+## Glossary
+
+- **Destructive step**: A pipeline step that deletes or removes data from the knowledge store. Running such a step after partial write failures could cause data loss.
+- **Error gate**: The engine-level check that prevents destructive steps from executing when prior steps have recorded errors.
+- **Write phase**: The portion of the pipeline that persists data (EmbedStep, StoreStep). Errors here trigger the error gate for subsequent destructive steps.

--- a/specs/037-pipeline-engine-destructive-step-safety/tasks.md
+++ b/specs/037-pipeline-engine-destructive-step-safety/tasks.md
@@ -1,0 +1,90 @@
+# Tasks: Pipeline Engine Safety -- Formalize Destructive Step Handling
+
+**Story**: #37  
+**Status**: Draft  
+**Date**: 2026-04-08  
+
+---
+
+## Task List
+
+### T1: Add destructive-step gating to IngestEngine.run()
+
+**File**: `core/domain/pipeline/engine.py`  
+**Depends on**: None  
+**Acceptance criteria**:
+- Before calling `step.execute(context)`, engine checks `getattr(step, "destructive", False)`.
+- If `True` and `len(context.errors) > 0`, the step is skipped.
+- A skip message is appended to `context.errors` in format: `"{step.name}: skipped (destructive step gated by {N} prior error(s))"`.
+- A WARNING-level log is emitted.
+- `StepMetrics` are recorded with `duration=0.0`, `items_in`/`items_out` = current chunk count, `error_count=1`.
+- Steps without `destructive` attribute or with `destructive=False` execute normally regardless of errors.
+**Tests**: T4
+
+### T2: Add docstring to PipelineStep protocol
+
+**File**: `core/domain/pipeline/engine.py`  
+**Depends on**: T1  
+**Acceptance criteria**:
+- `PipelineStep` protocol class has a docstring explaining the optional `destructive` attribute.
+- Docstring explains engine gating behavior.
+**Tests**: None (documentation only)
+
+### T3: Update OrphanCleanupStep to use engine-level gating
+
+**File**: `core/domain/pipeline/steps.py`  
+**Depends on**: T1  
+**Acceptance criteria**:
+- `OrphanCleanupStep` has `destructive = True` as a class-level attribute (not a property).
+- The `any(e.startswith("StoreStep:") ...)` guard is removed from `execute()`.
+- The "skipped cleanup because earlier storage writes failed" error append is removed from `execute()`.
+- `execute()` runs its cleanup logic unconditionally (engine handles gating).
+**Tests**: T5
+
+### T4: Add engine-level destructive step gating tests
+
+**File**: `tests/core/domain/test_pipeline_steps.py`  
+**Depends on**: T1  
+**Acceptance criteria**:
+- New `TestDestructiveStepGating` class with the following tests:
+  - `test_destructive_step_skipped_when_errors_exist`: Destructive step does not execute when context has errors.
+  - `test_destructive_step_runs_when_no_errors`: Destructive step executes normally when no errors.
+  - `test_non_destructive_steps_run_despite_errors`: Steps without `destructive` attribute still execute when errors exist.
+  - `test_skip_message_format`: Skip message matches expected format and is appended to errors.
+  - `test_metrics_recorded_for_skipped_step`: Skipped destructive step has metrics with error_count=1 and duration~0.
+  - `test_multiple_destructive_steps_all_skipped`: Multiple destructive steps in a pipeline are all skipped when errors exist.
+  - `test_destructive_false_treated_as_non_destructive`: Steps with explicit `destructive = False` still run.
+**Tests**: Self (these are the tests)
+
+### T5: Update OrphanCleanupStep tests for engine-level gating
+
+**File**: `tests/core/domain/test_pipeline_steps.py`  
+**Depends on**: T3  
+**Acceptance criteria**:
+- `test_skips_cleanup_on_store_step_errors` is rewritten to test via `IngestEngine`: a pipeline with a failing step before `OrphanCleanupStep` results in OrphanCleanupStep being skipped.
+- New test `test_orphan_cleanup_has_destructive_attribute`: Verifies `OrphanCleanupStep.destructive is True`.
+- New test `test_orphan_cleanup_runs_when_no_errors_via_engine`: OrphanCleanupStep runs normally in a clean pipeline.
+- Existing direct-call tests (`test_orphan_deletion`, `test_removed_document_cleanup`, `test_idempotent_on_empty_sets`) are unchanged.
+**Tests**: Self (these are the tests)
+
+---
+
+## Dependency Order
+
+```
+T1 (engine gating) --> T2 (docstring)
+T1 (engine gating) --> T3 (OrphanCleanupStep update) --> T5 (OrphanCleanupStep tests)
+T1 (engine gating) --> T4 (engine gating tests)
+```
+
+T4 and T3 can execute in parallel after T1.
+T2 can execute any time after T1.
+T5 executes after T3.
+
+## Execution Order
+
+1. T1 -- Engine gating logic
+2. T2 -- Protocol docstring (parallel with T3, T4)
+3. T3 -- OrphanCleanupStep update (parallel with T2, T4)
+4. T4 -- Engine gating tests (parallel with T2, T3)
+5. T5 -- OrphanCleanupStep test updates (after T3)

--- a/tests/core/domain/test_pipeline_steps.py
+++ b/tests/core/domain/test_pipeline_steps.py
@@ -568,6 +568,254 @@ class TestIngestEngine:
 
 
 # ---------------------------------------------------------------------------
+# Destructive step gating tests (Story #37)
+# ---------------------------------------------------------------------------
+
+
+class TestDestructiveStepGating:
+    """Engine-level tests for the destructive-step error gate."""
+
+    async def test_destructive_step_skipped_when_errors_exist(self):
+        """A step with destructive=True is skipped when context.errors is non-empty."""
+        executed = []
+
+        class ErrorStep:
+            @property
+            def name(self):
+                return "error_producer"
+
+            async def execute(self, context):
+                raise RuntimeError("something broke")
+
+        class DestructiveStep:
+            destructive = True
+
+            @property
+            def name(self):
+                return "cleanup"
+
+            async def execute(self, context):
+                executed.append("cleanup")
+
+        engine = IngestEngine(steps=[
+            ErrorStep(),  # type: ignore[list-item]
+            DestructiveStep(),  # type: ignore[list-item]
+        ])
+        result = await engine.run([], "test")
+
+        assert "cleanup" not in executed
+        assert result.success is False
+        assert any("skipped (destructive step gated by" in e for e in result.errors)
+
+    async def test_destructive_step_runs_when_no_errors(self):
+        """A step with destructive=True runs normally when no prior errors."""
+        executed = []
+
+        class SafeStep:
+            @property
+            def name(self):
+                return "safe"
+
+            async def execute(self, context):
+                executed.append("safe")
+
+        class DestructiveStep:
+            destructive = True
+
+            @property
+            def name(self):
+                return "cleanup"
+
+            async def execute(self, context):
+                executed.append("cleanup")
+
+        engine = IngestEngine(steps=[
+            SafeStep(),  # type: ignore[list-item]
+            DestructiveStep(),  # type: ignore[list-item]
+        ])
+        result = await engine.run([], "test")
+
+        assert "cleanup" in executed
+        assert result.success is True
+
+    async def test_non_destructive_steps_run_despite_errors(self):
+        """Steps without destructive attribute still execute when errors exist."""
+        executed = []
+
+        class ErrorStep:
+            @property
+            def name(self):
+                return "error_producer"
+
+            async def execute(self, context):
+                raise RuntimeError("broke")
+
+        class NormalStep:
+            @property
+            def name(self):
+                return "normal"
+
+            async def execute(self, context):
+                executed.append("normal")
+
+        engine = IngestEngine(steps=[
+            ErrorStep(),  # type: ignore[list-item]
+            NormalStep(),  # type: ignore[list-item]
+        ])
+        result = await engine.run([], "test")
+
+        assert "normal" in executed
+        assert result.success is False
+
+    async def test_skip_message_format(self):
+        """Skip message includes step name and error count."""
+        class ErrorStep:
+            @property
+            def name(self):
+                return "writer"
+
+            async def execute(self, context):
+                raise RuntimeError("fail1")
+
+        class DestructiveStep:
+            destructive = True
+
+            @property
+            def name(self):
+                return "cleanup"
+
+            async def execute(self, context):
+                pass
+
+        engine = IngestEngine(steps=[
+            ErrorStep(),  # type: ignore[list-item]
+            DestructiveStep(),  # type: ignore[list-item]
+        ])
+        result = await engine.run([], "test")
+
+        skip_msgs = [e for e in result.errors if "skipped" in e]
+        assert len(skip_msgs) == 1
+        assert "cleanup: skipped (destructive step gated by 1 prior error(s))" == skip_msgs[0]
+
+    async def test_metrics_recorded_for_skipped_step(self):
+        """Skipped destructive steps have metrics with error_count=1 and duration=0."""
+        class ErrorStep:
+            @property
+            def name(self):
+                return "writer"
+
+            async def execute(self, context):
+                raise RuntimeError("fail")
+
+        class DestructiveStep:
+            destructive = True
+
+            @property
+            def name(self):
+                return "cleanup"
+
+            async def execute(self, context):
+                pass
+
+        captured_metrics: dict = {}
+
+        class MetricReader:
+            @property
+            def name(self):
+                return "reader"
+
+            async def execute(self, context):
+                captured_metrics.update(context.metrics)
+
+        engine = IngestEngine(steps=[
+            ErrorStep(),  # type: ignore[list-item]
+            DestructiveStep(),  # type: ignore[list-item]
+            MetricReader(),  # type: ignore[list-item]
+        ])
+        await engine.run([], "test")
+
+        assert "cleanup" in captured_metrics
+        m = captured_metrics["cleanup"]
+        assert m.duration == 0.0
+        assert m.error_count == 1
+        assert m.items_in == m.items_out
+
+    async def test_multiple_destructive_steps_all_skipped(self):
+        """All destructive steps are skipped when errors exist."""
+        executed = []
+
+        class ErrorStep:
+            @property
+            def name(self):
+                return "error_producer"
+
+            async def execute(self, context):
+                raise RuntimeError("broke")
+
+        class DestructiveA:
+            destructive = True
+
+            @property
+            def name(self):
+                return "cleanup_a"
+
+            async def execute(self, context):
+                executed.append("cleanup_a")
+
+        class DestructiveB:
+            destructive = True
+
+            @property
+            def name(self):
+                return "cleanup_b"
+
+            async def execute(self, context):
+                executed.append("cleanup_b")
+
+        engine = IngestEngine(steps=[
+            ErrorStep(),  # type: ignore[list-item]
+            DestructiveA(),  # type: ignore[list-item]
+            DestructiveB(),  # type: ignore[list-item]
+        ])
+        result = await engine.run([], "test")
+
+        assert executed == []
+        skip_msgs = [e for e in result.errors if "skipped" in e]
+        assert len(skip_msgs) == 2
+
+    async def test_destructive_false_treated_as_non_destructive(self):
+        """Steps with explicit destructive=False still run when errors exist."""
+        executed = []
+
+        class ErrorStep:
+            @property
+            def name(self):
+                return "error_producer"
+
+            async def execute(self, context):
+                raise RuntimeError("broke")
+
+        class NonDestructiveStep:
+            destructive = False
+
+            @property
+            def name(self):
+                return "safe_step"
+
+            async def execute(self, context):
+                executed.append("safe_step")
+
+        engine = IngestEngine(steps=[
+            ErrorStep(),  # type: ignore[list-item]
+            NonDestructiveStep(),  # type: ignore[list-item]
+        ])
+        result = await engine.run([], "test")
+
+        assert "safe_step" in executed
+        assert result.success is False
+
+
+# ---------------------------------------------------------------------------
 # T010: ChangeDetectionStep tests
 # ---------------------------------------------------------------------------
 
@@ -827,26 +1075,75 @@ class TestOrphanCleanupStep:
         assert len(store.collections["coll"]) == 1
         assert len(ctx.errors) == 0
 
-    async def test_skips_cleanup_on_store_step_errors(self):
-        """Cleanup is skipped when StoreStep had write failures."""
+    async def test_skips_cleanup_on_prior_errors_via_engine(self):
+        """OrphanCleanupStep is skipped by the engine when prior steps had errors."""
         store = MockKnowledgeStorePort()
         store.collections["coll"] = [
             {"id": "orphan-1", "metadata": {"documentId": "doc-1"}, "document": "old"},
         ]
 
-        ctx = PipelineContext(
-            collection_name="coll",
-            documents=[],
-            orphan_ids={"orphan-1"},
-            errors=["StoreStep: storage failed for batch 0: connection refused"],
-        )
-        await OrphanCleanupStep(knowledge_store_port=store).execute(ctx)
+        class FailingWriteStep:
+            @property
+            def name(self):
+                return "failing_write"
+
+            async def execute(self, context):
+                raise RuntimeError("write failed")
+
+        class OrphanSetupStep:
+            """Injects orphan IDs into context before the cleanup step."""
+            @property
+            def name(self):
+                return "orphan_setup"
+
+            async def execute(self, context):
+                context.orphan_ids = {"orphan-1"}
+
+        engine = IngestEngine(steps=[
+            OrphanSetupStep(),  # type: ignore[list-item]
+            FailingWriteStep(),  # type: ignore[list-item]
+            OrphanCleanupStep(knowledge_store_port=store),
+        ])
+        result = await engine.run([], "coll")
 
         # Orphan should NOT have been deleted
         remaining_ids = [it["id"] for it in store.collections["coll"]]
         assert "orphan-1" in remaining_ids
-        assert ctx.chunks_deleted == 0
-        assert any("skipped cleanup" in e for e in ctx.errors)
+        assert result.success is False
+        assert any("skipped (destructive step gated by" in e for e in result.errors)
+
+    async def test_orphan_cleanup_has_destructive_attribute(self):
+        """OrphanCleanupStep declares destructive = True."""
+        store = MockKnowledgeStorePort()
+        step = OrphanCleanupStep(knowledge_store_port=store)
+        assert step.destructive is True
+
+    async def test_orphan_cleanup_runs_when_no_errors_via_engine(self):
+        """OrphanCleanupStep runs normally via engine when no prior errors."""
+        store = MockKnowledgeStorePort()
+        store.collections["coll"] = [
+            {"id": "orphan-1", "metadata": {"documentId": "doc-1"}, "document": "old"},
+            {"id": "keep-1", "metadata": {"documentId": "doc-1"}, "document": "keep"},
+        ]
+
+        class OrphanSetupStep:
+            @property
+            def name(self):
+                return "orphan_setup"
+
+            async def execute(self, context):
+                context.orphan_ids = {"orphan-1"}
+
+        engine = IngestEngine(steps=[
+            OrphanSetupStep(),  # type: ignore[list-item]
+            OrphanCleanupStep(knowledge_store_port=store),
+        ])
+        result = await engine.run([], "coll")
+
+        remaining_ids = [it["id"] for it in store.collections["coll"]]
+        assert "orphan-1" not in remaining_ids
+        assert "keep-1" in remaining_ids
+        assert result.success is True
 
     async def test_step_name(self):
         store = MockKnowledgeStorePort()


### PR DESCRIPTION
## Summary

- Adds engine-level error gating for destructive pipeline steps, replacing the fragile string-matching guard in `OrphanCleanupStep`
- Steps can now declare `destructive = True` as a class attribute; `IngestEngine.run()` skips them when prior steps have recorded errors, preventing data loss after partial write failures
- Removes the `StoreStep:` prefix string-matching from `OrphanCleanupStep.execute()` -- the engine handles gating generically for all current and future destructive steps

Closes #37

**SDD artifacts**: `specs/037-pipeline-engine-destructive-step-safety/` (spec.md, clarifications.md, plan.md, tasks.md)

**Clarify loop iterations**: 2 (1 productive + 1 clean pass)
**Analyze loop iterations**: 2 (1 productive + 1 clean pass)

## Test plan

- [x] 7 new `TestDestructiveStepGating` engine-level tests covering: skip on errors, run on clean, non-destructive unaffected, message format, metrics recording, multiple destructive steps, explicit `destructive=False`
- [x] 3 updated `TestOrphanCleanupStep` tests: engine-integration skip test, `destructive` attribute assertion, engine-integration clean-run test
- [x] All 341 existing tests pass (0 failures, 3 pre-existing warnings)
- [x] `ruff check` clean, `pyright` 0 errors (41 pre-existing warnings unchanged)


Generated with [Claude Code](https://claude.com/claude-code)