### PR TITLE
fix(ci): use org bot token and set version 0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Python Semantic Release
         uses: python-semantic-release/python-semantic-release@v9
         with:
-          github_token: ${{ secrets.RELEASE_TOKEN }}
+          github_token: ${{ secrets.ALKEMIO_INFRASTRUCTURE_BOT_PUSH_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "alkemio-virtual-contributor"
-version = "1.0.0"
+version = "0.1.0"
 description = "Alkemio Virtual Contributor — unified microkernel engine with pluggable handlers"
 authors = ["Alkemio BV <info@alkem.io>"]
 license = "EUPL-1.2"


### PR DESCRIPTION
## Summary
- Use `ALKEMIO_INFRASTRUCTURE_BOT_PUSH_TOKEN` (org-level PAT) instead of `RELEASE_TOKEN` for semantic release — fixes the 401 from the previous attempt
- Revert version to `0.1.0` to let semantic-release determine it from commit history

## Test plan
- [ ] Merge and verify the Release workflow succeeds (no 401)
- [ ] Verify GitHub Release `v0.1.0` is created
- [ ] Verify Build workflow triggers and pushes `alkemio/virtual-contributor:0.1.0` to Docker Hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)