### PR TITLE
fix: fill missing required fields with type defaults in PromptGraph (spec 029)

### DIFF
--- a/core/domain/prompt_graph.py
+++ b/core/domain/prompt_graph.py
@@ -53,13 +53,53 @@ class PromptGraph:
         self._compiled = None
 
     @staticmethod
+    def _default_for_annotation(annotation: Any) -> Any:
+        """Pick a permissive default value for a Pydantic field annotation.
+
+        Used by :meth:`_recover_fields` to fill in fields that the LLM
+        dropped entirely. The intent is to keep the response flowing when
+        a small model omits an auxiliary required field (e.g.
+        ``answer_language``) rather than dead-lettering the whole message.
+        """
+        import typing
+
+        origin = typing.get_origin(annotation)
+
+        # Unwrap Optional[X] / Union[X, None] → X (first non-None arg).
+        if origin is typing.Union or origin is getattr(
+            __import__("types"), "UnionType", None
+        ):
+            args = [a for a in typing.get_args(annotation) if a is not type(None)]
+            if not args:
+                return None
+            annotation = args[0]
+            origin = typing.get_origin(annotation)
+
+        if annotation is str:
+            return ""
+        if annotation is bool:
+            return False
+        if annotation in (int, float):
+            return 0
+        if origin is list or annotation is list:
+            return []
+        if origin is dict or annotation is dict:
+            return {}
+        # Nested BaseModel or unknown → try {}; Pydantic will coerce or fail.
+        if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+            return {}
+        return None
+
+    @staticmethod
     def _recover_fields(raw_text: str, model: type[BaseModel]) -> dict | None:
         """Best-effort recovery of model fields from free-form LLM output.
 
         Used when ``PydanticOutputParser`` fails because the LLM wrapped
-        the required keys under extra objects.  We find the JSON body,
-        walk it and pluck any key matching a model field.  Missing
-        required fields abort the recovery.
+        the required keys under extra objects, or dropped a required
+        auxiliary field (common with small/terse models). We find the JSON
+        body, walk it, pluck any key matching a model field, and fill
+        missing required fields with type-appropriate defaults so the
+        response can still flow.
         """
         import json as _json
         import re as _re
@@ -102,7 +142,7 @@ class PromptGraph:
         if not found:
             return None
         # Drop null values for required fields so the validator can use
-        # defaults or report the real missing-field error.
+        # defaults or we can fill them below.
         for name, finfo in model.model_fields.items():
             if finfo.is_required() and found.get(name) is None:
                 found.pop(name, None)
@@ -111,8 +151,23 @@ class PromptGraph:
             name for name, finfo in model.model_fields.items()
             if finfo.is_required()
         }
-        if required - found.keys():
-            return None
+        missing_required = required - found.keys()
+        if missing_required:
+            # Fill missing required fields with type-appropriate defaults.
+            # This keeps responses flowing when a small LLM drops an
+            # auxiliary field (e.g. ``answer_language``) rather than
+            # failing the whole message.
+            filled = []
+            for name in missing_required:
+                finfo = model.model_fields[name]
+                found[name] = PromptGraph._default_for_annotation(
+                    finfo.annotation
+                )
+                filled.append(name)
+            logger.warning(
+                "Recovery filled missing required fields with defaults: %s",
+                ", ".join(sorted(filled)),
+            )
         try:
             return model.model_validate(found).model_dump()
         except Exception:

--- a/specs/029-promptgraph-field-recovery/checklists/requirements.md
+++ b/specs/029-promptgraph-field-recovery/checklists/requirements.md
@@ -1,0 +1,43 @@
+# Specification Quality Checklist: PromptGraph Field Recovery
+
+**Purpose**: Validate specification completeness and quality
+**Created**: 2026-04-23
+**Feature**: [spec.md](../spec.md)
+
+## Completeness
+
+- [X] CHK001 All mandatory sections present (User Scenarios, Requirements, Success Criteria, Assumptions)
+- [X] CHK002 User stories have priorities assigned (P1, P2, P3)
+- [X] CHK003 Each user story has acceptance scenarios with Given/When/Then
+- [X] CHK004 Edge cases documented (all fields missing, nested BaseModel, Optional unwrapping, null values, validation failure after fill)
+- [X] CHK005 Functional requirements are concrete and testable (FR-001 through FR-007)
+- [X] CHK006 Success criteria are measurable (SC-001 through SC-004)
+
+## Quality
+
+- [X] CHK007 Spec reads as a specification, not code description
+- [X] CHK008 Business/user language used (response delivered, answer lost, error reply)
+- [X] CHK009 Each user story is independently testable
+- [X] CHK010 Requirements trace to user stories (FR-001/FR-002 -> US2, FR-003 -> US1, FR-004 -> US3)
+- [X] CHK011 No placeholder text or template markers remain
+
+## Consistency
+
+- [X] CHK012 Spec aligns with plan.md technical approach
+- [X] CHK013 Data model section documents behavior change and default mapping table
+- [X] CHK014 All changed files accounted for in tasks.md (prompt_graph.py, test_prompt_graph.py)
+- [X] CHK015 Task count matches scope of changes (11 tasks for 2 files, ~120 lines)
+
+## Constitution Compliance
+
+- [X] CHK016 No port/adapter boundary violations (changes in core/domain only)
+- [X] CHK017 No cross-plugin coupling introduced
+- [X] CHK018 Changes in appropriate layer (core/domain = shared internal logic per Domain Logic Isolation standard)
+- [X] CHK019 Async-first maintained (recovery is pure synchronous transformation inside async node)
+- [X] CHK020 Tests are meaningful, not filler (each guards a specific type default or regression case per P7)
+
+## Notes
+
+- No contracts/ directory needed -- no external interface changes
+- No new configuration -- recovery behavior is automatic
+- 7 new tests cover: str, dict, list, bool, int defaults, plus text-alias recovery and real-world Mistral-Small regression

--- a/specs/029-promptgraph-field-recovery/checklists/requirements.md
+++ b/specs/029-promptgraph-field-recovery/checklists/requirements.md
@@ -40,4 +40,4 @@
 
 - No contracts/ directory needed -- no external interface changes
 - No new configuration -- recovery behavior is automatic
-- 7 new tests cover: str, dict, list, bool, int defaults, plus text-alias recovery and real-world Mistral-Small regression
+- 6 new tests cover: str, dict, list, bool, int defaults, and real-world Mistral-Small regression

--- a/specs/029-promptgraph-field-recovery/data-model.md
+++ b/specs/029-promptgraph-field-recovery/data-model.md
@@ -1,0 +1,32 @@
+# Data Model: PromptGraph Field Recovery
+
+**Feature Branch**: `029-promptgraph-field-recovery`
+**Date**: 2026-04-23
+
+## No New Pydantic Models
+
+This feature modifies the internal recovery behavior of `PromptGraph._recover_fields`. No new Pydantic models, event schemas, or persistent data structures are introduced.
+
+## Default Mapping Table
+
+The new `_default_for_annotation` static method maps Python type annotations to fill-in defaults for missing required fields:
+
+| Annotation | Default Value | Rationale |
+|---|---|---|
+| `str` | `""` | Empty string passes str validation; safe for text fields |
+| `bool` | `False` | Conservative boolean default |
+| `int` | `0` | Numeric zero-value |
+| `float` | `0` | Numeric zero-value |
+| `list` / `list[T]` | `[]` | Empty collection |
+| `dict` / `dict[K, V]` | `{}` | Empty mapping |
+| `BaseModel` subclass | `{}` | Pydantic coerces to nested model using its own field defaults |
+| `Optional[X]` / `X \| None` | Default of `X` | Unwrapped to inner type before lookup |
+| Unknown / unrecognized | `None` | Fallback; may cause validation failure for non-optional fields |
+
+## Behavior Change in `_recover_fields`
+
+**Before**: If any required field was missing after the JSON walk, `_recover_fields` returned `None`, discarding the entire recovery attempt.
+
+**After**: Missing required fields are filled with type-appropriate defaults from the table above. A WARNING log lists the filled field names. `model_validate` is then attempted with the filled data. If validation still fails (e.g., a custom validator rejects the default), `_recover_fields` returns `None` as before.
+
+The change is localized to the `missing_required` handling block in `_recover_fields` (lines 150-170 of `core/domain/prompt_graph.py`).

--- a/specs/029-promptgraph-field-recovery/plan.md
+++ b/specs/029-promptgraph-field-recovery/plan.md
@@ -1,0 +1,62 @@
+# Implementation Plan: PromptGraph Field Recovery
+
+**Branch**: `029-promptgraph-field-recovery` | **Date**: 2026-04-23 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/029-promptgraph-field-recovery/spec.md`
+
+## Summary
+
+Adds type-aware default filling to `PromptGraph._recover_fields` so that missing required fields from small/terse LLMs are filled with sensible defaults (`""`, `0`, `False`, `[]`, `{}`) instead of aborting the entire recovery. A new static method `_default_for_annotation` maps Python type annotations to safe defaults, with `Optional[X]` unwrapping. Warning logs identify filled fields for observability.
+
+## Technical Context
+
+**Language/Version**: Python 3.12
+**Primary Dependencies**: Pydantic v2, LangGraph, LangChain
+**Storage**: N/A (in-memory recovery logic)
+**Testing**: pytest with asyncio_mode=auto
+**Target Platform**: Linux container (K8s)
+**Project Type**: Microservice (microkernel + hexagonal architecture)
+
+## Constitution Check
+
+| Principle/Standard | Status | Notes |
+|---|---|---|
+| P1 AI-Native Development | PASS | Single-concern fix, fully automatable |
+| P2 SOLID Architecture | PASS | Single Responsibility -- `_default_for_annotation` has one job; `_recover_fields` has one job. No new classes or interfaces needed |
+| P3 No Vendor Lock-in | N/A | No provider-specific changes; fix benefits all LLM providers |
+| P4 Optimised Feedback Loops | PASS | 7 new targeted tests; all deterministic; local pytest execution |
+| P5 Best Available Infrastructure | N/A | No CI/CD changes |
+| P6 Spec-Driven Development | PASS | This retrospec documents the change |
+| P7 No Filling Tests | PASS | Each test guards a specific behavioral contract (type default, regression case) |
+| P8 ADR | N/A | No architectural decision -- behavioral enhancement within existing recovery mechanism |
+| Microkernel Architecture | PASS | Changes in `core/domain/` -- shared internal logic, not a plugin |
+| Hexagonal Boundaries | PASS | No port or adapter changes |
+| Plugin Contract | PASS | No contract changes |
+| Event Schema | PASS | No event model changes |
+| Domain Logic Isolation | PASS | `_recover_fields` and `_default_for_annotation` are domain logic in `core/domain/prompt_graph.py` |
+| Async-First | PASS | Recovery is synchronous by design (pure data transformation inside an async node) |
+| Simplicity Over Speculation | PASS | Handles exactly the types Pydantic models use; no speculative extensions |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/029-promptgraph-field-recovery/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── tasks.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code
+
+```text
+core/domain/prompt_graph.py                    # ~40 lines added: _default_for_annotation + _recover_fields fill logic
+tests/core/domain/test_prompt_graph.py         # ~80 lines added: 7 new tests in TestRecoverFields
+```
+
+**Structure Decision**: Two-file change -- the recovery logic and its tests. Both are in `core/domain/`, consistent with the Domain Logic Isolation standard.

--- a/specs/029-promptgraph-field-recovery/plan.md
+++ b/specs/029-promptgraph-field-recovery/plan.md
@@ -56,7 +56,7 @@ specs/029-promptgraph-field-recovery/
 
 ```text
 core/domain/prompt_graph.py                    # ~40 lines added: _default_for_annotation + _recover_fields fill logic
-tests/core/domain/test_prompt_graph.py         # ~80 lines added: 7 new tests in TestRecoverFields
+tests/core/domain/test_prompt_graph.py         # ~80 lines added: 6 new tests in TestRecoverFields
 ```
 
 **Structure Decision**: Two-file change -- the recovery logic and its tests. Both are in `core/domain/`, consistent with the Domain Logic Isolation standard.

--- a/specs/029-promptgraph-field-recovery/quickstart.md
+++ b/specs/029-promptgraph-field-recovery/quickstart.md
@@ -1,0 +1,32 @@
+# Quickstart: PromptGraph Field Recovery
+
+**Feature Branch**: `029-promptgraph-field-recovery`
+**Date**: 2026-04-23
+
+## What it does
+
+Improves the PromptGraph's structured output recovery so that missing required fields from small/terse LLMs (e.g., Mistral-Small) are filled with type-appropriate defaults instead of aborting the entire response. Users who previously received errors when an auxiliary field was dropped now receive their answer with the missing field set to a safe default.
+
+## New Configuration
+
+None. No new environment variables, settings, or configuration changes.
+
+## How to verify
+
+1. Deploy with a small LLM (e.g., Mistral-Small) configured as the provider.
+2. Send a query through a PromptGraph node whose output schema requires multiple fields (e.g., `knowledge_answer`, `answer_language`, `source_scores`).
+3. If the LLM drops an auxiliary field:
+   - **Before**: Response lost, user receives error or empty reply.
+   - **After**: Response delivered with the missing field set to its type default.
+4. Check logs for: `WARNING ... Recovery filled missing required fields with defaults: answer_language`
+5. Run the test suite to confirm:
+   ```bash
+   poetry run pytest tests/core/domain/test_prompt_graph.py -v -k "recover"
+   ```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `core/domain/prompt_graph.py` | Added `_default_for_annotation` static method; updated `_recover_fields` to fill missing required fields with type defaults and log a warning |
+| `tests/core/domain/test_prompt_graph.py` | Added 7 new tests: `test_fills_missing_str_with_empty_string`, `test_fills_missing_dict_with_empty_dict`, `test_fills_missing_list_with_empty_list`, `test_fills_missing_bool_with_false`, `test_fills_missing_int_with_zero`, `test_real_world_answer_response_shape`, plus type-default coverage via the existing recovery test class |

--- a/specs/029-promptgraph-field-recovery/quickstart.md
+++ b/specs/029-promptgraph-field-recovery/quickstart.md
@@ -29,4 +29,4 @@ None. No new environment variables, settings, or configuration changes.
 | File | Change |
 |------|--------|
 | `core/domain/prompt_graph.py` | Added `_default_for_annotation` static method; updated `_recover_fields` to fill missing required fields with type defaults and log a warning |
-| `tests/core/domain/test_prompt_graph.py` | Added 7 new tests: `test_fills_missing_str_with_empty_string`, `test_fills_missing_dict_with_empty_dict`, `test_fills_missing_list_with_empty_list`, `test_fills_missing_bool_with_false`, `test_fills_missing_int_with_zero`, `test_real_world_answer_response_shape`, plus type-default coverage via the existing recovery test class |
+| `tests/core/domain/test_prompt_graph.py` | Added 6 new tests: `test_fills_missing_str_with_empty_string`, `test_fills_missing_dict_with_empty_dict`, `test_fills_missing_list_with_empty_list`, `test_fills_missing_bool_with_false`, `test_fills_missing_int_with_zero`, `test_real_world_answer_response_shape` |

--- a/specs/029-promptgraph-field-recovery/research.md
+++ b/specs/029-promptgraph-field-recovery/research.md
@@ -1,0 +1,60 @@
+# Research: PromptGraph Field Recovery
+
+**Feature Branch**: `029-promptgraph-field-recovery`
+**Date**: 2026-04-23
+
+## Decision Summary
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | Fill missing fields with type-appropriate defaults vs. return None | Preserves valid responses when only auxiliary fields are missing |
+| D2 | Type-based defaults vs. generic None | Non-optional fields reject None; type-aware defaults pass Pydantic validation |
+| D3 | Unwrap Optional before selecting default | Optional[str] should default to "" not None, since the field was required |
+| D4 | Log warning vs. silent filling | Provides observability for model quality without blocking the response |
+| D5 | Static method on PromptGraph vs. standalone function | Co-locates with the only caller; avoids module-level function clutter |
+
+## Decisions
+
+### D1: Fill missing required fields with type-appropriate defaults
+
+**Decision**: When `_recover_fields` finds some but not all required fields in the LLM output, fill the missing ones with type-appropriate defaults and proceed with validation.
+
+**Rationale**: The previous behavior returned `None` when any required field was missing, discarding the entire response -- including correctly extracted primary fields. This was triggered in production by Mistral-Small dropping the `answer_language` field while correctly providing `knowledge_answer` and `source_scores`. The user received an error for what was a valid answer.
+
+**Alternatives considered**:
+- Return None (previous behavior): Rejected because it kills valid responses over cosmetic fields.
+- Fill all missing fields with None: Rejected because Pydantic rejects None for non-optional required fields like `str` or `int`.
+- Make all fields optional in the schema: Rejected because that weakens the schema contract for well-behaved LLMs and shifts the problem downstream.
+
+### D2: Type-based defaults instead of generic None
+
+**Decision**: Map each Python type annotation to a sensible zero-value: `""` for str, `False` for bool, `0` for int/float, `[]` for list, `{}` for dict and BaseModel.
+
+**Rationale**: Pydantic v2 strictly validates field types. A `str` field receiving `None` raises `ValidationError`. Each type has a natural "empty" or "zero" value that passes validation and is semantically safe for auxiliary fields (e.g., empty string for a language hint, empty dict for source scores).
+
+**Alternatives considered**:
+- Use `field.default` from the model: Rejected because these are *required* fields -- they have no default.
+- Use `field.default_factory`: Same problem -- required fields don't have factories.
+
+### D3: Unwrap Optional[X] / Union[X, None] before selecting default
+
+**Decision**: If the annotation is `Optional[str]` (i.e., `Union[str, None]`), extract `str` and return its default (`""`).
+
+**Rationale**: A required field can be typed as `Optional[str]` in Pydantic v2 (meaning it accepts None but has no default). Since we are filling in for a missing *required* field, we want the most useful value -- the unwrapped type's zero-value -- rather than None. This also handles Python 3.10+ `str | None` union syntax via `types.UnionType`.
+
+### D4: Log a warning when defaults are applied
+
+**Decision**: Emit a WARNING-level log listing the field names filled with defaults.
+
+**Rationale**: Silent filling would mask LLM quality issues. Operators need to know which models are dropping fields to tune prompts or switch providers. WARNING level is appropriate because the response still flows (no data loss) but the behavior is unexpected and actionable.
+
+**Alternatives considered**:
+- DEBUG level: Rejected because this is actionable operational information, not diagnostic noise.
+- ERROR level: Rejected because the response is successfully recovered -- it is not an error.
+- No logging: Rejected because it makes model regression invisible.
+
+### D5: Static method placement on PromptGraph
+
+**Decision**: `_default_for_annotation` is a `@staticmethod` on the `PromptGraph` class.
+
+**Rationale**: Its only caller is `_recover_fields`, also a static method on `PromptGraph`. Co-locating keeps the recovery logic self-contained. A module-level utility function would be equally valid but adds no benefit and separates related logic.

--- a/specs/029-promptgraph-field-recovery/spec.md
+++ b/specs/029-promptgraph-field-recovery/spec.md
@@ -1,0 +1,98 @@
+# Feature Specification: PromptGraph Field Recovery
+
+**Feature Branch**: `029-promptgraph-field-recovery`
+**Created**: 2026-04-23
+**Status**: Implemented
+**Input**: Retrospec from code changes
+
+## User Scenarios & Testing
+
+### User Story 1 - Responses Survive When Small LLMs Drop Auxiliary Required Fields (Priority: P1)
+
+As a virtual contributor user querying through a small LLM (e.g. Mistral-Small), when the model produces a correct primary answer but omits an auxiliary required field (e.g. `answer_language`), the system fills the missing field with a safe default and delivers my response instead of silently discarding the entire answer.
+
+**Why this priority**: Small and terse LLMs frequently produce valid structured output for the primary fields but drop auxiliary required fields. Previously, `_recover_fields` returned `None` when any required field was missing, causing the entire response to be lost and the user to receive an error or empty reply for what was an otherwise correct answer.
+
+**Independent Test**: Send a query via a PromptGraph node whose output schema requires `knowledge_answer`, `answer_language`, and `source_scores`. Use Mistral-Small or simulate its behavior by providing JSON with `answer_language` omitted. Verify the response is delivered with `answer_language` set to `""`.
+
+**Acceptance Scenarios**:
+
+1. **Given** an LLM response containing `knowledge_answer` and `source_scores` but missing `answer_language`, **When** `_recover_fields` processes it, **Then** it returns a valid dict with `answer_language` set to `""`.
+2. **Given** an LLM response where the only required `str` field is present, **When** no other fields are missing, **Then** `_recover_fields` returns the validated model without any default filling.
+3. **Given** an LLM response where all required fields are missing (no recognized keys at all), **When** `_recover_fields` processes it, **Then** it returns `None` (no data to recover).
+4. **Given** an LLM response missing a required `bool` field, **When** `_recover_fields` processes it, **Then** the field is filled with `False`.
+
+---
+
+### User Story 2 - Type-Appropriate Defaults for All Common Python Types (Priority: P2)
+
+As a developer defining PromptGraph output schemas, when the recovery mechanism fills a missing field, it uses a sensible type-appropriate default (empty string, zero, empty list, etc.) rather than a generic `None` that would fail Pydantic validation for non-optional fields.
+
+**Why this priority**: Using `None` as a universal fill-in would cause Pydantic validation to reject non-optional `str`, `int`, `bool`, `list`, and `dict` fields. Type-aware defaults ensure the model validates successfully and the response flows through the pipeline.
+
+**Independent Test**: Create Pydantic models with required fields of each supported type (`str`, `bool`, `int`, `float`, `list`, `dict`, nested `BaseModel`, `Optional[str]`). Call `_default_for_annotation` for each and verify the expected default.
+
+**Acceptance Scenarios**:
+
+1. **Given** annotation `str`, **When** `_default_for_annotation` is called, **Then** returns `""`.
+2. **Given** annotation `bool`, **When** `_default_for_annotation` is called, **Then** returns `False`.
+3. **Given** annotation `int` or `float`, **When** `_default_for_annotation` is called, **Then** returns `0`.
+4. **Given** annotation `list` or `list[str]`, **When** `_default_for_annotation` is called, **Then** returns `[]`.
+5. **Given** annotation `dict` or `dict[str, int]`, **When** `_default_for_annotation` is called, **Then** returns `{}`.
+6. **Given** a nested `BaseModel` subclass, **When** `_default_for_annotation` is called, **Then** returns `{}`.
+7. **Given** `Optional[str]` (i.e., `Union[str, None]`), **When** `_default_for_annotation` is called, **Then** unwraps to `str` and returns `""`.
+8. **Given** an unknown/unrecognized annotation, **When** `_default_for_annotation` is called, **Then** returns `None`.
+
+---
+
+### User Story 3 - Warning Logging When Defaults Are Applied (Priority: P3)
+
+As a developer monitoring production logs, when `_recover_fields` fills missing required fields with defaults, a warning-level log message is emitted listing the field names that were filled, so I can identify which LLMs are dropping fields and adjust prompts or models accordingly.
+
+**Why this priority**: Silent default-filling would mask model quality issues. Warning logs provide observability without blocking the response.
+
+**Independent Test**: Trigger `_recover_fields` with a missing required field and verify that a WARNING log is emitted containing the field name.
+
+**Acceptance Scenarios**:
+
+1. **Given** `_recover_fields` fills one missing field, **When** the fill occurs, **Then** a WARNING log is emitted with the field name.
+2. **Given** `_recover_fields` fills multiple missing fields, **When** the fill occurs, **Then** the WARNING log lists all filled field names sorted alphabetically.
+3. **Given** no fields are missing, **When** `_recover_fields` completes, **Then** no warning log is emitted.
+
+---
+
+### Edge Cases
+
+- **All fields missing**: When `_walk` finds zero matching keys in the JSON payload, `_recover_fields` returns `None` before attempting any default filling.
+- **Nested BaseModel field**: A required field typed as a `BaseModel` subclass is filled with `{}`, which Pydantic will attempt to coerce into the nested model using its own defaults.
+- **Optional unwrapping**: `Optional[str]` is unwrapped to `str` before determining the default, so the default for `Optional[str]` is `""`, not `None`.
+- **Null values for required fields**: Null values found during walk are dropped before the fill step, so they do not prevent default filling.
+- **Pydantic validation failure after fill**: If the filled defaults still fail Pydantic validation (e.g., a custom validator rejects empty strings), `_recover_fields` returns `None`.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: `_default_for_annotation` MUST return `""` for `str`, `False` for `bool`, `0` for `int`/`float`, `[]` for `list`, `{}` for `dict`, `{}` for `BaseModel` subclasses, and `None` for unknown types.
+- **FR-002**: `_default_for_annotation` MUST unwrap `Optional[X]` / `Union[X, None]` to the inner type before selecting the default.
+- **FR-003**: `_recover_fields` MUST fill missing required fields with type-appropriate defaults from `_default_for_annotation` instead of returning `None`.
+- **FR-004**: `_recover_fields` MUST emit a WARNING-level log listing all field names that were filled with defaults.
+- **FR-005**: `_recover_fields` MUST still return `None` when no recognized fields are found in the JSON payload (the walk finds nothing).
+- **FR-006**: `_recover_fields` MUST still return `None` if Pydantic `model_validate` fails after filling defaults.
+- **FR-007**: `_default_for_annotation` MUST be a `@staticmethod` on `PromptGraph`.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Queries that previously returned errors due to dropped auxiliary fields now deliver valid responses with filled defaults.
+- **SC-002**: All 7 new tests pass, covering each type default and the real-world Mistral-Small regression case.
+- **SC-003**: Warning logs identify which fields were filled, enabling prompt/model tuning.
+- **SC-004**: No existing tests regress.
+
+## Assumptions
+
+- The primary required field (e.g., `knowledge_answer`) is always present in the LLM output; only auxiliary fields are dropped.
+- Type-appropriate defaults (empty string, zero, false, empty collections) are acceptable for auxiliary fields in the domain context.
+- Pydantic models used as PromptGraph output schemas do not have custom validators that reject empty/zero defaults for auxiliary fields.
+- The `model.model_fields` API (Pydantic v2) correctly reports field annotations and required status.

--- a/specs/029-promptgraph-field-recovery/spec.md
+++ b/specs/029-promptgraph-field-recovery/spec.md
@@ -86,7 +86,7 @@ As a developer monitoring production logs, when `_recover_fields` fills missing 
 ### Measurable Outcomes
 
 - **SC-001**: Queries that previously returned errors due to dropped auxiliary fields now deliver valid responses with filled defaults.
-- **SC-002**: All 7 new tests pass, covering each type default and the real-world Mistral-Small regression case.
+- **SC-002**: All 6 new tests pass, covering each type default and the real-world Mistral-Small regression case.
 - **SC-003**: Warning logs identify which fields were filled, enabling prompt/model tuning.
 - **SC-004**: No existing tests regress.
 

--- a/specs/029-promptgraph-field-recovery/tasks.md
+++ b/specs/029-promptgraph-field-recovery/tasks.md
@@ -1,0 +1,55 @@
+# Tasks: PromptGraph Field Recovery
+
+**Input**: Design documents from `specs/029-promptgraph-field-recovery/`
+**Prerequisites**: plan.md (required), spec.md (required)
+
+**Organization**: Tasks grouped by user story.
+
+## Phase 1: User Story 1 - Responses Survive Dropped Fields (Priority: P1)
+
+**Goal**: `_recover_fields` fills missing required fields instead of returning None
+
+- [X] T001 [US1] Add `_default_for_annotation` static method to `PromptGraph` in `core/domain/prompt_graph.py`
+- [X] T002 [US1] Implement type mapping: str->""  bool->False  int/float->0  list->[]  dict->{}  BaseModel->{}  unknown->None in `core/domain/prompt_graph.py`
+- [X] T003 [US1] Add Optional[X] / Union[X, None] unwrapping logic before type lookup in `core/domain/prompt_graph.py`
+- [X] T004 [US1] Replace the `return None` for missing required fields with default-fill loop in `_recover_fields` in `core/domain/prompt_graph.py`
+- [X] T005 [US1] Add test `test_fills_missing_str_with_empty_string` (Mistral-Small drop case) in `tests/core/domain/test_prompt_graph.py`
+- [X] T006 [US1] Add test `test_real_world_answer_response_shape` (full Mistral-Small regression) in `tests/core/domain/test_prompt_graph.py`
+
+**Checkpoint**: Recovery fills defaults; str and real-world regression tests pass
+
+---
+
+## Phase 2: User Story 2 - Type-Appropriate Defaults (Priority: P2)
+
+**Goal**: All common Python types have correct defaults
+
+- [X] T007 [US2] Add test `test_fills_missing_dict_with_empty_dict` in `tests/core/domain/test_prompt_graph.py`
+- [X] T008 [US2] Add test `test_fills_missing_list_with_empty_list` in `tests/core/domain/test_prompt_graph.py`
+- [X] T009 [US2] Add test `test_fills_missing_bool_with_false` in `tests/core/domain/test_prompt_graph.py`
+- [X] T010 [US2] Add test `test_fills_missing_int_with_zero` in `tests/core/domain/test_prompt_graph.py`
+
+**Checkpoint**: All type-default tests pass
+
+---
+
+## Phase 3: User Story 3 - Warning Logging (Priority: P3)
+
+**Goal**: Filled fields produce a warning log
+
+- [X] T011 [US3] Add `logger.warning` call listing sorted filled field names in `_recover_fields` in `core/domain/prompt_graph.py`
+
+**Checkpoint**: Warning log emitted when defaults are applied
+
+---
+
+## Dependencies & Execution Order
+
+- **Phase 1**: T004 depends on T001-T003 (needs the default method). T005-T006 depend on T004.
+- **Phase 2**: T007-T010 depend on T001-T004 (need the default-fill infrastructure). Can run in parallel with each other.
+- **Phase 3**: T011 is independent of tests but logically part of T004's implementation.
+- T001-T003 can be implemented as a single atomic change (one static method).
+
+### Parallel Opportunities
+
+- T005, T006, T007, T008, T009, T010 can all run in parallel (independent test functions).

--- a/tests/core/domain/test_prompt_graph.py
+++ b/tests/core/domain/test_prompt_graph.py
@@ -274,6 +274,87 @@ class TestRecoverFields:
         assert result is not None
         assert result["answer"] == "found"
 
+    def test_fills_missing_str_with_empty_string(self):
+        from pydantic import BaseModel
+
+        class AnswerModel(BaseModel):
+            answer: str
+            answer_language: str
+
+        # Classic Mistral-Small regression: drops the auxiliary field.
+        raw = '{"answer": "Hi there"}'
+        result = PromptGraph._recover_fields(raw, AnswerModel)
+        assert result is not None
+        assert result["answer"] == "Hi there"
+        assert result["answer_language"] == ""
+
+    def test_fills_missing_dict_with_empty_dict(self):
+        from pydantic import BaseModel
+
+        class AnswerModel(BaseModel):
+            answer: str
+            source_scores: dict
+
+        raw = '{"answer": "Hi"}'
+        result = PromptGraph._recover_fields(raw, AnswerModel)
+        assert result is not None
+        assert result["source_scores"] == {}
+
+    def test_fills_missing_list_with_empty_list(self):
+        from pydantic import BaseModel
+
+        class AnswerModel(BaseModel):
+            answer: str
+            tags: list[str]
+
+        raw = '{"answer": "Hi"}'
+        result = PromptGraph._recover_fields(raw, AnswerModel)
+        assert result is not None
+        assert result["tags"] == []
+
+    def test_fills_missing_bool_with_false(self):
+        from pydantic import BaseModel
+
+        class AnswerModel(BaseModel):
+            answer: str
+            requires_followup: bool
+
+        raw = '{"answer": "Hi"}'
+        result = PromptGraph._recover_fields(raw, AnswerModel)
+        assert result is not None
+        assert result["requires_followup"] is False
+
+    def test_fills_missing_int_with_zero(self):
+        from pydantic import BaseModel
+
+        class AnswerModel(BaseModel):
+            answer: str
+            confidence: int
+
+        raw = '{"answer": "Hi"}'
+        result = PromptGraph._recover_fields(raw, AnswerModel)
+        assert result is not None
+        assert result["confidence"] == 0
+
+    def test_real_world_answer_response_shape(self):
+        """Reproduces the Mistral-Small / oasisbot query failure."""
+        from pydantic import BaseModel
+
+        class AnswerResponse(BaseModel):
+            knowledge_answer: str
+            answer_language: str
+            source_scores: dict
+
+        raw = (
+            '{"knowledge_answer": "Maria\'s phone number is +359 88 6111122.",'
+            ' "source_scores": {"0": 7, "1": 0, "2": 0, "3": 0, "4": 0}}'
+        )
+        result = PromptGraph._recover_fields(raw, AnswerResponse)
+        assert result is not None
+        assert "Maria" in result["knowledge_answer"]
+        assert result["source_scores"] == {"0": 7, "1": 0, "2": 0, "3": 0, "4": 0}
+        assert result["answer_language"] == ""  # filled default, message flows
+
 
 # ---------------------------------------------------------------------------
 # _state_to_dict and wrappers


### PR DESCRIPTION
## Summary

- `_recover_fields` now fills missing required fields with type-appropriate defaults instead of aborting
- Handles str→"", bool→False, int/float→0, list→[], dict→{}, BaseModel→{}, Optional unwrap
- Fixes Mistral-Small regression where `answer_language` field was dropped from structured output
- SDD spec 029 with all 7 artifacts

## Test plan

- [x] `poetry run pytest tests/core/domain/test_prompt_graph.py -v` — 36 passing
- [x] `poetry run pytest -x` — 545 passing (full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured output recovery now fills missing required fields with type-appropriate defaults (empty strings, zeros, empty collections, empty objects) and emits warnings listing which fields were filled.

* **Documentation**
  * Added specification, plan, quickstart, research, tasks, and a requirements checklist detailing the recovery behavior and acceptance criteria.

* **Tests**
  * Added unit tests validating recovery and default-filling across string, numeric, boolean, list, and dict types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->