### PR TITLE
feat: formalize destructive step handling in pipeline engine

### DIFF
--- a/core/domain/pipeline/engine.py
+++ b/core/domain/pipeline/engine.py
@@ -65,6 +65,28 @@ class IngestEngine:
         for step in self._steps:
             items_before = len(context.chunks)
             errors_before = len(context.errors)
+
+            # Gate: skip destructive steps when prior errors exist
+            if getattr(step, "destructive", False) and context.errors:
+                n_errors = len(context.errors)
+                msg = (
+                    f"{step.name}: skipped "
+                    f"(destructive step gated by {n_errors} prior error(s))"
+                )
+                context.errors.append(msg)
+                logger.warning(
+                    "Skipping destructive step '%s' due to %d prior error(s)",
+                    step.name,
+                    n_errors,
+                )
+                context.metrics[step.name] = StepMetrics(
+                    duration=0.0,
+                    items_in=items_before,
+                    items_out=len(context.chunks),
+                    error_count=1,
+                )
+                continue
+
             start = time.monotonic()
 
             try:

--- a/core/domain/pipeline/steps.py
+++ b/core/domain/pipeline/steps.py
@@ -519,13 +519,11 @@ class OrphanCleanupStep:
     def name(self) -> str:
         return "orphan_cleanup"
 
-    async def execute(self, context: PipelineContext) -> None:
-        if any(e.startswith("StoreStep:") for e in context.errors):
-            context.errors.append(
-                "OrphanCleanupStep: skipped cleanup because earlier storage writes failed"
-            )
-            return
+    @property
+    def destructive(self) -> bool:
+        return True
 
+    async def execute(self, context: PipelineContext) -> None:
         deleted = 0
 
         # Delete orphan chunk IDs

--- a/specs/011-pipeline-destructive-step-safety/checklists/requirements.md
+++ b/specs/011-pipeline-destructive-step-safety/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Pipeline Engine Safety -- Formalize Destructive Step Handling
+
+**Purpose**: Validate specification completeness and quality
+**Created**: 2026-04-14
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- The spec references `getattr` and `PipelineStep` protocol in FR-001 and FR-007. This is acceptable because the feature is inherently about the internal engine mechanism -- the acceptance scenarios need to reference the duck-typing approach to be testable and unambiguous.
+- All clarifications from the original clarifications.md have been incorporated into the spec's Clarifications section.

--- a/specs/011-pipeline-destructive-step-safety/clarifications.md
+++ b/specs/011-pipeline-destructive-step-safety/clarifications.md
@@ -1,0 +1,45 @@
+# Clarifications
+
+**Iteration count:** 1
+
+---
+
+## Clarification 1: Protocol extension strategy for backward compatibility
+
+**Question:** The `PipelineStep` protocol is `@runtime_checkable`. Adding a new required property `destructive` would break all existing steps that do not implement it. Should we (a) make it a required protocol member with a default in a base mixin, (b) make the engine use `getattr(step, 'destructive', False)`, or (c) define a separate `DestructiveStep` protocol?
+
+**Chosen answer:** (b) Use `getattr(step, 'destructive', False)` in `IngestEngine.run()`. The `PipelineStep` protocol remains unchanged -- no new required member. Steps that want to declare themselves destructive simply add a `destructive` property returning `True`. This is the least invasive option and is consistent with Python duck-typing conventions already used in this codebase (e.g., plugin contracts).
+
+**Rationale:** Adding a required property to the protocol would force all existing step classes (and any external/test steps) to add the property, violating backward compatibility. A separate protocol adds unnecessary complexity. Using `getattr` with a safe default is idiomatic Python and zero-disruption.
+
+## Clarification 2: Error message format for skipped destructive steps
+
+**Question:** When the engine skips a destructive step, what format should the error message use? The existing convention in `OrphanCleanupStep` uses `"OrphanCleanupStep: skipped cleanup because earlier storage writes failed"`. Should the engine-level message follow the same `{StepName}: ...` pattern?
+
+**Chosen answer:** Yes. The engine-level message will use the format `"{step.name}: skipped (destructive step gated by prior errors)"`. This is consistent with how `IngestEngine.run()` already formats caught exception messages as `f"{step.name}: {exc}"`.
+
+**Rationale:** Consistent error message format across the engine. Using `step.name` (the property) rather than the class name keeps messages aligned with what appears in metrics.
+
+## Clarification 3: Should the engine log at WARNING or INFO level when skipping?
+
+**Question:** The existing string-matching guard in `OrphanCleanupStep` does not log at all (only appends to `context.errors`). The engine's exception handler uses `logger.exception`. What log level for a gated destructive skip?
+
+**Chosen answer:** `logger.warning`. It is not an exception (nothing crashed), but it is noteworthy enough that operators should see it. The skip is an intentional safety mechanism, not routine.
+
+**Rationale:** `INFO` would be too quiet for a safety mechanism activation. `ERROR` would be misleading since the skip is desired behavior. `WARNING` is the correct semantic level.
+
+## Clarification 4: Should metrics still be recorded for skipped destructive steps?
+
+**Question:** When a destructive step is skipped by the engine gate, should `StepMetrics` still be recorded for it?
+
+**Chosen answer:** Yes. Record a `StepMetrics` entry with `duration=0.0`, `items_in` and `items_out` at their current values, and `error_count=1` (the skip message counts as an error). This ensures the metrics dict always has entries for all steps in the pipeline, making monitoring consistent.
+
+**Rationale:** Having metrics for all configured steps (even skipped ones) avoids confusion in monitoring dashboards. The `error_count=1` and `duration=0.0` make it unambiguous that the step was skipped, not just fast.
+
+## Clarification 5: What if a step has both `destructive=True` and is not the last step?
+
+**Question:** The issue only discusses `OrphanCleanupStep`, but the mechanism should be general. If a destructive step is positioned in the middle of the pipeline, should subsequent non-destructive steps still run?
+
+**Chosen answer:** Yes. The `destructive` flag only gates the specific step that declares it. Non-destructive steps always run regardless of where destructive steps appear. The engine iterates all steps in order and only checks the destructive flag per-step.
+
+**Rationale:** This is the simplest and most predictable behavior. If operators want to prevent all downstream execution, they should use the error-propagation mechanism (exceptions caught by the engine) rather than relying on the destructive flag.

--- a/specs/011-pipeline-destructive-step-safety/clarifications.md
+++ b/specs/011-pipeline-destructive-step-safety/clarifications.md
@@ -1,6 +1,6 @@
 # Clarifications
 
-**Iteration count:** 1
+**Iteration count:** 2
 
 ---
 
@@ -16,7 +16,7 @@
 
 **Question:** When the engine skips a destructive step, what format should the error message use? The existing convention in `OrphanCleanupStep` uses `"OrphanCleanupStep: skipped cleanup because earlier storage writes failed"`. Should the engine-level message follow the same `{StepName}: ...` pattern?
 
-**Chosen answer:** Yes. The engine-level message will use the format `"{step.name}: skipped (destructive step gated by prior errors)"`. This is consistent with how `IngestEngine.run()` already formats caught exception messages as `f"{step.name}: {exc}"`.
+**Chosen answer:** Yes. The engine-level message will use the format `"{step.name}: skipped (destructive step gated by {N} prior error(s))"`, where `{N}` is the count of prior errors. This is consistent with how `IngestEngine.run()` already formats caught exception messages as `f"{step.name}: {exc}"`.
 
 **Rationale:** Consistent error message format across the engine. Using `step.name` (the property) rather than the class name keeps messages aligned with what appears in metrics.
 

--- a/specs/011-pipeline-destructive-step-safety/data-model.md
+++ b/specs/011-pipeline-destructive-step-safety/data-model.md
@@ -1,0 +1,65 @@
+# Data Model: Pipeline Engine Safety -- Formalize Destructive Step Handling
+
+**Feature Branch**: `story/37-pipeline-engine-safety-destructive-step-handling`
+**Date**: 2026-04-14
+
+## Overview
+
+This feature does not introduce new database tables, event schemas, or domain entities. All changes are behavioral modifications to existing classes. No data model changes.
+
+## Entity: PipelineStep Protocol (unchanged)
+
+**File**: `core/domain/pipeline/engine.py`
+
+The `PipelineStep` protocol is NOT modified. It retains only:
+
+| Member | Type | Description |
+|--------|------|-------------|
+| `name` | `property -> str` | Step identifier |
+| `execute` | `async method(context: PipelineContext) -> None` | Step execution |
+
+The `destructive` flag is opt-in via duck typing, not a protocol requirement.
+
+## Entity: OrphanCleanupStep (modified)
+
+**File**: `core/domain/pipeline/steps.py`
+
+### New Property
+
+| Property | Type | Value | Description |
+|----------|------|-------|-------------|
+| `destructive` | `bool` | `True` | Declares this step as destructive for engine-level gating |
+
+### Removed Behavior
+
+- The `if any(e.startswith("StoreStep:") for e in context.errors)` guard and associated error append + early return are removed from `execute()`.
+
+## Entity: IngestEngine (modified behavior)
+
+**File**: `core/domain/pipeline/engine.py`
+
+### New Behavior in `run()`
+
+Before calling `step.execute(context)`, the engine checks:
+- `getattr(step, 'destructive', False)` AND `len(context.errors) > 0`
+- If both are true: skip execution, log warning, append skip message, record metrics
+
+No new fields or constructor parameters.
+
+## Relationships
+
+```text
+IngestEngine.run()
+  ├── iterates → [PipelineStep, ...]
+  ├── checks → getattr(step, 'destructive', False)
+  ├── if destructive + errors → skip + log + metrics
+  └── else → step.execute(context)
+
+OrphanCleanupStep
+  ├── satisfies → PipelineStep protocol (unchanged)
+  └── declares → destructive = True (new, opt-in)
+```
+
+## State Transitions
+
+No state machines affected. The destructive gating is a runtime per-step check within the existing sequential execution loop.

--- a/specs/011-pipeline-destructive-step-safety/plan.md
+++ b/specs/011-pipeline-destructive-step-safety/plan.md
@@ -1,0 +1,88 @@
+# Plan: Pipeline Engine Safety -- Formalize Destructive Step Handling
+
+**Story:** #37
+**Spec:** `spec.md`
+
+---
+
+## Architecture
+
+The change is localized to two files in `core/domain/pipeline/` and their corresponding test file. No new modules, no new dependencies, no configuration changes.
+
+**Before:**
+```
+IngestEngine.run() -> for step in steps: step.execute(context)
+OrphanCleanupStep.execute() -> manual string check: any(e.startswith("StoreStep:") ...)
+```
+
+**After:**
+```
+IngestEngine.run() -> for step in steps:
+    if getattr(step, 'destructive', False) and context.errors:
+        skip + log + record metrics
+    else:
+        step.execute(context)
+OrphanCleanupStep -> destructive = True (property); execute() has NO guard
+```
+
+## Affected Modules
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `core/domain/pipeline/engine.py` | Modify | Add destructive-step gating logic in `IngestEngine.run()` |
+| `core/domain/pipeline/steps.py` | Modify | Add `destructive` property to `OrphanCleanupStep`; remove string-matching guard |
+| `tests/core/domain/test_pipeline_steps.py` | Modify | Update `test_skips_cleanup_on_store_step_errors` to test engine-level gating; add new engine-level tests |
+
+## Data Model Deltas
+
+None. `PipelineContext`, `StepMetrics`, `IngestResult` are unchanged. The `PipelineStep` protocol is not modified (we use `getattr` duck-typing).
+
+## Interface Contracts
+
+### PipelineStep Protocol (unchanged)
+```python
+@runtime_checkable
+class PipelineStep(Protocol):
+    @property
+    def name(self) -> str: ...
+    async def execute(self, context: PipelineContext) -> None: ...
+```
+
+### Destructive Step Convention (new, opt-in)
+Steps that want engine-level error gating declare:
+```python
+@property
+def destructive(self) -> bool:
+    return True
+```
+
+The engine checks `getattr(step, 'destructive', False)`. Steps without this property default to `False` (non-destructive).
+
+### IngestEngine.run() Contract Change
+When `getattr(step, 'destructive', False)` is `True` and `len(context.errors) > 0`:
+- Step is NOT executed
+- A warning is logged: `"Skipping destructive step '%s' due to %d prior error(s)"`
+- An error is appended: `"{step.name}: skipped (destructive step gated by {N} prior error(s))"`
+- Metrics are recorded with `duration=0.0` and `error_count=1`
+
+## Test Strategy
+
+1. **Unit: Engine destructive gating** -- New test class `TestDestructiveStepGating` in test_pipeline_steps.py:
+   - Test engine skips destructive step when context has errors
+   - Test engine runs destructive step when context has no errors
+   - Test non-destructive steps still run even when errors exist
+   - Test metrics recorded for skipped destructive steps
+   - Test skip message format in context.errors
+
+2. **Unit: OrphanCleanupStep.destructive property** -- New test in `TestOrphanCleanupStep`:
+   - `assert OrphanCleanupStep(...).destructive is True`
+
+3. **Update: test_skips_cleanup_on_store_step_errors** -- Change from testing step-level string guard to testing engine-level gating (run through IngestEngine with a failing StoreStep followed by OrphanCleanupStep).
+
+4. **Regression: all existing tests** -- Must pass without changes to non-destructive steps.
+
+## Rollout Notes
+
+- Zero-config change. No environment variables, no feature flags.
+- Backward compatible. Existing pipeline step implementations continue to work without modification.
+- The behavior change is strictly safer: destructive steps are now gated by any prior error, not just errors matching a specific string pattern.

--- a/specs/011-pipeline-destructive-step-safety/plan.md
+++ b/specs/011-pipeline-destructive-step-safety/plan.md
@@ -1,88 +1,77 @@
-# Plan: Pipeline Engine Safety -- Formalize Destructive Step Handling
+# Implementation Plan: Pipeline Engine Safety -- Formalize Destructive Step Handling
 
-**Story:** #37
-**Spec:** `spec.md`
+**Branch**: `story/37-pipeline-engine-safety-destructive-step-handling` | **Date**: 2026-04-14 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/011-pipeline-destructive-step-safety/spec.md`
 
----
+## Summary
 
-## Architecture
+Add engine-level `destructive` flag support to pipeline steps. `IngestEngine.run()` skips destructive steps when prior errors exist, replacing the fragile string-matching guard in `OrphanCleanupStep`. The `PipelineStep` protocol remains unchanged -- the flag is opt-in via duck typing (`getattr` with default). `OrphanCleanupStep` declares itself destructive and its manual guard is removed.
 
-The change is localized to two files in `core/domain/pipeline/` and their corresponding test file. No new modules, no new dependencies, no configuration changes.
+## Technical Context
 
-**Before:**
+**Language/Version**: Python 3.12 (Poetry)
+**Primary Dependencies**: No new dependencies. Existing: pydantic-settings ^2.11.0
+**Storage**: ChromaDB (unchanged)
+**Testing**: pytest ^9.0 + pytest-asyncio ^1.3 (asyncio_mode = auto)
+**Target Platform**: Linux server (Docker containers, K8s)
+**Project Type**: Microkernel service
+**Performance Goals**: N/A (safety mechanism, no performance impact)
+**Constraints**: Full backward compatibility; PipelineStep protocol unchanged; sequential execution model preserved (ADR-0004)
+**Scale/Scope**: 3 files modified, ~50 lines added, ~10 lines removed
+
+## Constitution Check
+
+| # | Principle / Standard | Status | Notes |
+|---|---------------------|--------|-------|
+| P1 | AI-Native Development | PASS | Pure code change, no interactive steps |
+| P2 | SOLID Architecture | PASS | Open/Closed: new behavior via opt-in property, no protocol modification. Single Responsibility: engine handles gating, steps declare intent |
+| P3 | No Vendor Lock-in | N/A | No provider changes |
+| P4 | Optimised Feedback Loops | PASS | 7 new meaningful tests covering gating behavior, metrics, and message format |
+| P5 | Best Available Infrastructure | N/A | No CI changes |
+| P6 | SDD | PASS | Full SDD artifacts produced |
+| P7 | No Filling Tests | PASS | Every test guards a specific behavioral contract or boundary condition |
+| P8 | ADR | PASS | No port/contract changes. No new external dependencies |
+| AS:Microkernel | Microkernel Architecture | PASS | Change localized to core domain logic. No cross-plugin coupling |
+| AS:Hexagonal | Hexagonal Boundaries | PASS | No port or adapter changes |
+| AS:Plugin | Plugin Contract | PASS | PluginContract unchanged. Ingest plugins unaffected |
+| AS:Domain | Domain Logic Isolation | PASS | Engine and step changes are internal to core/domain/pipeline/ |
+| AS:Simplicity | Simplicity Over Speculation | PASS | Single boolean flag + getattr. No phase model, no new protocols, no abstractions |
+| AS:Async | Async-First Design | PASS | No new sync calls |
+
+**Gate result**: PASS -- no violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/011-pipeline-destructive-step-safety/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── tasks.md
+├── clarifications.md
+└── checklists/
+    └── requirements.md
 ```
-IngestEngine.run() -> for step in steps: step.execute(context)
-OrphanCleanupStep.execute() -> manual string check: any(e.startswith("StoreStep:") ...)
+
+### Source Code (repository root)
+
+```text
+core/
+└── domain/
+    └── pipeline/
+        ├── engine.py      # Add destructive-step gating logic in IngestEngine.run()
+        └── steps.py       # Add destructive property to OrphanCleanupStep; remove string guard
+
+tests/
+└── core/
+    └── domain/
+        └── test_pipeline_steps.py  # 7 new tests + 2 updated tests
 ```
 
-**After:**
-```
-IngestEngine.run() -> for step in steps:
-    if getattr(step, 'destructive', False) and context.errors:
-        skip + log + record metrics
-    else:
-        step.execute(context)
-OrphanCleanupStep -> destructive = True (property); execute() has NO guard
-```
+## Complexity Tracking
 
-## Affected Modules
-
-| File | Change Type | Description |
-|------|-------------|-------------|
-| `core/domain/pipeline/engine.py` | Modify | Add destructive-step gating logic in `IngestEngine.run()` |
-| `core/domain/pipeline/steps.py` | Modify | Add `destructive` property to `OrphanCleanupStep`; remove string-matching guard |
-| `tests/core/domain/test_pipeline_steps.py` | Modify | Update `test_skips_cleanup_on_store_step_errors` to test engine-level gating; add new engine-level tests |
-
-## Data Model Deltas
-
-None. `PipelineContext`, `StepMetrics`, `IngestResult` are unchanged. The `PipelineStep` protocol is not modified (we use `getattr` duck-typing).
-
-## Interface Contracts
-
-### PipelineStep Protocol (unchanged)
-```python
-@runtime_checkable
-class PipelineStep(Protocol):
-    @property
-    def name(self) -> str: ...
-    async def execute(self, context: PipelineContext) -> None: ...
-```
-
-### Destructive Step Convention (new, opt-in)
-Steps that want engine-level error gating declare:
-```python
-@property
-def destructive(self) -> bool:
-    return True
-```
-
-The engine checks `getattr(step, 'destructive', False)`. Steps without this property default to `False` (non-destructive).
-
-### IngestEngine.run() Contract Change
-When `getattr(step, 'destructive', False)` is `True` and `len(context.errors) > 0`:
-- Step is NOT executed
-- A warning is logged: `"Skipping destructive step '%s' due to %d prior error(s)"`
-- An error is appended: `"{step.name}: skipped (destructive step gated by {N} prior error(s))"`
-- Metrics are recorded with `duration=0.0` and `error_count=1`
-
-## Test Strategy
-
-1. **Unit: Engine destructive gating** -- New test class `TestDestructiveStepGating` in test_pipeline_steps.py:
-   - Test engine skips destructive step when context has errors
-   - Test engine runs destructive step when context has no errors
-   - Test non-destructive steps still run even when errors exist
-   - Test metrics recorded for skipped destructive steps
-   - Test skip message format in context.errors
-
-2. **Unit: OrphanCleanupStep.destructive property** -- New test in `TestOrphanCleanupStep`:
-   - `assert OrphanCleanupStep(...).destructive is True`
-
-3. **Update: test_skips_cleanup_on_store_step_errors** -- Change from testing step-level string guard to testing engine-level gating (run through IngestEngine with a failing StoreStep followed by OrphanCleanupStep).
-
-4. **Regression: all existing tests** -- Must pass without changes to non-destructive steps.
-
-## Rollout Notes
-
-- Zero-config change. No environment variables, no feature flags.
-- Backward compatible. Existing pipeline step implementations continue to work without modification.
-- The behavior change is strictly safer: destructive steps are now gated by any prior error, not just errors matching a specific string pattern.
+No constitution violations to justify.

--- a/specs/011-pipeline-destructive-step-safety/quickstart.md
+++ b/specs/011-pipeline-destructive-step-safety/quickstart.md
@@ -30,13 +30,13 @@ Expected: 9 tests pass (7 new gating tests + 1 property test + 1 updated integra
 
 When an ingest pipeline encounters an error (e.g., storage write failure), the engine logs:
 
-```
+```text
 WARNING: Skipping destructive step 'orphan_cleanup' due to 1 prior error(s)
 ```
 
 And `IngestResult.errors` contains:
 
-```
+```text
 orphan_cleanup: skipped (destructive step gated by 1 prior error(s))
 ```
 

--- a/specs/011-pipeline-destructive-step-safety/quickstart.md
+++ b/specs/011-pipeline-destructive-step-safety/quickstart.md
@@ -1,0 +1,61 @@
+# Quickstart: Pipeline Engine Safety -- Formalize Destructive Step Handling
+
+**Feature Branch**: `story/37-pipeline-engine-safety-destructive-step-handling`
+**Date**: 2026-04-14
+
+## What This Feature Does
+
+Adds engine-level safety for destructive pipeline steps during ingestion:
+
+1. **Destructive step gating** -- `IngestEngine.run()` automatically skips steps marked `destructive = True` when prior errors exist
+2. **OrphanCleanupStep migration** -- Declares itself destructive and removes the fragile string-matching guard
+
+The pipeline is now intrinsically safe: any error in any earlier step prevents destructive operations from running, regardless of error message format.
+
+## Zero Configuration
+
+This feature requires no environment variables, no feature flags, and no configuration changes. It is backward compatible -- existing pipeline behavior is unchanged when all steps succeed.
+
+## Quick Verification
+
+### 1. Run tests
+
+```bash
+poetry run pytest tests/core/domain/test_pipeline_steps.py -v -k "destructive"
+```
+
+Expected: 9 tests pass (7 new gating tests + 1 property test + 1 updated integration test).
+
+### 2. Verify engine-level gating
+
+When an ingest pipeline encounters an error (e.g., storage write failure), the engine logs:
+
+```
+WARNING: Skipping destructive step 'orphan_cleanup' due to 1 prior error(s)
+```
+
+And `IngestResult.errors` contains:
+
+```
+orphan_cleanup: skipped (destructive step gated by 1 prior error(s))
+```
+
+### 3. Verify normal operation
+
+When an ingest pipeline succeeds with no errors, `OrphanCleanupStep` runs normally and cleans up orphan chunks.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `core/domain/pipeline/engine.py` | Add destructive-step gating logic in `IngestEngine.run()` |
+| `core/domain/pipeline/steps.py` | Add `destructive` property to `OrphanCleanupStep`; remove string-matching guard |
+| `tests/core/domain/test_pipeline_steps.py` | 7 new gating tests, 1 property test, 1 updated integration test |
+
+## Contracts
+
+No external interface changes:
+- **PipelineStep protocol**: Unchanged (destructive flag is opt-in via duck typing)
+- **PluginContract**: Unchanged
+- **Event schemas**: Unchanged
+- **Port interfaces**: Unchanged

--- a/specs/011-pipeline-destructive-step-safety/research.md
+++ b/specs/011-pipeline-destructive-step-safety/research.md
@@ -1,0 +1,69 @@
+# Research: Pipeline Engine Safety -- Formalize Destructive Step Handling
+
+**Feature Branch**: `story/37-pipeline-engine-safety-destructive-step-handling`
+**Date**: 2026-04-14
+
+## Research Tasks
+
+### R1: Protocol extension strategy for backward compatibility
+
+**Context**: The `PipelineStep` protocol is `@runtime_checkable`. Adding a new required property `destructive` would break all existing steps that do not implement it. Need to choose a backward-compatible approach.
+
+**Findings**:
+
+Three options were evaluated:
+
+1. **Add required `destructive` property to `PipelineStep` protocol**: Would force all existing step classes and test steps to add the property. Breaks backward compatibility.
+2. **Define a separate `DestructiveStep` protocol**: Adds unnecessary complexity. Engine would need `isinstance` checks against a second protocol.
+3. **Use `getattr(step, 'destructive', False)` in the engine**: Zero-disruption. Steps that want destructive gating add a `destructive` property. All others default to `False` automatically. Consistent with Python duck-typing conventions already used in this codebase (e.g., plugin contracts).
+
+**Decision**: Use `getattr(step, 'destructive', False)` in `IngestEngine.run()`. The `PipelineStep` protocol remains unchanged.
+**Rationale**: Least invasive. Zero changes to existing steps. Idiomatic Python duck typing.
+**Alternatives considered**: (a) Required protocol property -- rejected (breaks backward compatibility). (b) Separate `DestructiveStep` protocol -- rejected (unnecessary complexity).
+
+---
+
+### R2: Replacing the string-matching guard in OrphanCleanupStep
+
+**Context**: `OrphanCleanupStep.execute()` currently checks `any(e.startswith("StoreStep:") for e in context.errors)` to decide whether to skip cleanup. This guard is fragile: it depends on exact error message formatting and only matches errors from `StoreStep`.
+
+**Findings**:
+
+The existing guard has several problems:
+1. Coupled to `StoreStep`'s error message prefix -- if message format changes, guard breaks silently.
+2. Only protects against `StoreStep` errors -- errors from other steps (e.g., `EmbedStep`) would not trigger the guard.
+3. Each new destructive step would need its own string-matching logic.
+
+With engine-level gating (R1), `OrphanCleanupStep.execute()` can be simplified to only contain its cleanup logic. The engine handles all error-based skipping.
+
+**Decision**: Remove the string-matching guard entirely. Add `destructive = True` property. Let the engine gate.
+**Rationale**: Engine-level gating is more general (any error triggers skip), more robust (no string matching), and centralized (one check point).
+**Alternatives considered**: (a) Keep guard as defense-in-depth -- rejected (redundant with engine gating, increases maintenance burden). (b) Change guard to check `len(context.errors) > 0` instead of string matching -- rejected (still step-level, engine-level is cleaner).
+
+---
+
+### R3: Metrics for skipped destructive steps
+
+**Context**: When a destructive step is skipped, should `StepMetrics` be recorded?
+
+**Findings**:
+
+The `IngestEngine.run()` always records metrics in `context.metrics[step.name]` after executing a step. If skipped steps have no metrics entry, monitoring dashboards may show missing steps, causing confusion.
+
+Recording `StepMetrics` with `duration=0.0` and `error_count=1` makes it unambiguous that the step was skipped (not just fast). The `items_in` and `items_out` values reflect the current state at the time of skipping.
+
+**Decision**: Record `StepMetrics` for skipped steps with `duration=0.0`, current `items_in`/`items_out`, and `error_count=1`.
+**Rationale**: Consistent metrics dict. Monitoring always shows all configured steps. `error_count=1` + `duration=0.0` is a clear signal of intentional skip.
+**Alternatives considered**: (a) No metrics for skipped steps -- rejected (gaps in monitoring). (b) Metrics with `error_count=0` -- rejected (ambiguous, could look like a fast success).
+
+---
+
+## Summary of Decisions
+
+| Topic | Decision | Key Rationale |
+|-------|----------|---------------|
+| Protocol extension | `getattr(step, 'destructive', False)` | Zero-disruption, idiomatic Python |
+| String-matching guard | Remove entirely | Engine-level gating is more general and robust |
+| Metrics for skipped steps | Record with `duration=0.0`, `error_count=1` | Consistent monitoring, clear skip signal |
+| Log level for skipping | `logger.warning` | Safety mechanism activation, not routine |
+| Mid-pipeline destructive steps | Non-destructive steps still run | Simplest predictable behavior |

--- a/specs/011-pipeline-destructive-step-safety/spec.md
+++ b/specs/011-pipeline-destructive-step-safety/spec.md
@@ -1,41 +1,117 @@
-# Spec: Pipeline Engine Safety -- Formalize Destructive Step Handling
+# Feature Specification: Pipeline Engine Safety -- Formalize Destructive Step Handling
 
-**Story:** #37
-**Status:** Draft
-**Author:** SDD Agent
+**Feature Branch**: `story/37-pipeline-engine-safety-destructive-step-handling`
+**Created**: 2026-04-14
+**Status**: Implemented
+**Input**: Story #37
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 -- Engine-Level Destructive Step Gating (Priority: P1)
+
+As a platform operator, I want the ingest pipeline engine to automatically skip destructive steps (e.g., orphan cleanup) when earlier steps have recorded errors, so that partial write failures never trigger data deletion and I can trust that failed ingestions do not cause data loss.
+
+**Why this priority**: The current guard is a fragile string-matching check inside `OrphanCleanupStep` that looks for a `"StoreStep:"` prefix in `context.errors`. If error message formats change or new destructive steps are added, this guard silently breaks. An engine-level mechanism is the only reliable way to prevent data loss during partial failures.
+
+**Independent Test**: Run an ingest pipeline with a step that injects an error into `context.errors` followed by a step marked `destructive = True`. Verify the destructive step is skipped, a warning is logged, a skip message appears in errors, and metrics are recorded with `duration=0.0` and `error_count=1`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pipeline with a failing step followed by a destructive step, **When** `IngestEngine.run()` executes, **Then** the destructive step is NOT executed, a warning is logged, and a skip message is appended to `context.errors`.
+2. **Given** a pipeline with no prior errors and a destructive step, **When** `IngestEngine.run()` executes, **Then** the destructive step runs normally.
+3. **Given** a pipeline with errors and a non-destructive step, **When** `IngestEngine.run()` executes, **Then** the non-destructive step still runs regardless of errors.
+4. **Given** a pipeline with errors and multiple destructive steps, **When** `IngestEngine.run()` executes, **Then** all destructive steps are skipped.
+5. **Given** a pipeline where a non-destructive step raises an exception, **When** `IngestEngine.run()` catches the error and continues to a destructive step, **Then** the destructive step is skipped due to the caught error.
+6. **Given** a destructive step is skipped, **When** metrics are recorded, **Then** `StepMetrics` has `duration=0.0` and `error_count=1`.
+7. **Given** a destructive step is skipped due to 2 prior errors, **When** the skip message is appended, **Then** the message format is `"cleanup: skipped (destructive step gated by 2 prior error(s))"`.
 
 ---
 
-## User Value
+### User Story 2 -- OrphanCleanupStep Declares Itself Destructive (Priority: P2)
 
-Prevent data loss during ingestion by ensuring that destructive pipeline steps (e.g., orphan cleanup) are automatically skipped when earlier write steps have experienced errors. Currently, the only protection is a fragile string-matching guard in `OrphanCleanupStep` that checks for a `"StoreStep:"` prefix in `context.errors`. This does not generalize: if new destructive steps are added, or if error message formats change, the guard silently breaks. A first-class engine-level mechanism makes the pipeline intrinsically safe, regardless of how many destructive steps exist or how error messages are formatted.
+As a developer maintaining the pipeline, I want `OrphanCleanupStep` to declare itself as destructive via a `destructive` property so that the engine-level gating mechanism protects it automatically, and the fragile string-matching guard can be removed.
 
-## Scope
+**Why this priority**: This story applies the engine-level mechanism (US1) to the only currently known destructive step. Without this, the old string-matching guard remains as the sole protection.
 
-1. Establish an opt-in `destructive` property convention for pipeline steps. The `PipelineStep` protocol itself is NOT modified; instead, `IngestEngine.run()` uses `getattr(step, 'destructive', False)` to detect the flag.
-2. Update `IngestEngine.run()` to check `context.errors` before executing any step that declares itself destructive, and skip it with a logged warning + recorded error if prior errors exist.
-3. Mark `OrphanCleanupStep` as `destructive = True`.
-4. Remove the string-matching guard (`any(e.startswith("StoreStep:") ...)`) from `OrphanCleanupStep.execute()`.
-5. Add/update tests to cover the new engine-level gating behavior, the `destructive` property on `OrphanCleanupStep`, and to remove assertions on the old string-matching behavior.
+**Independent Test**: Instantiate `OrphanCleanupStep` and verify `step.destructive is True`. Run an `IngestEngine` pipeline with a failing store step followed by `OrphanCleanupStep` and verify orphan data is not deleted.
 
-## Out of Scope
+**Acceptance Scenarios**:
 
-- Phase-based execution model (grouping steps into named phases like `analyze`, `write`, `cleanup`). The simple `destructive` flag is sufficient for the current pipeline shape.
-- Any changes to non-destructive steps (`ChunkStep`, `ContentHashStep`, `ChangeDetectionStep`, `DocumentSummaryStep`, `BodyOfKnowledgeSummaryStep`, `EmbedStep`, `StoreStep`).
-- Changes to ingest plugin wiring (`ingest_website/plugin.py`, `ingest_space/plugin.py`). These pass step lists to `IngestEngine` and are unaffected by the protocol extension.
+1. **Given** an `OrphanCleanupStep` instance, **When** `step.destructive` is checked, **Then** it returns `True`.
+2. **Given** a pipeline with a failing store step and an `OrphanCleanupStep`, **When** `IngestEngine.run()` executes, **Then** orphan cleanup is skipped and orphan data remains intact.
+3. **Given** `OrphanCleanupStep.execute()`, **When** the source code is inspected, **Then** it no longer contains the `startswith("StoreStep:")` string-matching guard.
 
-## Acceptance Criteria
+---
 
-1. Steps may optionally declare a `destructive` property returning `True`. The `PipelineStep` protocol is unchanged; the engine uses `getattr(step, 'destructive', False)` to detect the flag.
-2. `IngestEngine.run()` skips any step where `step.destructive is True` if `context.errors` is non-empty at that point, logs a warning, and appends a skip message to `context.errors`.
-3. `OrphanCleanupStep.destructive` returns `True`.
-4. `OrphanCleanupStep.execute()` no longer contains the `startswith("StoreStep:")` string-matching guard.
-5. Existing non-destructive steps continue to satisfy the `PipelineStep` protocol without changes (the `destructive` property defaults to `False` via the protocol or a mixin).
-6. All existing tests pass, with the orphan cleanup skip test updated to exercise the new engine-level mechanism instead of the old step-level string check.
-7. New tests cover: (a) engine skips destructive steps when errors exist; (b) engine runs destructive steps when no errors exist; (c) the `destructive` property on `OrphanCleanupStep`.
+### Edge Cases
 
-## Constraints
+- When a step has `destructive = True` but is positioned in the middle of the pipeline, non-destructive steps after it still execute normally.
+- When a non-destructive step does not define a `destructive` attribute, `getattr(step, 'destructive', False)` safely returns `False` -- no error, no behavioral change.
+- When all steps succeed, destructive steps run normally as if the flag did not exist.
+- When a destructive step is the first step in the pipeline and no errors exist, it executes normally.
 
-- Must remain backward-compatible with the existing `PipelineStep` protocol. Existing steps that do not define `destructive` must still satisfy the protocol (use `getattr` with default or a protocol with default).
-- No new runtime dependencies.
-- Must keep the pipeline engine's sequential execution model (see ADR-0004).
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `IngestEngine.run()` MUST check `getattr(step, 'destructive', False)` before executing each step.
+- **FR-002**: `IngestEngine.run()` MUST skip any step where `destructive` is `True` and `context.errors` is non-empty, appending a skip message to `context.errors`.
+- **FR-003**: `IngestEngine.run()` MUST log a warning when skipping a destructive step: `"Skipping destructive step '%s' due to %d prior error(s)"`.
+- **FR-004**: `IngestEngine.run()` MUST record `StepMetrics` for skipped destructive steps with `duration=0.0` and `error_count=1`.
+- **FR-005**: `OrphanCleanupStep` MUST declare a `destructive` property returning `True`.
+- **FR-006**: `OrphanCleanupStep.execute()` MUST NOT contain the `startswith("StoreStep:")` string-matching guard.
+- **FR-007**: The `PipelineStep` protocol MUST remain unchanged -- the `destructive` flag is opt-in via duck typing (`getattr` with default).
+- **FR-008**: Existing non-destructive steps MUST continue to satisfy the `PipelineStep` protocol without any modifications.
+
+### Key Entities
+
+- **Destructive Step Convention**: An opt-in property (`destructive: bool`) on pipeline steps. Steps that delete or modify existing data in irreversible ways declare `destructive = True`. The engine uses `getattr(step, 'destructive', False)` to detect the flag without modifying the `PipelineStep` protocol.
+- **Skip Message**: A formatted error string appended to `context.errors` when a destructive step is gated: `"{step.name}: skipped (destructive step gated by {N} prior error(s))"`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Destructive steps are automatically gated by any prior error, not just errors matching a specific string pattern.
+- **SC-002**: The `PipelineStep` protocol is unchanged -- existing steps work without modification.
+- **SC-003**: All new and existing tests pass (pytest green), including 7 new destructive gating tests.
+- **SC-004**: The string-matching guard in `OrphanCleanupStep` is fully removed, eliminating the fragile coupling to error message formats.
+
+## Assumptions
+
+- The `PipelineStep` protocol is `@runtime_checkable` and adding a `destructive` property to individual step classes does not break protocol conformance for other steps.
+- The sequential execution model of `IngestEngine.run()` (ADR-0004) is preserved -- destructive gating is a per-step check within the existing loop.
+- No new runtime dependencies are needed.
+- Only `OrphanCleanupStep` is currently destructive. Future destructive steps can opt in by adding the property.
+
+## Clarifications
+
+### C1: Protocol extension strategy for backward compatibility
+
+**Question**: Should `destructive` be added to the `PipelineStep` protocol, use a mixin, or use `getattr`?
+
+**Answer**: Use `getattr(step, 'destructive', False)` in `IngestEngine.run()`. The protocol remains unchanged. This is consistent with Python duck-typing conventions used elsewhere in this codebase.
+
+### C2: Error message format for skipped destructive steps
+
+**Question**: What format should the engine-level skip message use?
+
+**Answer**: `"{step.name}: skipped (destructive step gated by {N} prior error(s))"`. Consistent with how the engine already formats caught exception messages as `f"{step.name}: {exc}"`.
+
+### C3: Log level for skipping
+
+**Question**: What log level for a gated destructive skip?
+
+**Answer**: `logger.warning`. Not an exception (nothing crashed), but noteworthy enough for operators. The skip is an intentional safety mechanism, not routine.
+
+### C4: Metrics for skipped steps
+
+**Question**: Should `StepMetrics` be recorded for skipped destructive steps?
+
+**Answer**: Yes. Record with `duration=0.0`, current `items_in`/`items_out`, and `error_count=1`. Ensures monitoring dashboards always have entries for all configured steps.
+
+### C5: Destructive step in mid-pipeline
+
+**Question**: If a destructive step is not the last step, do subsequent non-destructive steps still run?
+
+**Answer**: Yes. The `destructive` flag only gates the specific step that declares it. Non-destructive steps always run.

--- a/specs/011-pipeline-destructive-step-safety/spec.md
+++ b/specs/011-pipeline-destructive-step-safety/spec.md
@@ -1,0 +1,41 @@
+# Spec: Pipeline Engine Safety -- Formalize Destructive Step Handling
+
+**Story:** #37
+**Status:** Draft
+**Author:** SDD Agent
+
+---
+
+## User Value
+
+Prevent data loss during ingestion by ensuring that destructive pipeline steps (e.g., orphan cleanup) are automatically skipped when earlier write steps have experienced errors. Currently, the only protection is a fragile string-matching guard in `OrphanCleanupStep` that checks for a `"StoreStep:"` prefix in `context.errors`. This does not generalize: if new destructive steps are added, or if error message formats change, the guard silently breaks. A first-class engine-level mechanism makes the pipeline intrinsically safe, regardless of how many destructive steps exist or how error messages are formatted.
+
+## Scope
+
+1. Establish an opt-in `destructive` property convention for pipeline steps. The `PipelineStep` protocol itself is NOT modified; instead, `IngestEngine.run()` uses `getattr(step, 'destructive', False)` to detect the flag.
+2. Update `IngestEngine.run()` to check `context.errors` before executing any step that declares itself destructive, and skip it with a logged warning + recorded error if prior errors exist.
+3. Mark `OrphanCleanupStep` as `destructive = True`.
+4. Remove the string-matching guard (`any(e.startswith("StoreStep:") ...)`) from `OrphanCleanupStep.execute()`.
+5. Add/update tests to cover the new engine-level gating behavior, the `destructive` property on `OrphanCleanupStep`, and to remove assertions on the old string-matching behavior.
+
+## Out of Scope
+
+- Phase-based execution model (grouping steps into named phases like `analyze`, `write`, `cleanup`). The simple `destructive` flag is sufficient for the current pipeline shape.
+- Any changes to non-destructive steps (`ChunkStep`, `ContentHashStep`, `ChangeDetectionStep`, `DocumentSummaryStep`, `BodyOfKnowledgeSummaryStep`, `EmbedStep`, `StoreStep`).
+- Changes to ingest plugin wiring (`ingest_website/plugin.py`, `ingest_space/plugin.py`). These pass step lists to `IngestEngine` and are unaffected by the protocol extension.
+
+## Acceptance Criteria
+
+1. Steps may optionally declare a `destructive` property returning `True`. The `PipelineStep` protocol is unchanged; the engine uses `getattr(step, 'destructive', False)` to detect the flag.
+2. `IngestEngine.run()` skips any step where `step.destructive is True` if `context.errors` is non-empty at that point, logs a warning, and appends a skip message to `context.errors`.
+3. `OrphanCleanupStep.destructive` returns `True`.
+4. `OrphanCleanupStep.execute()` no longer contains the `startswith("StoreStep:")` string-matching guard.
+5. Existing non-destructive steps continue to satisfy the `PipelineStep` protocol without changes (the `destructive` property defaults to `False` via the protocol or a mixin).
+6. All existing tests pass, with the orphan cleanup skip test updated to exercise the new engine-level mechanism instead of the old step-level string check.
+7. New tests cover: (a) engine skips destructive steps when errors exist; (b) engine runs destructive steps when no errors exist; (c) the `destructive` property on `OrphanCleanupStep`.
+
+## Constraints
+
+- Must remain backward-compatible with the existing `PipelineStep` protocol. Existing steps that do not define `destructive` must still satisfy the protocol (use `getattr` with default or a protocol with default).
+- No new runtime dependencies.
+- Must keep the pipeline engine's sequential execution model (see ADR-0004).

--- a/specs/011-pipeline-destructive-step-safety/tasks.md
+++ b/specs/011-pipeline-destructive-step-safety/tasks.md
@@ -1,58 +1,92 @@
 # Tasks: Pipeline Engine Safety -- Formalize Destructive Step Handling
 
-**Story:** #37
-**Plan:** `plan.md`
+**Input**: Design documents from `specs/011-pipeline-destructive-step-safety/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md
+**Organization**: Tasks grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Include exact file paths in descriptions
 
 ---
 
-## Task 1: Add destructive-step gating to IngestEngine.run()
+## Phase 1: User Story 1 -- Engine-Level Destructive Step Gating (Priority: P1) MVP
 
-**File:** `core/domain/pipeline/engine.py`
-**Depends on:** None
-**AC:**
-- Before calling `step.execute(context)`, the engine checks `getattr(step, 'destructive', False)`.
-- If `True` and `len(context.errors) > 0`, the step is skipped.
-- A warning log is emitted: `"Skipping destructive step '%s' due to %d prior error(s)"`.
-- An error is appended to `context.errors`: `"{step.name}: skipped (destructive step gated by {N} prior error(s))"`.
-- `StepMetrics` is recorded for the skipped step with `duration=0.0`, current `items_in`/`items_out`, and `error_count=1`.
-- Non-destructive steps are completely unaffected (existing behavior preserved).
+**Goal**: Add engine-level gating that automatically skips destructive steps when prior errors exist.
 
-**Tests:** T1a-T1e (Task 3)
+**Independent Test**: Run `IngestEngine` with an error-producing step followed by a destructive step. Verify the destructive step is not executed, a skip message is in errors, and metrics have `duration=0.0`.
 
-## Task 2: Mark OrphanCleanupStep as destructive and remove string-matching guard
+### Implementation for User Story 1
 
-**File:** `core/domain/pipeline/steps.py`
-**Depends on:** Task 1 (the engine must gate before we remove the step-level guard)
-**AC:**
-- `OrphanCleanupStep` gains a `@property` `destructive` returning `True`.
-- The lines `if any(e.startswith("StoreStep:") for e in context.errors): ...` (and the associated error append + return) are removed from `OrphanCleanupStep.execute()`.
-- `OrphanCleanupStep.execute()` now executes its cleanup logic unconditionally (the engine handles gating).
+- [X] T001 [US1] Add destructive-step gating logic in `IngestEngine.run()` in core/domain/pipeline/engine.py: before calling `step.execute(context)`, check `getattr(step, 'destructive', False)`; if True and `context.errors` is non-empty, skip with warning log, append skip message, record `StepMetrics` with `duration=0.0` and `error_count=1`
+- [X] T002 [P] [US1] Add test `test_engine_skips_destructive_step_with_prior_errors` in tests/core/domain/test_pipeline_steps.py: verify destructive step is not executed when errors exist, skip message appears in errors
+- [X] T003 [P] [US1] Add test `test_engine_runs_destructive_step_with_no_errors` in tests/core/domain/test_pipeline_steps.py: verify destructive step runs when no errors
+- [X] T004 [P] [US1] Add test `test_non_destructive_steps_run_despite_errors` in tests/core/domain/test_pipeline_steps.py: verify non-destructive steps execute regardless of errors
+- [X] T005 [P] [US1] Add test `test_multiple_destructive_steps_all_skipped` in tests/core/domain/test_pipeline_steps.py: verify all destructive steps skipped when errors exist
+- [X] T006 [P] [US1] Add test `test_destructive_step_skipped_after_failing_non_destructive` in tests/core/domain/test_pipeline_steps.py: verify destructive skipped after exception-raising step
+- [X] T007 [P] [US1] Add test `test_metrics_recorded_for_skipped_destructive_step` in tests/core/domain/test_pipeline_steps.py: verify `StepMetrics` has `duration=0.0` and `error_count=1`
+- [X] T008 [P] [US1] Add test `test_skip_message_format` in tests/core/domain/test_pipeline_steps.py: verify exact skip message format includes step name and error count
 
-**Tests:** T2a (Task 3)
+**Checkpoint**: Engine-level destructive gating is fully functional and tested independently.
 
-## Task 3: Add and update tests
+---
 
-**File:** `tests/core/domain/test_pipeline_steps.py`
-**Depends on:** Tasks 1 and 2
-**AC:**
+## Phase 2: User Story 2 -- OrphanCleanupStep Destructive Declaration (Priority: P2)
 
-**New tests (TestDestructiveStepGating class):**
-- **T1a:** Engine skips a destructive step when `context.errors` is non-empty. Verify step's `execute()` is not called, skip message is in errors, and metrics have `duration=0.0`, `error_count=1`.
-- **T1b:** Engine runs a destructive step when `context.errors` is empty. Verify step's `execute()` is called.
-- **T1c:** Non-destructive steps run even when errors exist. Verify `execute()` is called for non-destructive steps regardless of error state.
-- **T1d:** Multiple destructive steps: all are skipped when errors exist.
-- **T1e:** Destructive step after a failing non-destructive step: verify the destructive step is skipped due to the error introduced by the prior step's failure.
+**Goal**: Mark `OrphanCleanupStep` as destructive and remove the fragile string-matching guard.
 
-**New test in TestOrphanCleanupStep:**
-- **T2a:** `OrphanCleanupStep(...).destructive is True`.
+**Independent Test**: Instantiate `OrphanCleanupStep` and assert `step.destructive is True`. Run engine with failing store step followed by orphan cleanup and verify orphan data is preserved.
 
-**Updated test:**
-- **T3a:** `test_skips_cleanup_on_store_step_errors` is rewritten to use `IngestEngine` with a `FailingStoreStep` followed by `OrphanCleanupStep`. Verifies the orphan is NOT deleted and a skip message is in the result errors.
+### Implementation for User Story 2
 
-## Task 4: Verify all gates pass
+- [X] T009 [US2] Add `@property destructive` returning `True` to `OrphanCleanupStep` in core/domain/pipeline/steps.py
+- [X] T010 [US2] Remove the `if any(e.startswith("StoreStep:") ...)` string-matching guard and associated error append + return from `OrphanCleanupStep.execute()` in core/domain/pipeline/steps.py
+- [X] T011 [P] [US2] Add test `test_destructive_property` in tests/core/domain/test_pipeline_steps.py: assert `OrphanCleanupStep(...).destructive is True`
+- [X] T012 [US2] Update test `test_skips_cleanup_on_store_step_errors` in tests/core/domain/test_pipeline_steps.py: rewrite to use `IngestEngine` with `FailingStoreStep` followed by `OrphanCleanupStep`, verify orphan is NOT deleted and skip message contains "destructive step gated"
 
-**Depends on:** Tasks 1-3
-**AC:**
-- `poetry run pytest` passes (all tests green).
-- `poetry run ruff check core/ plugins/ tests/` passes (no lint errors).
-- `poetry run pyright core/ plugins/` passes (no type errors).
+**Checkpoint**: OrphanCleanupStep is protected by engine-level gating. String-matching guard fully removed.
+
+---
+
+## Phase 3: Polish & Cross-Cutting Concerns
+
+- [X] T013 Verify all gates pass: `poetry run pytest` (all green), `poetry run ruff check core/ plugins/ tests/` (no lint errors), `poetry run pyright core/ plugins/` (no type errors)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **User Story 1 (Phase 1)**: No dependencies -- start immediately
+- **User Story 2 (Phase 2)**: Depends on Phase 1 T001 (engine must gate before step-level guard is removed)
+- **Polish (Phase 3)**: Depends on all user stories complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Independent -- engine-level gating with no prerequisite changes
+- **User Story 2 (P2)**: Depends on US1 T001 (engine gating must exist before removing the old guard)
+
+### Parallel Opportunities
+
+**Phase 1**: T001 is sequential (engine code). T002-T008 are parallel (all test file, separate test classes).
+**Phase 2**: T009 and T010 are sequential (same file, same class). T011 and T012 parallel with each other but depend on T009/T010.
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Engine-level gating in `engine.py`
+2. Complete Phase 1 tests: 7 new tests validating gating behavior
+3. **STOP and VALIDATE**: Engine-level gating works with any step that declares `destructive = True`
+4. Deploy -- pipeline is intrinsically safer
+
+### Incremental Delivery
+
+1. Phase 1 -> Engine-level gating (MVP!)
+2. Add US2 -> OrphanCleanupStep migrated to engine gating -> Deploy
+3. Phase 3 -> Final validation

--- a/specs/011-pipeline-destructive-step-safety/tasks.md
+++ b/specs/011-pipeline-destructive-step-safety/tasks.md
@@ -1,0 +1,58 @@
+# Tasks: Pipeline Engine Safety -- Formalize Destructive Step Handling
+
+**Story:** #37
+**Plan:** `plan.md`
+
+---
+
+## Task 1: Add destructive-step gating to IngestEngine.run()
+
+**File:** `core/domain/pipeline/engine.py`
+**Depends on:** None
+**AC:**
+- Before calling `step.execute(context)`, the engine checks `getattr(step, 'destructive', False)`.
+- If `True` and `len(context.errors) > 0`, the step is skipped.
+- A warning log is emitted: `"Skipping destructive step '%s' due to %d prior error(s)"`.
+- An error is appended to `context.errors`: `"{step.name}: skipped (destructive step gated by {N} prior error(s))"`.
+- `StepMetrics` is recorded for the skipped step with `duration=0.0`, current `items_in`/`items_out`, and `error_count=1`.
+- Non-destructive steps are completely unaffected (existing behavior preserved).
+
+**Tests:** T1a-T1e (Task 3)
+
+## Task 2: Mark OrphanCleanupStep as destructive and remove string-matching guard
+
+**File:** `core/domain/pipeline/steps.py`
+**Depends on:** Task 1 (the engine must gate before we remove the step-level guard)
+**AC:**
+- `OrphanCleanupStep` gains a `@property` `destructive` returning `True`.
+- The lines `if any(e.startswith("StoreStep:") for e in context.errors): ...` (and the associated error append + return) are removed from `OrphanCleanupStep.execute()`.
+- `OrphanCleanupStep.execute()` now executes its cleanup logic unconditionally (the engine handles gating).
+
+**Tests:** T2a (Task 3)
+
+## Task 3: Add and update tests
+
+**File:** `tests/core/domain/test_pipeline_steps.py`
+**Depends on:** Tasks 1 and 2
+**AC:**
+
+**New tests (TestDestructiveStepGating class):**
+- **T1a:** Engine skips a destructive step when `context.errors` is non-empty. Verify step's `execute()` is not called, skip message is in errors, and metrics have `duration=0.0`, `error_count=1`.
+- **T1b:** Engine runs a destructive step when `context.errors` is empty. Verify step's `execute()` is called.
+- **T1c:** Non-destructive steps run even when errors exist. Verify `execute()` is called for non-destructive steps regardless of error state.
+- **T1d:** Multiple destructive steps: all are skipped when errors exist.
+- **T1e:** Destructive step after a failing non-destructive step: verify the destructive step is skipped due to the error introduced by the prior step's failure.
+
+**New test in TestOrphanCleanupStep:**
+- **T2a:** `OrphanCleanupStep(...).destructive is True`.
+
+**Updated test:**
+- **T3a:** `test_skips_cleanup_on_store_step_errors` is rewritten to use `IngestEngine` with a `FailingStoreStep` followed by `OrphanCleanupStep`. Verifies the orphan is NOT deleted and a skip message is in the result errors.
+
+## Task 4: Verify all gates pass
+
+**Depends on:** Tasks 1-3
+**AC:**
+- `poetry run pytest` passes (all tests green).
+- `poetry run ruff check core/ plugins/ tests/` passes (no lint errors).
+- `poetry run pyright core/ plugins/` passes (no type errors).

--- a/tests/core/domain/test_pipeline_steps.py
+++ b/tests/core/domain/test_pipeline_steps.py
@@ -568,6 +568,261 @@ class TestIngestEngine:
 
 
 # ---------------------------------------------------------------------------
+# T037: Destructive step gating tests
+# ---------------------------------------------------------------------------
+
+
+class TestDestructiveStepGating:
+    """Verify IngestEngine skips destructive steps when prior errors exist."""
+
+    async def test_engine_skips_destructive_step_with_prior_errors(self):
+        """Destructive step is not executed when context has errors."""
+        executed = []
+
+        class ErrorStep:
+            @property
+            def name(self):
+                return "error_step"
+
+            async def execute(self, context):
+                context.errors.append("error_step: something went wrong")
+
+        class DestructiveStep:
+            @property
+            def name(self):
+                return "cleanup"
+
+            @property
+            def destructive(self):
+                return True
+
+            async def execute(self, context):
+                executed.append("cleanup")
+
+        engine = IngestEngine(steps=[
+            ErrorStep(),  # type: ignore[list-item]
+            DestructiveStep(),  # type: ignore[list-item]
+        ])
+        result = await engine.run([], "test")
+
+        assert "cleanup" not in executed
+        assert any("destructive step gated" in e for e in result.errors)
+        assert result.success is False
+
+    async def test_engine_runs_destructive_step_with_no_errors(self):
+        """Destructive step executes normally when no prior errors exist."""
+        executed = []
+
+        class DestructiveStep:
+            @property
+            def name(self):
+                return "cleanup"
+
+            @property
+            def destructive(self):
+                return True
+
+            async def execute(self, context):
+                executed.append("cleanup")
+
+        engine = IngestEngine(steps=[
+            DestructiveStep(),  # type: ignore[list-item]
+        ])
+        result = await engine.run([], "test")
+
+        assert "cleanup" in executed
+        assert result.success is True
+
+    async def test_non_destructive_steps_run_despite_errors(self):
+        """Non-destructive steps run regardless of prior errors."""
+        executed = []
+
+        class ErrorStep:
+            @property
+            def name(self):
+                return "error_step"
+
+            async def execute(self, context):
+                context.errors.append("error_step: failure")
+
+        class NormalStep:
+            @property
+            def name(self):
+                return "normal"
+
+            async def execute(self, context):
+                executed.append("normal")
+
+        engine = IngestEngine(steps=[
+            ErrorStep(),  # type: ignore[list-item]
+            NormalStep(),  # type: ignore[list-item]
+        ])
+        result = await engine.run([], "test")
+
+        assert "normal" in executed
+        assert result.success is False
+
+    async def test_multiple_destructive_steps_all_skipped(self):
+        """All destructive steps are skipped when errors exist."""
+        executed = []
+
+        class ErrorStep:
+            @property
+            def name(self):
+                return "error_step"
+
+            async def execute(self, context):
+                context.errors.append("error_step: failure")
+
+        class DestructiveA:
+            @property
+            def name(self):
+                return "cleanup_a"
+
+            @property
+            def destructive(self):
+                return True
+
+            async def execute(self, context):
+                executed.append("cleanup_a")
+
+        class DestructiveB:
+            @property
+            def name(self):
+                return "cleanup_b"
+
+            @property
+            def destructive(self):
+                return True
+
+            async def execute(self, context):
+                executed.append("cleanup_b")
+
+        engine = IngestEngine(steps=[
+            ErrorStep(),  # type: ignore[list-item]
+            DestructiveA(),  # type: ignore[list-item]
+            DestructiveB(),  # type: ignore[list-item]
+        ])
+        result = await engine.run([], "test")
+
+        assert executed == []
+        assert any("cleanup_a" in e and "destructive step gated" in e for e in result.errors)
+        assert any("cleanup_b" in e and "destructive step gated" in e for e in result.errors)
+
+    async def test_destructive_step_skipped_after_failing_non_destructive(self):
+        """Destructive step is skipped when a prior non-destructive step raises an exception."""
+        executed = []
+
+        class RaisingStep:
+            @property
+            def name(self):
+                return "raiser"
+
+            async def execute(self, context):
+                raise RuntimeError("unexpected crash")
+
+        class DestructiveStep:
+            @property
+            def name(self):
+                return "cleanup"
+
+            @property
+            def destructive(self):
+                return True
+
+            async def execute(self, context):
+                executed.append("cleanup")
+
+        engine = IngestEngine(steps=[
+            RaisingStep(),  # type: ignore[list-item]
+            DestructiveStep(),  # type: ignore[list-item]
+        ])
+        result = await engine.run([], "test")
+
+        assert "cleanup" not in executed
+        assert any("destructive step gated" in e for e in result.errors)
+
+    async def test_metrics_recorded_for_skipped_destructive_step(self):
+        """Skipped destructive steps get StepMetrics with duration=0.0 and error_count=1."""
+
+        class ErrorStep:
+            @property
+            def name(self):
+                return "error_step"
+
+            async def execute(self, context):
+                context.errors.append("error_step: failure")
+
+        class DestructiveStep:
+            @property
+            def name(self):
+                return "cleanup"
+
+            @property
+            def destructive(self):
+                return True
+
+            async def execute(self, context):
+                pass  # pragma: no cover
+
+        captured_metrics: dict = {}
+
+        class MetricCapture:
+            @property
+            def name(self):
+                return "capture"
+
+            async def execute(self, context):
+                captured_metrics.update(context.metrics)
+
+        engine = IngestEngine(steps=[
+            ErrorStep(),  # type: ignore[list-item]
+            DestructiveStep(),  # type: ignore[list-item]
+            MetricCapture(),  # type: ignore[list-item]
+        ])
+        await engine.run([], "test")
+
+        assert "cleanup" in captured_metrics
+        m = captured_metrics["cleanup"]
+        assert m.duration == 0.0
+        assert m.error_count == 1
+
+    async def test_skip_message_format(self):
+        """Verify the exact format of the skip message includes step name and error count."""
+
+        class ErrorStep:
+            @property
+            def name(self):
+                return "error_step"
+
+            async def execute(self, context):
+                context.errors.append("error_step: fail 1")
+                context.errors.append("error_step: fail 2")
+
+        class DestructiveStep:
+            @property
+            def name(self):
+                return "cleanup"
+
+            @property
+            def destructive(self):
+                return True
+
+            async def execute(self, context):
+                pass  # pragma: no cover
+
+        engine = IngestEngine(steps=[
+            ErrorStep(),  # type: ignore[list-item]
+            DestructiveStep(),  # type: ignore[list-item]
+        ])
+        result = await engine.run([], "test")
+
+        skip_msgs = [e for e in result.errors if "destructive step gated" in e]
+        assert len(skip_msgs) == 1
+        assert skip_msgs[0] == "cleanup: skipped (destructive step gated by 2 prior error(s))"
+
+
+# ---------------------------------------------------------------------------
 # T010: ChangeDetectionStep tests
 # ---------------------------------------------------------------------------
 
@@ -828,25 +1083,50 @@ class TestOrphanCleanupStep:
         assert len(ctx.errors) == 0
 
     async def test_skips_cleanup_on_store_step_errors(self):
-        """Cleanup is skipped when StoreStep had write failures."""
+        """Engine-level destructive gating: cleanup is skipped when StoreStep had write failures."""
         store = MockKnowledgeStorePort()
         store.collections["coll"] = [
             {"id": "orphan-1", "metadata": {"documentId": "doc-1"}, "document": "old"},
         ]
 
-        ctx = PipelineContext(
-            collection_name="coll",
-            documents=[],
-            orphan_ids={"orphan-1"},
-            errors=["StoreStep: storage failed for batch 0: connection refused"],
-        )
-        await OrphanCleanupStep(knowledge_store_port=store).execute(ctx)
+        class FailingStoreStep:
+            @property
+            def name(self):
+                return "store"
+
+            async def execute(self, context):
+                context.errors.append("store: storage failed for batch 0: connection refused")
+
+        engine = IngestEngine(steps=[
+            FailingStoreStep(),  # type: ignore[list-item]
+            OrphanCleanupStep(knowledge_store_port=store),
+        ])
+        # Pre-populate context: engine creates a fresh context, so we run with
+        # a step that sets up orphan_ids first.
+        class SetupStep:
+            @property
+            def name(self):
+                return "setup"
+
+            async def execute(self, context):
+                context.orphan_ids = {"orphan-1"}
+
+        engine = IngestEngine(steps=[
+            SetupStep(),  # type: ignore[list-item]
+            FailingStoreStep(),  # type: ignore[list-item]
+            OrphanCleanupStep(knowledge_store_port=store),
+        ])
+        result = await engine.run([], "coll")
 
         # Orphan should NOT have been deleted
         remaining_ids = [it["id"] for it in store.collections["coll"]]
         assert "orphan-1" in remaining_ids
-        assert ctx.chunks_deleted == 0
-        assert any("skipped cleanup" in e for e in ctx.errors)
+        assert result.chunks_deleted == 0
+        assert any("destructive step gated" in e for e in result.errors)
+
+    async def test_destructive_property(self):
+        store = MockKnowledgeStorePort()
+        assert OrphanCleanupStep(knowledge_store_port=store).destructive is True
 
     async def test_step_name(self):
         store = MockKnowledgeStorePort()


### PR DESCRIPTION
## Summary

- Add engine-level safety gate in `IngestEngine.run()` that skips steps declaring `destructive=True` when prior pipeline errors exist, using `getattr(step, 'destructive', False)` for backward compatibility
- Mark `OrphanCleanupStep` as `destructive=True` and remove the fragile string-matching guard (`startswith("StoreStep:")`) that was the only protection against data loss
- Add 7 new tests for destructive step gating (skip, run, non-destructive passthrough, multiple destructive, exception-triggered gate, metrics, message format) and update the existing orphan cleanup skip test to exercise the engine-level mechanism

Closes #37

## SDD Artifacts

- `specs/011-pipeline-destructive-step-safety/spec.md`
- `specs/011-pipeline-destructive-step-safety/clarifications.md`
- `specs/011-pipeline-destructive-step-safety/plan.md`
- `specs/011-pipeline-destructive-step-safety/tasks.md`

## SDD Loop Counts

- Clarify iterations: 2
- Analyze iterations: 2

## Test plan

- [x] All 340 existing tests pass (0 regressions)
- [x] 7 new `TestDestructiveStepGating` tests pass
- [x] Updated `test_skips_cleanup_on_store_step_errors` passes via engine-level gating
- [x] `test_destructive_property` confirms `OrphanCleanupStep.destructive is True`
- [x] `ruff check` clean
- [x] `pyright` 0 errors (pre-existing warnings unchanged)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Engine now gates destructive pipeline steps: any step marked destructive is skipped if earlier steps produced errors, preventing unintended deletions.

* **Behavior Change**
  * Cleanup step that removes orphaned/removed documents is now treated as destructive and will be gated by the engine when prior errors exist.

* **Documentation**
  * Added spec, quickstart, research, checklist, and plan docs describing gating behavior, messages, and metrics.

* **Tests**
  * Added tests covering destructive-step gating, metrics for skipped steps, and related scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->