### PR TITLE
fix(ci): use bot token for checkout in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -14,6 +18,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.ALKEMIO_INFRASTRUCTURE_BOT_PUSH_TOKEN }}
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- Pass `ALKEMIO_INFRASTRUCTURE_BOT_PUSH_TOKEN` to `actions/checkout` so semantic-release can push the version bump commit and tag back to `main`

## Test plan
- [ ] Merge and verify the Release workflow creates tag `v0.1.1` and a GitHub Release
- [ ] Verify the Build workflow triggers and pushes to Docker Hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)