### PR TITLE
ci: automated semantic release pipeline (spec 030)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,9 @@ name: Build & Push
 
 on:
   push:
-    branches: [develop, main]
-    tags: ["v*"]
+    branches: [develop]
+  release:
+    types: [published]
 
 env:
   IMAGE_NAME: alkemio/virtual-contributor
@@ -20,10 +21,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to registry
+      - name: Log in to Docker Hub
+        if: github.event_name == 'release'
         uses: docker/login-action@v3
         with:
-          registry: ${{ vars.DOCKER_REGISTRY || 'ghcr.io' }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to ghcr.io
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -31,10 +40,11 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ vars.DOCKER_REGISTRY || 'ghcr.io' }}/${{ env.IMAGE_NAME }}
+          images: ${{ github.event_name == 'release' && 'alkemio/virtual-contributor' || format('ghcr.io/{0}', env.IMAGE_NAME) }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
             type=sha
 
       - name: Build and push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Python Semantic Release
+        uses: python-semantic-release/python-semantic-release@v9
+        with:
+          github_token: ${{ secrets.RELEASE_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,19 @@ Config → logging → plugin discovery → adapter wiring (via container) → p
 - Event factories: `make_input(...)`, `make_ingest_website(...)` for building test events with sensible defaults.
 - Plugin tests instantiate with mock ports, call `handle()`, and assert on LLM calls, knowledge store queries, and response content.
 
+## Commit Conventions
+
+This repo uses [Conventional Commits](https://www.conventionalcommits.org/) for automatic versioning via `python-semantic-release`. The commit prefix determines the version bump:
+
+| Prefix | Version bump | Example |
+|--------|-------------|---------|
+| `fix:` | Patch (0.1.0 → 0.1.1) | `fix: handle empty RAG results` |
+| `feat:` | Minor (0.1.0 → 0.2.0) | `feat: add PDF ingestion step` |
+| `feat!:` or `BREAKING CHANGE:` footer | Major (0.1.0 → 1.0.0) | `feat!: redesign plugin contract` |
+| `chore:`, `docs:`, `test:`, `refactor:`, `ci:` | No release | `docs: update README` |
+
+Scopes are optional: `feat(ingest): add retry logic`. All commits merged to `main` are analyzed — the highest bump wins.
+
 ## Key Design Decisions
 
 - `docs/adr/` contains Architecture Decision Records (microkernel, plugin contract, unified LLM adapter, content hash dedup).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,12 @@ omit = [
     "plugins/ingest_space/graphql_client.py",
 ]
 
+[tool.semantic_release]
+version_toml = ["pyproject.toml:tool.poetry.version"]
+branch = "main"
+commit_message = "chore(release): {version}"
+build_command = ""
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/specs/030-semantic-release/checklists/requirements.md
+++ b/specs/030-semantic-release/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Automated Semantic Release Pipeline
+
+**Purpose**: Validate specification completeness and quality
+**Created**: 2026-04-23
+**Feature**: [spec.md](../spec.md)
+
+## Completeness
+
+- [X] CHK001 All user stories have clear descriptions and acceptance scenarios
+- [X] CHK002 User stories are prioritized (P1, P2, P3)
+- [X] CHK003 Each user story is independently testable
+- [X] CHK004 Edge cases are identified and documented
+- [X] CHK005 Functional requirements are concrete and testable (FR-001 through FR-008)
+- [X] CHK006 Success criteria are measurable (SC-001 through SC-004)
+- [X] CHK007 Assumptions are explicitly documented
+
+## Quality
+
+- [X] CHK008 Spec reads as a forward-looking specification, not a code description
+- [X] CHK009 Business/user language is used over implementation language
+- [X] CHK010 Acceptance scenarios follow Given/When/Then format
+- [X] CHK011 Requirements use RFC 2119 keywords (MUST, SHOULD, MAY)
+- [X] CHK012 No placeholder text or template markers remain
+
+## Traceability
+
+- [X] CHK013 Every functional requirement maps to at least one acceptance scenario
+- [X] CHK014 Every user story maps to tasks in tasks.md
+- [X] CHK015 Plan.md references spec.md
+- [X] CHK016 Constitution check is complete with all principles evaluated
+
+## Architecture Compliance
+
+- [X] CHK017 Changes comply with constitution principles (no violations)
+- [X] CHK018 No application architecture changes bypass ADR requirement
+- [X] CHK019 Single Image, Multiple Deployments standard is preserved
+
+## Notes
+
+- This feature is CI/CD configuration only — no application code, no port/adapter changes, no event schema changes
+- Constitution compliance is straightforward as changes are outside the application boundary

--- a/specs/030-semantic-release/data-model.md
+++ b/specs/030-semantic-release/data-model.md
@@ -1,0 +1,19 @@
+# Data Model: Automated Semantic Release Pipeline
+
+**Feature Branch**: `030-semantic-release`
+**Date**: 2026-04-23
+
+## Overview
+
+This feature does not introduce or modify any application data models (Pydantic models, domain objects, or database schemas). All changes are to CI/CD configuration files and documentation.
+
+The only structured data involved is the `[tool.semantic_release]` configuration block in `pyproject.toml`, which is a standard TOML configuration section consumed by the `python-semantic-release` tool:
+
+| Field | Type | Value | Purpose |
+|-------|------|-------|---------|
+| `version_toml` | list[str] | `["pyproject.toml:tool.poetry.version"]` | Tells semantic-release where to read/write the version |
+| `branch` | str | `"main"` | The branch on which releases are created |
+| `commit_message` | str | `"chore(release): {version}"` | Template for the version bump commit message |
+| `build_command` | str | `""` | No build step needed (Docker build is handled by the Build workflow) |
+
+No entity relationships, state transitions, or validation rules are affected.

--- a/specs/030-semantic-release/plan.md
+++ b/specs/030-semantic-release/plan.md
@@ -1,0 +1,67 @@
+# Implementation Plan: Automated Semantic Release Pipeline
+
+**Branch**: `030-semantic-release` | **Date**: 2026-04-23 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/030-semantic-release/spec.md`
+
+## Summary
+
+Automates versioning and release publishing using `python-semantic-release`. On merge to `main`, a new GitHub Actions workflow analyzes conventional commits, bumps the version in `pyproject.toml`, creates a git tag and GitHub Release. The existing Build workflow is updated to distinguish between dev pushes (ghcr.io) and release events (Docker Hub), ensuring production images are published to Docker Hub with semantic version tags.
+
+## Technical Context
+
+**Language/Version**: Python 3.12
+**Primary Dependencies**: python-semantic-release v9 (GitHub Action), Docker
+**Storage**: N/A
+**Testing**: Manual verification via GitHub Actions runs
+**Target Platform**: GitHub Actions CI/CD
+**Project Type**: CI/CD pipeline configuration
+**Performance Goals**: Release pipeline completes within 5 minutes
+**Constraints**: Must not disrupt existing develop-branch CI flow
+**Scale/Scope**: Single repository, single Docker image
+
+## Constitution Check
+
+| Principle/Standard | Status | Notes |
+|---|---|---|
+| P1 AI-Native Development | PASS | Enables zero-touch release — merging to main triggers fully automated versioning and publishing |
+| P2 SOLID Architecture | N/A | CI/CD configuration, not application code |
+| P3 No Vendor Lock-in | N/A | CI/CD tooling choice, not application architecture |
+| P4 Optimised Feedback Loops | PASS | Automates release feedback — developers see releases created automatically within minutes of merge |
+| P5 Best Available Infrastructure | PASS | Uses standard GitHub Actions runners (ubuntu-latest) |
+| P6 Spec-Driven Development | PASS | This retrospec documents the feature |
+| P7 No Filling Tests | N/A | No application tests involved — CI/CD config changes |
+| P8 Architecture Decision Records | N/A | No architectural change to the application — CI/CD pipeline setup |
+| Single Image, Multiple Deployments | PASS | Preserves single Dockerfile, single image. Only changes where/when it's pushed |
+| Event Schema as Wire Contract | N/A | No event schema changes |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/030-semantic-release/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── tasks.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+.github/workflows/
+├── build.yml          # Modified: split registry auth, release-event trigger
+└── release.yml        # New: semantic-release workflow
+pyproject.toml         # Modified: added [tool.semantic_release] config
+CLAUDE.md              # Modified: added Commit Conventions section
+```
+
+**Structure Decision**: Changes are confined to CI/CD configuration and documentation. No application source code is modified.
+
+## Complexity Tracking
+
+No constitution violations — this section is not applicable.

--- a/specs/030-semantic-release/quickstart.md
+++ b/specs/030-semantic-release/quickstart.md
@@ -1,0 +1,42 @@
+# Quickstart: Automated Semantic Release Pipeline
+
+**Feature Branch**: `030-semantic-release`
+**Date**: 2026-04-23
+
+## What It Does
+
+Automates version bumping, git tagging, GitHub Release creation, and Docker Hub image publishing. When commits with conventional prefixes (`fix:`, `feat:`, `feat!:`) are merged to `main`, `python-semantic-release` determines the version bump, and the Build workflow publishes the Docker image to Docker Hub.
+
+## Prerequisites
+
+Configure these GitHub repository secrets:
+
+| Secret | Purpose |
+|--------|---------|
+| `RELEASE_TOKEN` | PAT or fine-grained token with `contents: write` permission — used by semantic-release to create tags and releases |
+| `DOCKERHUB_USERNAME` | Docker Hub username for image publishing |
+| `DOCKERHUB_TOKEN` | Docker Hub access token for image publishing |
+
+## How to Verify
+
+1. **Release workflow**: Push a `fix:` commit to `main` (via merged PR). Check the Actions tab — the "Release" workflow should run and create a new GitHub Release with a patch version bump.
+2. **Build workflow**: After the Release is published, the "Build & Push" workflow should trigger automatically and push the image to Docker Hub.
+3. **Dev workflow**: Push to `develop` — the "Build & Push" workflow should push to ghcr.io as before.
+
+## Commit Message Format
+
+| Prefix | Effect |
+|--------|--------|
+| `fix:` | Patch bump (0.1.0 → 0.1.1) |
+| `feat:` | Minor bump (0.1.0 → 0.2.0) |
+| `feat!:` or `BREAKING CHANGE:` footer | Major bump (0.1.0 → 1.0.0) |
+| `chore:`, `docs:`, `ci:`, `test:`, `refactor:` | No release |
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `.github/workflows/release.yml` | New — semantic-release workflow on push to main |
+| `.github/workflows/build.yml` | Modified — dual registry auth, release event trigger |
+| `pyproject.toml` | Modified — added `[tool.semantic_release]` config |
+| `CLAUDE.md` | Modified — added Commit Conventions documentation |

--- a/specs/030-semantic-release/research.md
+++ b/specs/030-semantic-release/research.md
@@ -1,0 +1,67 @@
+# Research: Automated Semantic Release Pipeline
+
+**Feature Branch**: `030-semantic-release`
+**Date**: 2026-04-23
+
+## Decision Summary
+
+| # | Decision | Rationale | Impact |
+|---|----------|-----------|--------|
+| D1 | Use `python-semantic-release` over `semantic-release` (Node.js) | Python project — keeps tooling in the same ecosystem, reads version from `pyproject.toml` natively | Low risk — well-maintained, v9 is stable |
+| D2 | Trigger Build on `release` event, not `tags` | Decouples build from tag creation mechanics; `release` event is the semantic signal that a version is ready for production | Cleaner separation of concerns |
+| D3 | Dual registry strategy (ghcr.io for dev, Docker Hub for releases) | Dev images are internal (ghcr.io is free for GitHub repos), production images go to Docker Hub where operators expect them | Requires two sets of credentials |
+| D4 | Use `RELEASE_TOKEN` instead of `GITHUB_TOKEN` for semantic-release | `GITHUB_TOKEN` cannot trigger other workflows (GitHub limitation). A PAT or fine-grained token in `RELEASE_TOKEN` allows the Release workflow's tag/release to trigger the Build workflow | Critical for the release→build chain |
+| D5 | Document conventions in CLAUDE.md rather than enforce via commit-msg hook | CLAUDE.md is read by AI agents (the primary developers). A hook would add friction without adding value since agents already follow instructions | Relies on convention, not enforcement |
+
+## Detailed Decisions
+
+### D1: python-semantic-release over Node.js semantic-release
+
+**Decision**: Use `python-semantic-release/python-semantic-release@v9` GitHub Action.
+
+**Rationale**: This is a Python project managed with Poetry. `python-semantic-release` natively understands `pyproject.toml` and can update `tool.poetry.version` directly. The Node.js `semantic-release` would require additional plugins and configuration to handle Python versioning.
+
+**Alternatives considered**:
+- **Node.js semantic-release**: More widely adopted, but requires Node.js in the CI environment and custom plugins for Python version files. Adds ecosystem complexity.
+- **Manual versioning with `bump2version`**: Would still require manual intervention to decide version bumps, defeating the automation goal.
+- **GitHub Actions release drafter**: Only drafts release notes, doesn't handle version bumping or tagging.
+
+### D2: Release event trigger instead of tag-based trigger
+
+**Decision**: The Build workflow triggers on `release: types: [published]` instead of `push: tags: ["v*"]`.
+
+**Rationale**: The `release` event is a higher-level semantic signal. It fires after `python-semantic-release` has created both the tag AND the GitHub Release. A tag-based trigger would fire on any tag push, including manual or accidental tags.
+
+**Alternatives considered**:
+- **Tag-based trigger (`push: tags: ["v*"]`)**: The previous approach. Less precise — any tag matching `v*` triggers a build, even manual tags not associated with a release.
+- **Workflow dispatch**: Would require manual triggering, defeating automation.
+
+### D3: Dual registry strategy
+
+**Decision**: Push dev images to ghcr.io, production images to Docker Hub.
+
+**Rationale**: ghcr.io is tightly integrated with GitHub (free for public repos, automatic auth). Docker Hub is where the Alkemio operations team pulls production images. Separating them prevents dev images from cluttering the production registry.
+
+**Alternatives considered**:
+- **Single registry (Docker Hub only)**: Would push dev images to Docker Hub, consuming rate limits and mixing dev/prod images.
+- **Single registry (ghcr.io only)**: Would require operators to change their pull source from Docker Hub.
+
+### D4: Dedicated RELEASE_TOKEN secret
+
+**Decision**: Use `secrets.RELEASE_TOKEN` (a PAT or fine-grained token) for the semantic-release step.
+
+**Rationale**: GitHub's default `GITHUB_TOKEN` cannot trigger other workflows. Since the Release workflow creates a GitHub Release that must trigger the Build workflow, a token with broader permissions is required.
+
+**Alternatives considered**:
+- **GITHUB_TOKEN**: Simplest option but would break the release→build chain due to GitHub's recursive workflow prevention.
+- **GitHub App token**: More secure but more complex to set up. Could be adopted later if PAT rotation becomes a concern.
+
+### D5: Convention over enforcement for commit messages
+
+**Decision**: Document conventional commit format in CLAUDE.md rather than adding a `commitlint` or `commit-msg` hook.
+
+**Rationale**: The primary contributors are AI agents that read CLAUDE.md as their operating instructions. A git hook would add CI complexity without improving compliance for the primary audience. `python-semantic-release` gracefully handles non-conventional commits by simply not creating a release.
+
+**Alternatives considered**:
+- **commitlint + husky**: Standard approach for human teams. Adds Node.js dev dependency and pre-commit hook complexity.
+- **Pre-commit hook with a regex check**: Lighter weight but still adds friction for no gain when agents already follow CLAUDE.md.

--- a/specs/030-semantic-release/spec.md
+++ b/specs/030-semantic-release/spec.md
@@ -1,0 +1,90 @@
+# Feature Specification: Automated Semantic Release Pipeline
+
+**Feature Branch**: `030-semantic-release`
+**Created**: 2026-04-23
+**Status**: Implemented
+**Input**: Retrospec from code changes
+
+## User Scenarios & Testing
+
+### User Story 1 - Automated Version Bumps on Merge to Main (Priority: P1)
+
+As a developer, when I merge a PR to `main` with conventional commit messages, the system automatically determines the correct version bump (patch/minor/major), updates `pyproject.toml`, creates a git tag, and publishes a GitHub Release — with zero manual intervention.
+
+**Why this priority**: This is the core value proposition — eliminating manual versioning and release creation, enabling the AI-native zero-touch delivery pipeline (Constitution P1).
+
+**Independent Test**: Merge a commit with prefix `fix:` to `main` and verify a patch release is created automatically.
+
+**Acceptance Scenarios**:
+
+1. **Given** a PR with a `fix:` commit is merged to `main`, **When** the Release workflow runs, **Then** `python-semantic-release` bumps the patch version, tags the commit, and creates a GitHub Release.
+2. **Given** a PR with a `feat:` commit is merged to `main`, **When** the Release workflow runs, **Then** the minor version is bumped.
+3. **Given** a PR with a `feat!:` commit or `BREAKING CHANGE:` footer is merged to `main`, **When** the Release workflow runs, **Then** the major version is bumped.
+4. **Given** a PR with only `chore:`, `docs:`, or `ci:` commits is merged to `main`, **When** the Release workflow runs, **Then** no release is created.
+
+---
+
+### User Story 2 - Docker Hub Publishing on Release (Priority: P1)
+
+As an operator, when a GitHub Release is published, the Build workflow automatically builds and pushes the Docker image to Docker Hub (not ghcr.io), tagged with the semantic version and `latest`.
+
+**Why this priority**: Production deployments pull from Docker Hub. Without this, releases don't reach production infrastructure.
+
+**Independent Test**: Publish a GitHub Release and verify the Docker image appears on Docker Hub with the correct version tag and `latest`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a GitHub Release is published, **When** the Build workflow triggers, **Then** it authenticates to Docker Hub using `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets and pushes the image as `alkemio/virtual-contributor:<version>`.
+2. **Given** a GitHub Release is published, **When** the Build workflow completes, **Then** the image is also tagged as `alkemio/virtual-contributor:latest`.
+
+---
+
+### User Story 3 - Dev Image Publishing on Push to Develop (Priority: P2)
+
+As a developer, when I push to `develop`, the Build workflow pushes a dev image to ghcr.io (not Docker Hub), preserving the existing dev workflow.
+
+**Why this priority**: Dev images enable testing in staging environments before release, but this is the pre-existing behavior being preserved, not new functionality.
+
+**Independent Test**: Push a commit to `develop` and verify the image appears on ghcr.io with the branch tag.
+
+**Acceptance Scenarios**:
+
+1. **Given** a push to `develop`, **When** the Build workflow triggers, **Then** it authenticates to ghcr.io using `GITHUB_TOKEN` and pushes the image as `ghcr.io/alkemio/virtual-contributor:develop`.
+2. **Given** a push to `develop`, **When** the Build workflow triggers, **Then** it does NOT authenticate to Docker Hub or push there.
+
+---
+
+### Edge Cases
+
+- What happens when `RELEASE_TOKEN` secret is missing? The Release workflow fails with a clear authentication error.
+- What happens when `DOCKERHUB_USERNAME` or `DOCKERHUB_TOKEN` secrets are missing? The Build workflow fails on the Docker Hub login step only for release events; develop pushes are unaffected.
+- What happens when a release commit has no conventional commit prefix? `python-semantic-release` skips the release (no version bump).
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST run `python-semantic-release` on every push to `main` to analyze conventional commits and determine version bumps.
+- **FR-002**: System MUST update the version in `pyproject.toml` (at `tool.poetry.version`) when a release is triggered.
+- **FR-003**: System MUST create a git tag and GitHub Release for each version bump.
+- **FR-004**: System MUST use `chore(release): {version}` as the release commit message format.
+- **FR-005**: Build workflow MUST authenticate to Docker Hub and push images when triggered by a `release` event.
+- **FR-006**: Build workflow MUST authenticate to ghcr.io and push images when triggered by a `push` event to `develop`.
+- **FR-007**: Release-triggered builds MUST tag images with the semantic version and `latest`.
+- **FR-008**: The `CLAUDE.md` documentation MUST describe conventional commit prefixes and their version bump effects.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: A `fix:` commit merged to `main` produces a patch release within 5 minutes with no human intervention.
+- **SC-002**: Docker Hub contains the correct versioned image after each release.
+- **SC-003**: Dev pushes to `develop` continue to produce ghcr.io images without regression.
+- **SC-004**: Zero manual version bumps or tag creation required for standard releases.
+
+## Assumptions
+
+- The `RELEASE_TOKEN` GitHub secret has sufficient permissions (`contents: write`) to create tags, commits, and releases.
+- `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets are configured in the repository settings.
+- The `main` branch is protected and receives changes only via merged PRs from `develop`.
+- Conventional commit format is enforced by team convention (documented in CLAUDE.md) rather than by a commit-msg hook.

--- a/specs/030-semantic-release/tasks.md
+++ b/specs/030-semantic-release/tasks.md
@@ -1,0 +1,79 @@
+# Tasks: Automated Semantic Release Pipeline
+
+**Input**: Design documents from `specs/030-semantic-release/`
+**Organization**: Tasks grouped by user story.
+
+## Phase 1: Foundational (Blocking Prerequisites)
+
+**Purpose**: Configuration that all user stories depend on
+
+- [X] T001 [US1] Add `[tool.semantic_release]` configuration block to `pyproject.toml` with version source, branch, commit message template, and empty build command
+- [X] T002 [US1] Document conventional commit prefixes and version bump mapping in `CLAUDE.md` under "Commit Conventions" section
+
+**Checkpoint**: Semantic release configuration is in place
+
+---
+
+## Phase 2: User Story 1 - Automated Version Bumps on Merge to Main (Priority: P1)
+
+**Goal**: Push to `main` triggers automatic version bump, tag, and GitHub Release
+
+**Independent Test**: Merge a `fix:` commit to `main` and verify a GitHub Release is created
+
+### Implementation for User Story 1
+
+- [X] T003 [US1] Create `.github/workflows/release.yml` with `push: branches: [main]` trigger, checkout with `fetch-depth: 0`, Python 3.12 setup, and `python-semantic-release/python-semantic-release@v9` action using `RELEASE_TOKEN`
+- [X] T004 [US1] Set `permissions: contents: write` in release workflow to allow tag and release creation
+
+**Checkpoint**: Merges to main now auto-create releases
+
+---
+
+## Phase 3: User Story 2 - Docker Hub Publishing on Release (Priority: P1)
+
+**Goal**: GitHub Release publication triggers Docker image push to Docker Hub
+
+**Independent Test**: Publish a GitHub Release and verify Docker Hub image
+
+### Implementation for User Story 2
+
+- [X] T005 [US2] Add `release: types: [published]` trigger to `.github/workflows/build.yml`
+- [X] T006 [US2] Add "Log in to Docker Hub" step conditional on `github.event_name == 'release'` using `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets
+- [X] T007 [US2] Update Docker metadata `images` to use `alkemio/virtual-contributor` for release events
+- [X] T008 [US2] Add `type=raw,value=latest,enable=${{ github.event_name == 'release' }}` tag to metadata
+
+**Checkpoint**: Releases now publish Docker images to Docker Hub with version + latest tags
+
+---
+
+## Phase 4: User Story 3 - Dev Image Publishing on Push to Develop (Priority: P2)
+
+**Goal**: Dev pushes continue to work via ghcr.io without regression
+
+**Independent Test**: Push to develop and verify ghcr.io image
+
+### Implementation for User Story 3
+
+- [X] T009 [US3] Update push trigger branches from `[develop, main]` to `[develop]` in `.github/workflows/build.yml`
+- [X] T010 [US3] Remove old single "Log in to registry" step and add "Log in to ghcr.io" step conditional on `github.event_name == 'push'` using `ghcr.io` registry, `github.actor`, and `GITHUB_TOKEN`
+- [X] T011 [US3] Update Docker metadata `images` to use `ghcr.io/alkemio/virtual-contributor` for push events via format function
+
+**Checkpoint**: Dev workflow preserved — pushes to develop still build and push to ghcr.io
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Foundational (Phase 1)**: No dependencies — configuration setup
+- **User Story 1 (Phase 2)**: Depends on Phase 1 (needs semantic_release config)
+- **User Story 2 (Phase 3)**: Depends on Phase 2 (needs releases to exist to trigger builds)
+- **User Story 3 (Phase 4)**: Independent of other stories — preserves existing behavior
+
+### Parallel Opportunities
+
+- T001 and T002 can run in parallel (different files)
+- T005, T006, T007, T008 all modify `build.yml` — must be sequential
+- T009, T010, T011 also modify `build.yml` — must be sequential with Phase 3 tasks
+- User Story 3 is independent and could be implemented in parallel with User Story 2


### PR DESCRIPTION
## Summary
- Add `python-semantic-release` workflow triggered on push to `main` — auto-bumps version, tags, and creates GitHub Releases from conventional commits
- Split `build.yml` registry auth: Docker Hub for release events, ghcr.io for develop pushes
- Configure `[tool.semantic_release]` in `pyproject.toml` (version source, branch, commit message template)
- Document conventional commit prefixes and version bump mapping in `CLAUDE.md`

## Test plan
- [ ] Verify `RELEASE_TOKEN`, `DOCKERHUB_USERNAME`, and `DOCKERHUB_TOKEN` secrets are configured in repo settings
- [ ] Merge a `fix:` commit to `main` and confirm a patch release is created automatically
- [ ] Confirm the published release triggers the Build workflow and pushes to Docker Hub
- [ ] Push to `develop` and confirm ghcr.io image is built (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to automate release management and Docker image publishing; development builds now publish to a container registry while release builds publish to Docker Hub with semantic versioning.

* **Documentation**
  * Added comprehensive release automation documentation including commit message conventions, release workflow steps, and verification procedures; clarified versioning bump rules for patch, minor, and major releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->