### PR TITLE
fix(ingest-website): include identification fields in result envelope

### DIFF
--- a/core/events/ingest_website.py
+++ b/core/events/ingest_website.py
@@ -30,8 +30,19 @@ class IngestWebsite(EventBase):
 
 
 class IngestWebsiteResult(EventBase):
-    """Result of a website ingestion run."""
+    """Result of a website ingestion run.
 
+    Carries the identification fields (``bodyOfKnowledgeId``, ``type``,
+    ``purpose``, ``personaId``) so the alkemio-server result handler can
+    correlate the result back to the persona that owns the body of
+    knowledge. ``bodyOfKnowledgeId`` defaults to an empty string because
+    website-typed bodies of knowledge are URL-identified, not UUID-keyed.
+    """
+
+    body_of_knowledge_id: str = Field(default="", alias="bodyOfKnowledgeId")
+    type: str = ""
+    purpose: str = ""
+    persona_id: str = Field(default="", alias="personaId")
     timestamp: int = Field(
         default_factory=lambda: int(time.time() * 1000)
     )

--- a/plugins/ingest_website/plugin.py
+++ b/plugins/ingest_website/plugin.py
@@ -113,6 +113,9 @@ class IngestWebsitePlugin:
                 ])
                 cleanup_result = await cleanup_engine.run([], collection_name)
                 return IngestWebsiteResult(
+                    type=event.type,
+                    purpose=event.purpose,
+                    persona_id=event.persona_id,
                     result=IngestionResult.SUCCESS if cleanup_result.success else IngestionResult.FAILURE,
                     error="; ".join(cleanup_result.errors) if cleanup_result.errors else "",
                 )
@@ -158,6 +161,9 @@ class IngestWebsitePlugin:
             result = await engine.run(documents, collection_name)
 
             return IngestWebsiteResult(
+                type=event.type,
+                purpose=event.purpose,
+                persona_id=event.persona_id,
                 result=IngestionResult.SUCCESS if result.success else IngestionResult.FAILURE,
                 error="; ".join(result.errors) if result.errors else "",
             )
@@ -165,6 +171,9 @@ class IngestWebsitePlugin:
         except Exception as exc:
             logger.exception("Website ingestion failed: %s", exc)
             return IngestWebsiteResult(
+                type=event.type,
+                purpose=event.purpose,
+                persona_id=event.persona_id,
                 result=IngestionResult.FAILURE,
                 error=str(exc),
             )

--- a/tests/core/test_events.py
+++ b/tests/core/test_events.py
@@ -201,6 +201,13 @@ class TestIngestWebsiteSerialization:
         assert dumped["result"] == "success"
         assert dumped["error"] == ""
         assert isinstance(dumped["timestamp"], int)
+        # Identification fields must be present in the dumped payload
+        # (camelCase aliases) so the alkemio-server result handler can
+        # correlate the result back to a persona.
+        assert dumped["bodyOfKnowledgeId"] == ""
+        assert dumped["personaId"] == ""
+        assert dumped["type"] == ""
+        assert dumped["purpose"] == ""
 
     def test_result_failure(self):
         result = IngestWebsiteResult(
@@ -209,6 +216,21 @@ class TestIngestWebsiteSerialization:
         dumped = result.model_dump()
         assert dumped["result"] == "failure"
         assert dumped["error"] == "Connection timeout"
+
+    def test_result_with_identification_fields(self):
+        result = IngestWebsiteResult(
+            body_of_knowledge_id="bok-1",
+            type="website",
+            purpose="knowledge",
+            persona_id="persona-1",
+            result=IngestionResult.SUCCESS,
+        )
+        dumped = result.model_dump()
+        assert dumped["bodyOfKnowledgeId"] == "bok-1"
+        assert dumped["personaId"] == "persona-1"
+        assert dumped["type"] == "website"
+        assert dumped["purpose"] == "knowledge"
+        assert dumped["result"] == "success"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_ingest_website.py
+++ b/tests/plugins/test_ingest_website.py
@@ -448,6 +448,12 @@ class TestIngestWebsitePlugin:
         # delete_collection is no longer called — incremental dedup replaces it
         assert plugin._knowledge_store.deleted == []
         assert "example.com-knowledge" in plugin._knowledge_store.collections
+        # Identification fields must be propagated from the request event
+        # so the alkemio-server result handler can correlate the result
+        # back to the persona.
+        assert result.persona_id == event.persona_id
+        assert result.type == event.type
+        assert result.purpose == event.purpose
 
     async def test_empty_crawl_runs_cleanup(self):
         """When crawl returns [], cleanup deletes pre-existing chunks."""
@@ -476,6 +482,10 @@ class TestIngestWebsitePlugin:
         assert result.result == "success"
         # All pre-existing chunks should have been deleted
         assert len(store.collections.get(collection, [])) == 0
+        # Cleanup-only path must still propagate identification fields.
+        assert result.persona_id == event.persona_id
+        assert result.type == event.type
+        assert result.purpose == event.purpose
 
     async def test_empty_extract_runs_cleanup(self):
         """When crawl returns pages but extraction yields nothing, cleanup runs."""


### PR DESCRIPTION
## Summary

The result-message wire format published by ingest plugins is `{"response": {...IngestWebsiteResult fields...}}`. The `alkemio-server` `IngestWebsiteResultHandler` reads identification fields from `event.response` to call `updatePersonaBoKLastUpdated()` against the right persona.

Pre-fix `IngestWebsiteResult` only carried `timestamp`, `result` and `error` — no way for the server to correlate a successful website ingest back to a persona. On the dev cluster this manifested as `EventBus: "IngestWebsiteResultHandler" has thrown an unhandled exception` flooding on every incoming result (the server was reading `event.original.personaId` and crashing on undefined).

This PR adds the four identification fields (`bodyOfKnowledgeId`, `type`, `purpose`, `personaId`) to the `IngestWebsiteResult` Pydantic model and propagates them from the incoming `IngestWebsite` request through every code path that constructs the result:

- cleanup-only branch (zero documents extracted)
- success branch (full ingest pipeline ran)
- exception branch (any uncaught error)

`bodyOfKnowledgeId` defaults to an empty string because website-typed bodies of knowledge are URL-identified, not UUID-keyed.

## Pairs with

`alkem-io/server` PR #6029 — server-side change that makes both ingest result handlers (`IngestWebsiteResultHandler`, `IngestBodyOfKnowledgeResultHandler`) read from `event.response.*` so they line up with the wire format pods actually publish.

## Test plan

- [x] `tests/core/test_events.py` extended to assert all four identification fields appear in the dumped (camelCase) payload
- [x] `tests/plugins/test_ingest_website.py` extended to assert the plugin propagates `persona_id`, `type`, `purpose` from event to result on both the cleanup-only and the full-pipeline branches
- [x] Full pod test suite green: 520/520 passed (excluding `tests/evaluation/test_metrics.py` which has a pre-existing `ragas` import error unrelated to this change)
- [ ] After release tags `v0.1.3`, bump `alkemio/virtual-contributor` image to `v0.1.3` in `dev-orchestration` PR #43 — server-side fix #6029 must be deployed first to pick up matching handler logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Website ingestion results now include identification metadata (knowledge base ID, type, purpose, and persona information).
  * Identification context is automatically propagated through the entire ingestion pipeline, regardless of processing path.

* **Tests**
  * Added test coverage validating identification fields in ingestion results and confirming proper data flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->