### PR TITLE
fix: consistent summarization behavior between ingest plugins

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -159,6 +159,12 @@ class BaseConfig(BaseSettings):
                 self.max_context_chars,
             )
 
+        # Summarize concurrency validation
+        if self.summarize_concurrency < 0:
+            raise ValueError(
+                f"SUMMARIZE_CONCURRENCY must be >= 0, got {self.summarize_concurrency}"
+            )
+
         # Chunk threshold validation
         if self.summary_chunk_threshold <= 0:
             raise ValueError(
@@ -268,6 +274,7 @@ class BaseConfig(BaseSettings):
     batch_size: int = 20
     summary_length: int = 10000
     summarize_concurrency: int = 8
+    summarize_enabled: bool = True
 
     # Health
     health_port: int = 8080

--- a/docs/stories/1827/plan.md
+++ b/docs/stories/1827/plan.md
@@ -1,0 +1,64 @@
+# Plan: Consistent Summarization Behavior Between ingest-website and ingest-space
+
+**Story:** alkem-io/alkemio#1827
+**Date:** 2026-04-08
+
+## Architecture
+
+No architectural changes. This is a behavioral alignment fix within the existing plugin + config layer.
+
+## Affected Modules
+
+| Module | Change |
+|--------|--------|
+| `core/config.py` | Add `summarize_enabled: bool = True` to `BaseConfig`. Add validation for `summarize_concurrency >= 0`. |
+| `plugins/ingest_website/plugin.py` | Remove conditional `if config.summarize_concurrency > 0` guard. Always include summary steps when `summarize_enabled` is true. Map `concurrency=0` to `concurrency=1`. Use `IngestWebsiteConfig`. |
+| `plugins/ingest_space/plugin.py` | Read `summarize_concurrency` and `summarize_enabled` from config. Conditionally include summary steps. Map `concurrency=0` to `concurrency=1`. Use `IngestSpaceConfig`. |
+| `tests/plugins/test_ingest_website.py` | Update existing test, add new tests for summarize_enabled flag and concurrency=0 behavior. |
+| `tests/plugins/test_ingest_space.py` | Add tests for summarize_enabled flag and concurrency from config. |
+| `tests/core/test_config_validation.py` | Add test for negative `summarize_concurrency` rejection and `summarize_enabled` defaults. |
+
+## Data Model Deltas
+
+None. No database/store schema changes.
+
+## Interface Contracts
+
+No port or protocol changes. The `DocumentSummaryStep` constructor already accepts `concurrency: int`. The only change is what values the callers pass.
+
+## Config Changes
+
+```python
+# core/config.py — BaseConfig
+summarize_enabled: bool = True      # NEW: controls whether summary steps are included
+summarize_concurrency: int = 8      # EXISTING: unchanged default, but 0 now means sequential
+```
+
+Validation addition: `summarize_concurrency >= 0` (reject negative values).
+
+## Concurrency Mapping Logic (shared by both plugins)
+
+```python
+effective_concurrency = max(config.summarize_concurrency, 1)
+```
+
+This ensures `0` maps to `1` (sequential) and positive values pass through unchanged.
+
+## Test Strategy
+
+1. **Unit tests (plugins):** For both `ingest-website` and `ingest-space`:
+   - Default behavior: summary steps are included in pipeline.
+   - `summarize_enabled=False`: summary steps are excluded.
+   - `summarize_concurrency=0`: `DocumentSummaryStep` receives `concurrency=1`.
+
+2. **Unit tests (config):**
+   - `summarize_enabled` defaults to `True`.
+   - Negative `summarize_concurrency` raises `ValueError`.
+
+3. **Existing tests:** Must continue to pass. The existing `test_pipeline_composition` test in `test_ingest_website.py` sets `summarize_concurrency=0` and will need updating since that no longer disables summarization.
+
+## Rollout Notes
+
+- **Backward compatible:** Deployments not setting `SUMMARIZE_ENABLED` get `true` (current ingest-space behavior), which is the correct default.
+- **Migration:** Deployments that relied on `SUMMARIZE_CONCURRENCY=0` to disable summarization in ingest-website must now set `SUMMARIZE_ENABLED=false` instead.
+- **No database migration needed.**

--- a/docs/stories/1827/spec.md
+++ b/docs/stories/1827/spec.md
@@ -1,0 +1,49 @@
+# Spec: Consistent Summarization Behavior Between ingest-website and ingest-space
+
+**Story:** alkem-io/alkemio#1827
+**Parent:** alkem-io/alkemio#1820
+**Date:** 2026-04-08
+
+## User Value
+
+Operators configuring the ingest pipeline expect `summarize_concurrency` to behave identically across all ingest plugins. Currently, setting `summarize_concurrency=0` silently disables summarization in `ingest-website` while `ingest-space` always summarizes. This inconsistency causes confusing behavior and makes the config parameter semantics unclear.
+
+## Scope
+
+1. **Align pipeline assembly in `ingest-website`** to always include `DocumentSummaryStep` and `BodyOfKnowledgeSummaryStep`, matching `ingest-space` behavior.
+2. **Introduce a `SUMMARIZE_ENABLED` boolean config flag** (default `true`) that explicitly controls whether summarization steps are included in the pipeline for both plugins.
+3. **Treat `summarize_concurrency=0` as sequential** (equivalent to concurrency=1) rather than "disabled", to avoid overloading the concurrency parameter.
+4. **Add tests** to verify consistent behavior across both plugins.
+
+## Out of Scope
+
+- Changes to the summarization prompts or quality.
+- Changes to `DocumentSummaryStep` or `BodyOfKnowledgeSummaryStep` internal logic beyond handling `concurrency <= 0`.
+- Changes to non-ingest plugins (expert, generic, guidance, openai_assistant).
+- Changes to the pipeline engine itself.
+
+## Acceptance Criteria
+
+1. `ingest-website` always includes `DocumentSummaryStep` and `BodyOfKnowledgeSummaryStep` in its pipeline, matching `ingest-space`.
+2. A new `SUMMARIZE_ENABLED` config flag (default `true`) controls whether summary steps are included. When `false`, both plugins skip summary steps.
+3. When `summarize_concurrency` is 0, `DocumentSummaryStep` receives `concurrency=1` (sequential), not disabled.
+4. Both plugins respect `SUMMARIZE_ENABLED` identically.
+5. Existing tests continue to pass.
+6. New tests verify: (a) both plugins include summary steps by default, (b) `SUMMARIZE_ENABLED=false` skips summary steps in both plugins, (c) `summarize_concurrency=0` results in sequential summarization (concurrency=1).
+
+## Constraints
+
+- Must not break backward compatibility for deployments not setting `SUMMARIZE_ENABLED` (default=true preserves current ingest-space behavior).
+- No changes to the plugin contract or port interfaces.
+- Config changes must follow existing Pydantic Settings patterns in `core/config.py`.
+
+## Clarifications (resolved)
+
+| # | Question | Decision | Rationale |
+|---|----------|----------|-----------|
+| 1 | What does `summarize_concurrency=0` mean? | Sequential (maps to concurrency=1) | Zero-as-unlimited is counterintuitive; the story suggests sequential. |
+| 2 | Where does `SUMMARIZE_ENABLED` live? | `BaseConfig` | Both plugins share the same base; matches how `summarize_concurrency` is defined. |
+| 3 | Reject negative `summarize_concurrency`? | Yes, add validation | Negative concurrency is nonsensical; matches existing validation patterns. |
+| 4 | Should `ingest-space` read `summarize_concurrency` from config? | Yes | Consistency: both plugins should use the same config-driven concurrency value. |
+| 5 | Should `ingest-space` respect `SUMMARIZE_ENABLED`? | Yes | True parity requires both plugins to honor the flag. |
+| 6 | Should inline `BaseConfig()` in `handle()` be changed? | Use plugin-specific config classes | Minimal improvement; `IngestWebsiteConfig`/`IngestSpaceConfig` inherit from `BaseConfig`. |

--- a/docs/stories/1827/tasks.md
+++ b/docs/stories/1827/tasks.md
@@ -1,0 +1,63 @@
+# Tasks: Consistent Summarization Behavior Between ingest-website and ingest-space
+
+**Story:** alkem-io/alkemio#1827
+**Date:** 2026-04-08
+
+## Task List
+
+### T1: Add `summarize_enabled` config field and `summarize_concurrency` validation
+
+**File:** `core/config.py`
+**Depends on:** none
+**Acceptance criteria:**
+- `BaseConfig.summarize_enabled` field exists with default `True`, type `bool`.
+- `BaseConfig` validator rejects `summarize_concurrency < 0` with `ValueError`.
+**Tests:** `tests/core/test_config_validation.py` — test default value, test negative concurrency rejection.
+
+### T2: Align `ingest-website` pipeline assembly
+
+**File:** `plugins/ingest_website/plugin.py`
+**Depends on:** T1
+**Acceptance criteria:**
+- `DocumentSummaryStep` and `BodyOfKnowledgeSummaryStep` are always included when `summarize_enabled=True`.
+- When `summarize_enabled=False`, both summary steps are skipped.
+- `concurrency` passed to `DocumentSummaryStep` is `max(config.summarize_concurrency, 1)`.
+- Uses `IngestWebsiteConfig` instead of `BaseConfig`.
+**Tests:** `tests/plugins/test_ingest_website.py` — updated pipeline composition test, new summarize_enabled tests.
+
+### T3: Align `ingest-space` pipeline assembly
+
+**File:** `plugins/ingest_space/plugin.py`
+**Depends on:** T1
+**Acceptance criteria:**
+- Reads `summarize_concurrency` and `summarize_enabled` from `IngestSpaceConfig`.
+- When `summarize_enabled=False`, both summary steps are skipped.
+- `concurrency` passed to `DocumentSummaryStep` is `max(config.summarize_concurrency, 1)`.
+**Tests:** `tests/plugins/test_ingest_space.py` — new config-driven pipeline tests.
+
+### T4: Update existing `test_ingest_website` test
+
+**File:** `tests/plugins/test_ingest_website.py`
+**Depends on:** T2
+**Acceptance criteria:**
+- `test_pipeline_composition` updated to reflect new behavior (summary steps included by default).
+- Test still passes and verifies pipeline runs correctly.
+
+### T5: Add new tests for summarization consistency
+
+**Files:** `tests/plugins/test_ingest_website.py`, `tests/plugins/test_ingest_space.py`, `tests/core/test_config_validation.py`
+**Depends on:** T1, T2, T3
+**Acceptance criteria:**
+- Test: both plugins include summary steps with default config.
+- Test: `SUMMARIZE_ENABLED=false` skips summary steps in both plugins.
+- Test: `summarize_concurrency=0` maps to `concurrency=1` in both plugins.
+- Test: negative `summarize_concurrency` raises `ValueError`.
+- Test: `summarize_enabled` defaults to `True`.
+
+### T6: Verify all exit gates pass
+
+**Depends on:** T1-T5
+**Acceptance criteria:**
+- `poetry run pytest` passes.
+- `poetry run ruff check core/ plugins/ tests/` passes.
+- `poetry run pyright core/ plugins/` passes.

--- a/plugins/ingest_space/plugin.py
+++ b/plugins/ingest_space/plugin.py
@@ -81,20 +81,30 @@ class IngestSpacePlugin:
                 )
 
             # Run ingest pipeline with ingest-space specific settings
+            from core.config import IngestSpaceConfig
+            config = IngestSpaceConfig()
             summary_llm = self._summarize_llm or self._llm
-            engine = IngestEngine(steps=[
+            steps: list = [
                 ChunkStep(chunk_size=9000, chunk_overlap=500),
                 ContentHashStep(),
                 ChangeDetectionStep(knowledge_store_port=self._knowledge_store),
-                DocumentSummaryStep(
+            ]
+            if config.summarize_enabled:
+                effective_concurrency = max(config.summarize_concurrency, 1)
+                steps.append(DocumentSummaryStep(
                     llm_port=summary_llm,
+                    concurrency=effective_concurrency,
                     chunk_threshold=self._chunk_threshold,
-                ),
-                BodyOfKnowledgeSummaryStep(llm_port=self._bok_llm or summary_llm),
+                ))
+                steps.append(BodyOfKnowledgeSummaryStep(
+                    llm_port=self._bok_llm or summary_llm,
+                ))
+            steps.extend([
                 EmbedStep(embeddings_port=self._embeddings),
                 StoreStep(knowledge_store_port=self._knowledge_store),
                 OrphanCleanupStep(knowledge_store_port=self._knowledge_store),
             ])
+            engine = IngestEngine(steps=steps)
             result = await engine.run(documents, collection_name)
 
             return IngestBodyOfKnowledgeResult(

--- a/plugins/ingest_website/plugin.py
+++ b/plugins/ingest_website/plugin.py
@@ -91,18 +91,19 @@ class IngestWebsitePlugin:
                 )
 
             # Run ingest pipeline
-            from core.config import BaseConfig
-            config = BaseConfig()
+            from core.config import IngestWebsiteConfig
+            config = IngestWebsiteConfig()
             summary_llm = self._summarize_llm or self._llm
             steps: list = [
                 ChunkStep(chunk_size=2000),
                 ContentHashStep(),
                 ChangeDetectionStep(knowledge_store_port=self._knowledge_store),
             ]
-            if config.summarize_concurrency > 0:
+            if config.summarize_enabled:
+                effective_concurrency = max(config.summarize_concurrency, 1)
                 steps.append(DocumentSummaryStep(
                     llm_port=summary_llm,
-                    concurrency=config.summarize_concurrency,
+                    concurrency=effective_concurrency,
                     chunk_threshold=self._chunk_threshold,
                 ))
                 bok_llm = self._bok_llm or summary_llm

--- a/tests/core/test_config_validation.py
+++ b/tests/core/test_config_validation.py
@@ -154,6 +154,34 @@ class TestPerPluginOverride:
         assert resolved is config
 
 
+class TestSummarizeConcurrencyValidation:
+    """Test summarize_concurrency validation."""
+
+    def test_negative_concurrency_raises(self) -> None:
+        with pytest.raises(ValueError, match="SUMMARIZE_CONCURRENCY must be >= 0"):
+            BaseConfig(llm_api_key="key", summarize_concurrency=-1)
+
+    def test_zero_concurrency_is_valid(self) -> None:
+        config = BaseConfig(llm_api_key="key", summarize_concurrency=0)
+        assert config.summarize_concurrency == 0
+
+    def test_positive_concurrency_is_valid(self) -> None:
+        config = BaseConfig(llm_api_key="key", summarize_concurrency=4)
+        assert config.summarize_concurrency == 4
+
+
+class TestSummarizeEnabledConfig:
+    """Test summarize_enabled config flag."""
+
+    def test_default_is_true(self) -> None:
+        config = BaseConfig(llm_api_key="key")
+        assert config.summarize_enabled is True
+
+    def test_can_be_set_to_false(self) -> None:
+        config = BaseConfig(llm_api_key="key", summarize_enabled=False)
+        assert config.summarize_enabled is False
+
+
 class TestUnsupportedProvider:
     """Test unsupported provider fail-fast (FR-008)."""
 

--- a/tests/plugins/test_ingest_space.py
+++ b/tests/plugins/test_ingest_space.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from core.events.ingest_space import IngestBodyOfKnowledgeResult
@@ -102,3 +104,115 @@ class TestIngestSpacePlugin:
     async def test_startup_shutdown(self, plugin):
         await plugin.startup()
         await plugin.shutdown()
+
+    async def test_pipeline_includes_summary_steps_by_default(self):
+        """Both summary steps are included when summarize_enabled=True (default)."""
+        mock_graphql = MagicMock()
+        plugin = IngestSpacePlugin(
+            llm=MockLLMPort(),
+            embeddings=MockEmbeddingsPort(),
+            knowledge_store=MockKnowledgeStorePort(),
+            graphql_client=mock_graphql,
+        )
+        event = make_ingest_body_of_knowledge()
+
+        mock_config = MagicMock()
+        mock_config.summarize_enabled = True
+        mock_config.summarize_concurrency = 8
+
+        from core.domain.ingest_pipeline import Document, DocumentMetadata
+        mock_docs = [Document(
+            content="Test document content for summary inclusion.",
+            metadata=DocumentMetadata(
+                document_id="doc-1", source="test", type="knowledge", title="Test",
+            ),
+        )]
+
+        with patch("plugins.ingest_space.space_reader.read_space_tree", return_value=mock_docs), \
+             patch("core.config.IngestSpaceConfig", return_value=mock_config), \
+             patch("plugins.ingest_space.plugin.IngestEngine") as mock_engine:
+            mock_engine.return_value.run = MagicMock(return_value=MagicMock(success=True, errors=[]))
+            await plugin.handle(event)
+
+        call_kwargs = mock_engine.call_args
+        if hasattr(call_kwargs, "kwargs") and "steps" in call_kwargs.kwargs:
+            steps = call_kwargs.kwargs["steps"]
+        else:
+            steps = call_kwargs[0][0] if call_kwargs[0] else []
+        step_types = [type(s).__name__ for s in steps]
+        assert "DocumentSummaryStep" in step_types
+        assert "BodyOfKnowledgeSummaryStep" in step_types
+
+    async def test_pipeline_skips_summary_when_disabled(self):
+        """Summary steps are excluded when summarize_enabled=False."""
+        mock_graphql = MagicMock()
+        plugin = IngestSpacePlugin(
+            llm=MockLLMPort(),
+            embeddings=MockEmbeddingsPort(),
+            knowledge_store=MockKnowledgeStorePort(),
+            graphql_client=mock_graphql,
+        )
+        event = make_ingest_body_of_knowledge()
+
+        mock_config = MagicMock()
+        mock_config.summarize_enabled = False
+        mock_config.summarize_concurrency = 8
+
+        from core.domain.ingest_pipeline import Document, DocumentMetadata
+        mock_docs = [Document(
+            content="Test document content for disabled summary.",
+            metadata=DocumentMetadata(
+                document_id="doc-1", source="test", type="knowledge", title="Test",
+            ),
+        )]
+
+        with patch("plugins.ingest_space.space_reader.read_space_tree", return_value=mock_docs), \
+             patch("core.config.IngestSpaceConfig", return_value=mock_config), \
+             patch("plugins.ingest_space.plugin.IngestEngine") as mock_engine:
+            mock_engine.return_value.run = MagicMock(return_value=MagicMock(success=True, errors=[]))
+            await plugin.handle(event)
+
+        call_kwargs = mock_engine.call_args
+        if hasattr(call_kwargs, "kwargs") and "steps" in call_kwargs.kwargs:
+            steps = call_kwargs.kwargs["steps"]
+        else:
+            steps = call_kwargs[0][0] if call_kwargs[0] else []
+        step_types = [type(s).__name__ for s in steps]
+        assert "DocumentSummaryStep" not in step_types
+        assert "BodyOfKnowledgeSummaryStep" not in step_types
+
+    async def test_concurrency_zero_maps_to_one(self):
+        """summarize_concurrency=0 should result in concurrency=1 (sequential)."""
+        mock_graphql = MagicMock()
+        plugin = IngestSpacePlugin(
+            llm=MockLLMPort(),
+            embeddings=MockEmbeddingsPort(),
+            knowledge_store=MockKnowledgeStorePort(),
+            graphql_client=mock_graphql,
+        )
+        event = make_ingest_body_of_knowledge()
+
+        mock_config = MagicMock()
+        mock_config.summarize_enabled = True
+        mock_config.summarize_concurrency = 0
+
+        from core.domain.ingest_pipeline import Document, DocumentMetadata
+        mock_docs = [Document(
+            content="Test document content for concurrency zero.",
+            metadata=DocumentMetadata(
+                document_id="doc-1", source="test", type="knowledge", title="Test",
+            ),
+        )]
+
+        with patch("plugins.ingest_space.space_reader.read_space_tree", return_value=mock_docs), \
+             patch("core.config.IngestSpaceConfig", return_value=mock_config), \
+             patch("plugins.ingest_space.plugin.DocumentSummaryStep") as mock_step, \
+             patch("plugins.ingest_space.plugin.IngestEngine") as mock_engine:
+            mock_engine.return_value.run = MagicMock(return_value=MagicMock(success=True, errors=[]))
+            await plugin.handle(event)
+
+        mock_step.assert_called_once()
+        call_kwargs = mock_step.call_args
+        assert call_kwargs.kwargs.get("concurrency") == 1 or (
+            len(call_kwargs.args) > 1 and call_kwargs.args[1] == 1
+        )

--- a/tests/plugins/test_ingest_website.py
+++ b/tests/plugins/test_ingest_website.py
@@ -162,15 +162,91 @@ class TestIngestWebsitePlugin:
         mock_pages = [{"url": "https://example.com", "html": "<p>Content for ingestion test.</p>"}]
 
         mock_config = MagicMock()
-        mock_config.summarize_concurrency = 0
+        mock_config.summarize_enabled = True
+        mock_config.summarize_concurrency = 8
 
         with patch("plugins.ingest_website.plugin.crawl", return_value=mock_pages), \
-             patch("core.config.BaseConfig", return_value=mock_config):
+             patch("core.config.IngestWebsiteConfig", return_value=mock_config):
             result = await plugin.handle(event)
         assert isinstance(result, IngestWebsiteResult)
         # delete_collection is no longer called — incremental dedup replaces it
         assert plugin._knowledge_store.deleted == []
         assert "example.com-knowledge" in plugin._knowledge_store.collections
+
+    async def test_pipeline_includes_summary_steps_by_default(self, plugin):
+        """Both summary steps are included when summarize_enabled=True (default)."""
+        event = make_ingest_website()
+        mock_pages = [{"url": "https://example.com", "html": "<p>Content for testing summary inclusion.</p>"}]
+
+        mock_config = MagicMock()
+        mock_config.summarize_enabled = True
+        mock_config.summarize_concurrency = 8
+
+        with patch("plugins.ingest_website.plugin.crawl", return_value=mock_pages), \
+             patch("core.config.IngestWebsiteConfig", return_value=mock_config), \
+             patch("plugins.ingest_website.plugin.IngestEngine") as mock_engine:
+            mock_engine.return_value.run = MagicMock(return_value=MagicMock(success=True, errors=[]))
+            await plugin.handle(event)
+
+        # Inspect the steps passed to IngestEngine
+        call_kwargs = mock_engine.call_args
+        steps = call_kwargs.kwargs.get("steps") or call_kwargs[1].get("steps") or call_kwargs[0][0] if call_kwargs[0] else []
+        # If positional: steps = call_kwargs[0][0], if keyword: steps = call_kwargs.kwargs["steps"]
+        if hasattr(call_kwargs, "kwargs") and "steps" in call_kwargs.kwargs:
+            steps = call_kwargs.kwargs["steps"]
+        else:
+            steps = call_kwargs[0][0] if call_kwargs[0] else []
+        step_types = [type(s).__name__ for s in steps]
+        assert "DocumentSummaryStep" in step_types
+        assert "BodyOfKnowledgeSummaryStep" in step_types
+
+    async def test_pipeline_skips_summary_when_disabled(self, plugin):
+        """Summary steps are excluded when summarize_enabled=False."""
+        event = make_ingest_website()
+        mock_pages = [{"url": "https://example.com", "html": "<p>Content for disabled summary test.</p>"}]
+
+        mock_config = MagicMock()
+        mock_config.summarize_enabled = False
+        mock_config.summarize_concurrency = 8
+
+        with patch("plugins.ingest_website.plugin.crawl", return_value=mock_pages), \
+             patch("core.config.IngestWebsiteConfig", return_value=mock_config), \
+             patch("plugins.ingest_website.plugin.IngestEngine") as mock_engine:
+            mock_engine.return_value.run = MagicMock(return_value=MagicMock(success=True, errors=[]))
+            await plugin.handle(event)
+
+        call_kwargs = mock_engine.call_args
+        if hasattr(call_kwargs, "kwargs") and "steps" in call_kwargs.kwargs:
+            steps = call_kwargs.kwargs["steps"]
+        else:
+            steps = call_kwargs[0][0] if call_kwargs[0] else []
+        step_types = [type(s).__name__ for s in steps]
+        assert "DocumentSummaryStep" not in step_types
+        assert "BodyOfKnowledgeSummaryStep" not in step_types
+
+    async def test_concurrency_zero_maps_to_one(self, plugin):
+        """summarize_concurrency=0 should result in concurrency=1 (sequential)."""
+        event = make_ingest_website()
+        mock_pages = [{"url": "https://example.com", "html": "<p>Content for concurrency zero test.</p>"}]
+
+        mock_config = MagicMock()
+        mock_config.summarize_enabled = True
+        mock_config.summarize_concurrency = 0
+
+        with patch("plugins.ingest_website.plugin.crawl", return_value=mock_pages), \
+             patch("core.config.IngestWebsiteConfig", return_value=mock_config), \
+             patch("plugins.ingest_website.plugin.DocumentSummaryStep") as mock_step:
+            mock_engine_patch = patch("plugins.ingest_website.plugin.IngestEngine")
+            with mock_engine_patch as mock_engine:
+                mock_engine.return_value.run = MagicMock(return_value=MagicMock(success=True, errors=[]))
+                await plugin.handle(event)
+
+        # Verify DocumentSummaryStep was called with concurrency=1
+        mock_step.assert_called_once()
+        call_kwargs = mock_step.call_args
+        assert call_kwargs.kwargs.get("concurrency") == 1 or (
+            len(call_kwargs.args) > 1 and call_kwargs.args[1] == 1
+        )
 
     async def test_unsupported_content_skip(self, plugin):
         """Empty crawl results should still succeed."""


### PR DESCRIPTION
## Summary

- Aligns `ingest-website` and `ingest-space` so both use `summarize_enabled` (new boolean config, default `true`) to control whether summary pipeline steps are included
- `summarize_concurrency=0` now maps to sequential (concurrency=1) instead of silently disabling summarization in ingest-website
- Both plugins read config-driven concurrency and use their specific config classes (`IngestWebsiteConfig`/`IngestSpaceConfig`)
- Adds validation rejecting negative `summarize_concurrency` values

## Linked Story

Closes alkem-io/alkemio#1827 (parent: alkem-io/alkemio#1820)

## SDD Artifacts

- `docs/stories/1827/spec.md` -- specification with clarifications
- `docs/stories/1827/plan.md` -- architecture plan
- `docs/stories/1827/tasks.md` -- task breakdown

Clarify loop count: 2
Analyze loop count: 2

## Test plan

- [x] Config: `summarize_enabled` defaults to `true`
- [x] Config: `summarize_enabled=false` accepted
- [x] Config: negative `summarize_concurrency` raises `ValueError`
- [x] Config: `summarize_concurrency=0` is valid
- [x] ingest-website: summary steps included by default
- [x] ingest-website: summary steps skipped when `SUMMARIZE_ENABLED=false`
- [x] ingest-website: `concurrency=0` maps to `concurrency=1`
- [x] ingest-space: summary steps included by default
- [x] ingest-space: summary steps skipped when `SUMMARIZE_ENABLED=false`
- [x] ingest-space: `concurrency=0` maps to `concurrency=1`
- [x] Full test suite: 343 passed, 0 failed
- [x] Ruff lint: all checks passed
- [x] Pyright: 0 errors (41 pre-existing warnings, none new)

Generated with [Claude Code](https://claude.com/claude-code)