### PR TITLE
fix(ci): add v prefix to Docker Hub semver tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
           images: ${{ github.event_name == 'release' && 'alkemio/virtual-contributor' || format('ghcr.io/{0}', env.IMAGE_NAME) }}
           tags: |
             type=ref,event=branch
-            type=semver,pattern={{version}}
+            type=semver,pattern=v{{version}}
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
             type=sha
 


### PR DESCRIPTION
## Summary
- Add `v` prefix to Docker Hub semver tags to match Alkemio convention (`alkemio/virtual-contributor:v0.1.1`)

## Test plan
- [ ] Verify release tags Docker image as `v{version}` on Docker Hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)