### PR TITLE
release: v0.1.3 — ingest-space KB routing + ingest-website result correlation

### DIFF
--- a/core/events/ingest_website.py
+++ b/core/events/ingest_website.py
@@ -30,8 +30,19 @@ class IngestWebsite(EventBase):
 
 
 class IngestWebsiteResult(EventBase):
-    """Result of a website ingestion run."""
+    """Result of a website ingestion run.
 
+    Carries the identification fields (``bodyOfKnowledgeId``, ``type``,
+    ``purpose``, ``personaId``) so the alkemio-server result handler can
+    correlate the result back to the persona that owns the body of
+    knowledge. ``bodyOfKnowledgeId`` defaults to an empty string because
+    website-typed bodies of knowledge are URL-identified, not UUID-keyed.
+    """
+
+    body_of_knowledge_id: str = Field(default="", alias="bodyOfKnowledgeId")
+    type: str = ""
+    purpose: str = ""
+    persona_id: str = Field(default="", alias="personaId")
     timestamp: int = Field(
         default_factory=lambda: int(time.time() * 1000)
     )

--- a/plugins/ingest_space/plugin.py
+++ b/plugins/ingest_space/plugin.py
@@ -74,14 +74,20 @@ class IngestSpacePlugin:
             if self._graphql_client is None:
                 raise RuntimeError("GraphQL client not configured")
 
-            from plugins.ingest_space.space_reader import read_space_tree
-            documents = await read_space_tree(self._graphql_client, bok_id)
+            from plugins.ingest_space.space_reader import read_body_of_knowledge
+            logger.info(
+                "Ingesting BoK %s (type=%s, purpose=%s)",
+                bok_id, event.type, event.purpose,
+            )
+            documents = await read_body_of_knowledge(
+                self._graphql_client, bok_id, event.type,
+            )
 
             if not documents:
                 # Fetch succeeded but returned zero documents — run cleanup
                 # pipeline to remove any previously stored chunks.
                 logger.info(
-                    "Space %s returned zero documents; running cleanup pipeline for collection %s",
+                    "BoK %s returned zero documents; running cleanup pipeline for collection %s",
                     bok_id,
                     collection_name,
                 )
@@ -148,7 +154,7 @@ class IngestSpacePlugin:
             )
 
         except Exception as exc:
-            logger.exception("Space ingestion failed: %s", exc)
+            logger.exception("BoK ingestion failed: %s", exc)
             return IngestBodyOfKnowledgeResult(
                 body_of_knowledge_id=event.body_of_knowledge_id,
                 type=event.type,

--- a/plugins/ingest_space/space_reader.py
+++ b/plugins/ingest_space/space_reader.py
@@ -12,6 +12,11 @@ from plugins.ingest_space.link_extractor import extract_text
 
 logger = logging.getLogger(__name__)
 
+# Wire-format values of IngestBodyOfKnowledge.type — must match what the
+# Alkemio server publishes on the ingest queue.
+BOK_TYPE_SPACE = "alkemio-space"
+BOK_TYPE_KNOWLEDGE_BASE = "alkemio-knowledge-base"
+
 # HTML cleanup ----------------------------------------------------------------
 
 _SCRIPT_STYLE_RE = re.compile(r"<(script|style)[^>]*>.*?</\1>", re.IGNORECASE | re.DOTALL)
@@ -92,6 +97,21 @@ query SpaceTree($spaceId: UUID!) {{
 }}
 """
 
+# Knowledge bases are flat: a profile and a single calloutsSet, no subspaces.
+KNOWLEDGE_BASE_QUERY = f"""
+query KnowledgeBaseTree($kbId: UUID!) {{
+  lookup {{
+    knowledgeBase(ID: $kbId) {{
+      id
+      profile {{ displayName description url }}
+      calloutsSet {{
+        callouts {{ {_CALLOUT_FIELDS} }}
+      }}
+    }}
+  }}
+}}
+"""
+
 
 async def read_space_tree(graphql_client, space_id: str) -> list[Document]:
     """Read the full space tree and convert to Documents."""
@@ -113,6 +133,50 @@ async def read_space_tree(graphql_client, space_id: str) -> list[Document]:
         len(documents), stats["fetched"], stats["skipped"],
     )
     return documents
+
+
+async def read_knowledge_base_tree(graphql_client, kb_id: str) -> list[Document]:
+    """Read a knowledge base and convert its callouts to Documents."""
+    data = await graphql_client.query(KNOWLEDGE_BASE_QUERY, {"kbId": kb_id})
+    kb = (data.get("lookup") or {}).get("knowledgeBase")
+    if not kb:
+        return []
+
+    # Reshape into the dict layout _process_space expects: a synthetic
+    # `collaboration.calloutsSet` wrapper and no `subspaces`.
+    space_shaped = {
+        **kb,
+        "collaboration": {"calloutsSet": kb.get("calloutsSet")},
+        "subspaces": [],
+    }
+
+    documents: list[Document] = []
+    seen: set[str] = set()
+    stats = {"fetched": 0, "skipped": 0}
+    await _process_space(
+        space_shaped, documents, seen,
+        graphql_client=graphql_client, stats=stats, depth=0,
+        top_doc_type=DocumentType.KNOWLEDGE.value,
+    )
+    logger.info(
+        "Knowledge base tree: emitted %d unique documents "
+        "(link bodies fetched=%d, skipped=%d)",
+        len(documents), stats["fetched"], stats["skipped"],
+    )
+    return documents
+
+
+async def read_body_of_knowledge(
+    graphql_client, bok_id: str, bok_type: str,
+) -> list[Document]:
+    """Dispatch to the correct reader based on the BoK type.
+
+    Unknown types fall back to the space reader, which matches the dominant
+    case on the platform today.
+    """
+    if bok_type == BOK_TYPE_KNOWLEDGE_BASE:
+        return await read_knowledge_base_tree(graphql_client, bok_id)
+    return await read_space_tree(graphql_client, bok_id)
 
 
 def _append_unique(
@@ -155,21 +219,32 @@ async def _process_space(
     graphql_client,
     stats: dict,
     depth: int,
+    top_doc_type: str | None = None,
 ) -> None:
-    """Process a space node and its children recursively."""
+    """Process a space node and its children recursively.
+
+    `top_doc_type` overrides the doc type used for the depth-0 document
+    (so knowledge bases can be tagged as KNOWLEDGE instead of SPACE).
+    """
     profile = space.get("profile") or {}
     space_name = profile.get("displayName", "") or ""
     description = profile.get("description", "") or ""
     space_url = profile.get("url", "") or None
 
     if description:
-        doc_type = DocumentType.SPACE if depth == 0 else DocumentType.SUBSPACE
+        if depth == 0 and top_doc_type is not None:
+            doc_type_value = top_doc_type
+        else:
+            doc_type_value = (
+                DocumentType.SPACE.value if depth == 0
+                else DocumentType.SUBSPACE.value
+            )
         _append_unique(
             documents, seen,
             content=f"{space_name}\n\n{description}",
             document_id=space["id"],
             source=f"space:{space['id']}",
-            doc_type=doc_type.value,
+            doc_type=doc_type_value,
             title=space_name,
             uri=space_url,
         )

--- a/plugins/ingest_website/plugin.py
+++ b/plugins/ingest_website/plugin.py
@@ -113,6 +113,9 @@ class IngestWebsitePlugin:
                 ])
                 cleanup_result = await cleanup_engine.run([], collection_name)
                 return IngestWebsiteResult(
+                    type=event.type,
+                    purpose=event.purpose,
+                    persona_id=event.persona_id,
                     result=IngestionResult.SUCCESS if cleanup_result.success else IngestionResult.FAILURE,
                     error="; ".join(cleanup_result.errors) if cleanup_result.errors else "",
                 )
@@ -158,6 +161,9 @@ class IngestWebsitePlugin:
             result = await engine.run(documents, collection_name)
 
             return IngestWebsiteResult(
+                type=event.type,
+                purpose=event.purpose,
+                persona_id=event.persona_id,
                 result=IngestionResult.SUCCESS if result.success else IngestionResult.FAILURE,
                 error="; ".join(result.errors) if result.errors else "",
             )
@@ -165,6 +171,9 @@ class IngestWebsitePlugin:
         except Exception as exc:
             logger.exception("Website ingestion failed: %s", exc)
             return IngestWebsiteResult(
+                type=event.type,
+                purpose=event.purpose,
+                persona_id=event.persona_id,
                 result=IngestionResult.FAILURE,
                 error=str(exc),
             )

--- a/specs/032-ingest-result-correlation/checklists/requirements.md
+++ b/specs/032-ingest-result-correlation/checklists/requirements.md
@@ -1,0 +1,59 @@
+# Specification Quality Checklist: Ingest Website Result Correlation Fields
+
+**Purpose**: Validate specification completeness and quality
+**Created**: 2026-04-30
+**Feature**: [spec.md](../spec.md)
+
+## User Stories
+
+- [X] CHK001 At least one user story defined with priority label (P1/P2/P3).
+- [X] CHK002 Each user story has a clear "Why this priority" rationale.
+- [X] CHK003 Each user story has at least one Given/When/Then acceptance scenario.
+- [X] CHK004 Each user story has an "Independent Test" describing how it can be verified in isolation.
+- [X] CHK005 Stories are ordered by priority and a P1 MVP story exists.
+
+## Requirements
+
+- [X] CHK010 Functional requirements numbered (FR-001, FR-002, ...).
+- [X] CHK011 Each functional requirement is concrete and testable.
+- [X] CHK012 No requirements contain `[NEEDS CLARIFICATION: ...]` markers.
+- [X] CHK013 Backward-compatibility requirement stated explicitly (FR-004).
+- [X] CHK014 Test-coverage requirement stated explicitly (FR-006).
+
+## Edge Cases
+
+- [X] CHK020 Empty / default-value behaviour described.
+- [X] CHK021 Failure path (exception inside plugin) addressed.
+- [X] CHK022 Cleanup-only path (zero-document crawl) addressed.
+- [X] CHK023 Wire-level edge case (`bodyOfKnowledgeId` reserved-but-empty) explained.
+
+## Success Criteria
+
+- [X] CHK030 Measurable outcomes numbered (SC-001, SC-002, ...).
+- [X] CHK031 Each criterion is technology-agnostic and verifiable.
+- [X] CHK032 At least one criterion ties back to the producer (SC-001) and one to the consumer (SC-002, SC-003).
+
+## Assumptions
+
+- [X] CHK040 Assumptions section present and lists external-system contracts.
+- [X] CHK041 The "no coordinated server release" assumption is stated explicitly.
+- [X] CHK042 The "empty string == not specified" semantic is stated explicitly.
+
+## Cross-Artifact Consistency
+
+- [X] CHK050 Spec's user stories map to tasks.md phases (US1 → Phase 2, US2 → Phase 3).
+- [X] CHK051 Spec's FRs are reflected in plan.md Constitution Check rows.
+- [X] CHK052 Spec's wire-format claims match contracts/ingest-website-result.md before/after diff.
+- [X] CHK053 Data-model.md field table matches the actual Pydantic model in `core/events/ingest_website.py`.
+
+## Constitution Alignment
+
+- [X] CHK060 Plan includes a Constitution Check covering all 8 principles + relevant Architecture Standards.
+- [X] CHK061 No constitution violations require justification (no Complexity Tracking entries).
+- [X] CHK062 Wire-format change documented under "Event Schema as Wire Contract" standard.
+- [X] CHK063 No ADR required (justified in plan.md — P8 N/A) because the change is a backward-compatible field addition, not a port/contract/deployment change.
+
+## Notes
+
+- Spec is retrospective — written after the code change on commit `3dedb17`.
+- All checklist items pass; no follow-up work needed before merging the spec PR.

--- a/specs/032-ingest-result-correlation/contracts/ingest-website-result.md
+++ b/specs/032-ingest-result-correlation/contracts/ingest-website-result.md
@@ -1,0 +1,104 @@
+# Contract: `IngestWebsiteResult` Wire Schema
+
+**Feature Branch**: `032-ingest-result-correlation`
+**Date**: 2026-04-30
+
+## Scope
+
+Defines the JSON-on-the-wire contract for the `IngestWebsiteResult` event published from the virtual-contributor `ingest_website` plugin to the alkemio-server result handler over RabbitMQ. This is a wire-format change governed by the constitution's "Event Schema as Wire Contract" standard.
+
+## Before
+
+```json
+{
+  "timestamp": "<int, ms-epoch>",
+  "result":    "success | failure",
+  "error":     "<str, empty when result=success>"
+}
+```
+
+Pydantic source:
+
+```python
+class IngestWebsiteResult(EventBase):
+    timestamp: int = Field(default_factory=lambda: int(time.time() * 1000))
+    result: IngestionResult = IngestionResult.SUCCESS
+    error: str = ""
+```
+
+## After
+
+```json
+{
+  "bodyOfKnowledgeId": "<str, default ''>",
+  "type":              "<str, default ''>",
+  "purpose":           "<str, default ''>",
+  "personaId":         "<str, default ''>",
+  "timestamp":         "<int, ms-epoch>",
+  "result":            "success | failure",
+  "error":             "<str, empty when result=success>"
+}
+```
+
+Pydantic source:
+
+```python
+class IngestWebsiteResult(EventBase):
+    body_of_knowledge_id: str = Field(default="", alias="bodyOfKnowledgeId")
+    type: str = ""
+    purpose: str = ""
+    persona_id: str = Field(default="", alias="personaId")
+    timestamp: int = Field(default_factory=lambda: int(time.time() * 1000))
+    result: IngestionResult = IngestionResult.SUCCESS
+    error: str = ""
+```
+
+## Diff
+
+```diff
++ "bodyOfKnowledgeId": "",
++ "type":              "",
++ "purpose":           "",
++ "personaId":         "",
+  "timestamp":         <int>,
+  "result":            "success" | "failure",
+  "error":             ""
+```
+
+Four fields added. Zero fields removed, renamed, or retyped.
+
+## Backward Compatibility
+
+| Direction | Compatible? | Why |
+|---|---|---|
+| New producer → old consumer | **Yes** | Old consumer ignores the four new keys; existing keys (`timestamp`, `result`, `error`) are unchanged in name and type. |
+| Old producer → new consumer | **Yes** | New consumer reads the four new keys with empty-string defaults if they are absent. (In practice no old producer remains after this image rolls out, but the schema permits it.) |
+| Round-trip (Pydantic) | **Yes** | `model_validate(model_dump(..., by_alias=True))` reconstructs an equivalent model. |
+
+## Producer Behaviour
+
+The `ingest_website` plugin is the sole producer. After this change, `IngestWebsitePlugin.handle` populates `type`, `purpose`, and `persona_id` from the inbound `IngestWebsite` event on every return path:
+
+| Return path | Trigger | Identification fields populated? |
+|---|---|---|
+| Cleanup-only success | Crawl/extract returned zero documents | Yes — copied from inbound event |
+| Normal success | Pipeline ran and `IngestEngine` returned `success=True` | Yes |
+| Normal failure | Pipeline ran and `IngestEngine` returned `success=False` | Yes |
+| Exception | Any uncaught exception in `handle` | Yes |
+
+`bodyOfKnowledgeId` is **not** populated by this plugin — see research.md D3.
+
+## Consumer Expectations
+
+The alkemio-server result handler MAY use any of the new fields to correlate the result back to a persona record. The recommended primary correlation key is `personaId`. `type` and `purpose` are advisory tags that the server may use for status reporting. `bodyOfKnowledgeId` is reserved and SHOULD be treated as advisory until a producer plugin begins populating it.
+
+**Consumer-side implementation is out of scope for this repo.** The actual handler logic — which field(s) the alkemio-server reads, how it maps `personaId` to a persona row, and how status is surfaced to the persona's owner — lives in the alkemio-server repository. This contract specifies only the wire-format guarantees the producer (virtual-contributor) provides; reviewers verifying end-to-end correlation should consult the corresponding server-side change.
+
+## Verification
+
+| Check | Where |
+|---|---|
+| Default-value serialization with all four camelCase aliases | `tests/core/test_events.py::TestIngestWebsiteSerialization::test_result_model` |
+| Explicit-value round-trip | `tests/core/test_events.py::TestIngestWebsiteSerialization::test_result_with_identification_fields` |
+| Plugin propagation on normal-ingest path | `tests/plugins/test_ingest_website.py::TestIngestWebsitePlugin::test_pipeline_composition` |
+| Plugin propagation on cleanup-only path | `tests/plugins/test_ingest_website.py::TestIngestWebsitePlugin::test_empty_crawl_runs_cleanup` |

--- a/specs/032-ingest-result-correlation/data-model.md
+++ b/specs/032-ingest-result-correlation/data-model.md
@@ -1,0 +1,78 @@
+# Data Model: Ingest Website Result Correlation Fields
+
+**Feature Branch**: `032-ingest-result-correlation`
+**Date**: 2026-04-30
+
+## Modified Entity: `IngestWebsiteResult`
+
+Defined in `core/events/ingest_website.py`. Inherits from `EventBase`.
+
+### Fields (post-change)
+
+| Attribute | Wire alias | Type | Default | New? | Notes |
+|---|---|---|---|---|---|
+| `body_of_knowledge_id` | `bodyOfKnowledgeId` | `str` | `""` | **Yes** | Reserved for parity with other ingest result types. Website plugin leaves this empty because websites are URL-identified, not UUID-keyed. |
+| `type` | `type` | `str` | `""` | **Yes** | Echoed from `IngestWebsite.type`. Identifies content category (e.g., `"website"`). |
+| `purpose` | `purpose` | `str` | `""` | **Yes** | Echoed from `IngestWebsite.purpose`. Identifies usage class (e.g., `"knowledge"`). |
+| `persona_id` | `personaId` | `str` | `""` | **Yes** | Echoed from `IngestWebsite.persona_id`. The primary correlation key — the persona that owns the body of knowledge. |
+| `timestamp` | `timestamp` | `int` | `int(time.time() * 1000)` | No | Unchanged. Milliseconds since epoch. |
+| `result` | `result` | `IngestionResult` | `SUCCESS` | No | Unchanged. `success` \| `failure`. |
+| `error` | `error` | `str` | `""` | No | Unchanged. Empty string on success; error message on failure. |
+
+### Validation Rules
+
+- All four new fields are plain `str` with no length, format, or content validation. The wire contract does not require non-empty values; the alkemio-server treats empty strings as "not specified".
+- No `Optional[str]` / `None` is used — every field has a stable default and is always present in the dumped payload.
+- Pydantic `populate_by_name = True` (inherited from `EventBase`) means both attribute names and aliases are accepted on input.
+
+## Relationships
+
+`IngestWebsite` (request) → `IngestWebsiteResult` (response): the plugin handler copies three of the four new fields directly from the request:
+
+```text
+IngestWebsite.type        → IngestWebsiteResult.type
+IngestWebsite.purpose     → IngestWebsiteResult.purpose
+IngestWebsite.persona_id  → IngestWebsiteResult.persona_id
+```
+
+`IngestWebsite.base_url` is **not** copied into `IngestWebsiteResult.body_of_knowledge_id` — see research.md D3 for rationale.
+
+`IngestWebsite` is unchanged by this feature; it already carried `type`, `purpose`, and `persona_id`.
+
+## State Transitions
+
+None. The model is a one-shot result envelope with no lifecycle.
+
+## Wire Format Example
+
+Before this change, a successful result looked like:
+
+```json
+{
+  "timestamp": 1714502400000,
+  "result": "success",
+  "error": ""
+}
+```
+
+After this change, the same result emitted from a request with `personaId="p-1"`, `type="website"`, `purpose="knowledge"`:
+
+```json
+{
+  "bodyOfKnowledgeId": "",
+  "type": "website",
+  "purpose": "knowledge",
+  "personaId": "p-1",
+  "timestamp": 1714502400000,
+  "result": "success",
+  "error": ""
+}
+```
+
+A consumer that ignores unknown fields produces the same domain semantics from both payloads.
+
+## Backward Compatibility
+
+- **Producers**: existing call sites that construct `IngestWebsiteResult(...)` without the new kwargs continue to compile and produce valid payloads (all fields default to `""`).
+- **Consumers**: existing consumers reading `result`, `error`, `timestamp` continue to work — none of those fields changed.
+- **Schema validators**: any external schema validator that enforces "no extra fields" must be relaxed to ignore the additions. The alkemio-server validator is not strict in this regard.

--- a/specs/032-ingest-result-correlation/plan.md
+++ b/specs/032-ingest-result-correlation/plan.md
@@ -1,0 +1,81 @@
+# Implementation Plan: Ingest Website Result Correlation Fields
+
+**Branch**: `032-ingest-result-correlation` | **Date**: 2026-04-30 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/032-ingest-result-correlation/spec.md`
+
+## Summary
+
+Add four identification fields (`bodyOfKnowledgeId`, `type`, `purpose`, `personaId`) to the `IngestWebsiteResult` event envelope and have `IngestWebsitePlugin.handle` copy them through from the inbound `IngestWebsite` request on every return path (cleanup-only, success, failure, exception). The change is additive on the wire — all four fields default to empty strings so any caller that does not yet populate them continues to work, and any consumer that does not yet read them is unaffected. The motivation is that the alkemio-server result handler must correlate the result back to the persona that owns the body of knowledge, and prior to this change the envelope carried only `result`, `error`, and `timestamp` — not enough to identify the originating request.
+
+## Technical Context
+
+**Language/Version**: Python 3.12
+**Primary Dependencies**: Pydantic v2 (event models), aio-pika (RabbitMQ transport)
+**Storage**: N/A — pure event schema and plugin handler change
+**Testing**: pytest with `asyncio_mode = "auto"`; existing mock ports in `tests/conftest.py`
+**Target Platform**: Linux container (single image, `PLUGIN_TYPE=ingest_website`)
+**Project Type**: Microkernel + Hexagonal Python service
+**Performance Goals**: No measurable performance impact — four extra string fields on a low-frequency result envelope
+**Constraints**: Wire format MUST remain backward-compatible with existing alkemio-server deployments; no coordinated release required
+**Scale/Scope**: Single plugin (`ingest_website`), single event model (`IngestWebsiteResult`), three return sites in `plugin.handle`
+
+## Constitution Check
+
+| Principle / Standard | Status | Notes |
+|---|---|---|
+| P1 AI-Native Development | PASS | Change is small, deterministic, fully covered by automated tests; no human verification needed beyond CI. |
+| P2 SOLID Architecture | PASS | Single Responsibility preserved — plugin still does one thing; the additional fields are pure data passthrough. No new coupling introduced. |
+| P3 No Vendor Lock-in | N/A | No provider-specific code touched. |
+| P4 Optimised Feedback Loops | PASS | New behaviour fully exercised by `tests/core/test_events.py` and `tests/plugins/test_ingest_website.py`; runs locally under `poetry run pytest`. |
+| P5 Best Available Infrastructure | N/A | No CI/CD changes. |
+| P6 Spec-Driven Development | PASS | This retrospec records the spec; the change qualified as a small bug fix under P6's exception clause but was promoted to a full SDD artifact set for traceability. |
+| P7 No Filling Tests | PASS | Tests assert wire-format invariants (camelCase aliases, default values, propagation through three return paths) — each guards a real behavioural contract with the alkemio-server. |
+| P8 Architecture Decision Records | N/A | No port/adapter, plugin contract, or deployment-model change. The change is a backward-compatible additive field on an existing event. |
+| Microkernel Architecture | PASS | Change confined to `core/events/` (schema) and `plugins/ingest_website/` (handler). Core untouched, no cross-plugin coupling. |
+| Plugin Contract | PASS | `PluginContract` protocol unchanged. |
+| Event Schema as Wire Contract | PASS | Additive change with empty-string defaults; existing field names and types preserved. camelCase aliases applied (`bodyOfKnowledgeId`, `personaId`); `type` and `purpose` are already lowercase so no alias is required. |
+| Domain Logic Isolation | N/A | Domain pipeline unchanged. |
+| Async-First Design | PASS | No change to async semantics. |
+| Simplicity Over Speculation | PASS | Minimal patch — four fields and three call-site updates. No abstractions introduced for the unused `bodyOfKnowledgeId` field; it is reserved by being present with an empty default. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/032-ingest-result-correlation/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── tasks.md
+├── contracts/
+│   └── ingest-website-result.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+core/
+└── events/
+    └── ingest_website.py          # Modified: 4 new fields on IngestWebsiteResult
+
+plugins/
+└── ingest_website/
+    └── plugin.py                  # Modified: propagate fields from event in 3 return sites
+
+tests/
+├── core/
+│   └── test_events.py             # Modified: default-value + explicit-value serialization tests
+└── plugins/
+    └── test_ingest_website.py     # Modified: propagation assertions on 2 plugin paths
+```
+
+**Structure Decision**: Standard microkernel layout. Changes live in `core/events/` (event schema is part of the wire contract) and `plugins/ingest_website/` (the only producer of `IngestWebsiteResult`). No new files. No directory or module-boundary changes.
+
+## Complexity Tracking
+
+No constitution violations — this section is not applicable.

--- a/specs/032-ingest-result-correlation/quickstart.md
+++ b/specs/032-ingest-result-correlation/quickstart.md
@@ -1,0 +1,82 @@
+# Quickstart: Ingest Website Result Correlation Fields
+
+**Feature Branch**: `032-ingest-result-correlation`
+**Date**: 2026-04-30
+
+## What This Feature Does
+
+Adds four identification fields — `bodyOfKnowledgeId`, `type`, `purpose`, `personaId` — to the `IngestWebsiteResult` event envelope, and propagates them from the inbound `IngestWebsite` request through every code path in the website ingest plugin. The alkemio-server result handler can now correlate every received result back to the originating persona without keeping any local correlation state.
+
+## Configuration
+
+No new environment variables. No new feature flags. No new configuration.
+
+## How to Verify Locally
+
+### 1. Run the affected test files
+
+```bash
+poetry run pytest tests/core/test_events.py::TestIngestWebsiteSerialization -v
+poetry run pytest tests/plugins/test_ingest_website.py::TestIngestWebsitePlugin -v
+```
+
+Expected: all tests pass, including:
+
+- `test_result_model` — confirms default-value payload includes `bodyOfKnowledgeId`, `personaId`, `type`, `purpose`.
+- `test_result_with_identification_fields` — confirms explicit values round-trip via `model_dump`.
+- `test_pipeline_composition` — confirms identification fields propagate from request to result on the normal ingest path.
+- `test_empty_crawl_runs_cleanup` — confirms identification fields propagate on the cleanup-only path.
+
+### 2. Inspect a result envelope manually
+
+```python
+from core.events.ingest_website import IngestWebsiteResult, IngestionResult
+
+result = IngestWebsiteResult(
+    body_of_knowledge_id="bok-1",
+    type="website",
+    purpose="knowledge",
+    persona_id="persona-1",
+    result=IngestionResult.SUCCESS,
+)
+print(result.model_dump(by_alias=True))
+```
+
+Expected output (camelCase keys):
+
+```python
+{
+    "bodyOfKnowledgeId": "bok-1",
+    "type":              "website",
+    "purpose":           "knowledge",
+    "personaId":         "persona-1",
+    "timestamp":         1714502400000,
+    "result":            "success",
+    "error":             ""
+}
+```
+
+### 3. End-to-end with a live RabbitMQ (optional)
+
+If you want to observe the wire format on RabbitMQ:
+
+```bash
+PLUGIN_TYPE=ingest_website poetry run python main.py
+```
+
+Publish an `IngestWebsite` request to the configured queue with `personaId="p-1"`, `type="website"`, `purpose="knowledge"`, and a small `baseUrl`. Capture the result message — it MUST contain `personaId: "p-1"` alongside the existing `result` and `error` fields.
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `core/events/ingest_website.py` | Added four identification fields to `IngestWebsiteResult`; documented why `bodyOfKnowledgeId` defaults empty. |
+| `plugins/ingest_website/plugin.py` | Populated `type`, `purpose`, `persona_id` from the inbound event in three result-construction sites: cleanup-only, normal success/failure, exception handler. |
+| `tests/core/test_events.py` | Added default-payload assertion (camelCase aliases present) and explicit-value round-trip test. |
+| `tests/plugins/test_ingest_website.py` | Added propagation assertions on the normal-ingest test and on the empty-crawl cleanup test. |
+
+## Rollout Notes
+
+- Backward compatible — no coordinated alkemio-server release required.
+- Empty-string defaults mean any existing producer or consumer that does not yet handle the new fields continues to work.
+- No data migration. No persistent state involved.

--- a/specs/032-ingest-result-correlation/research.md
+++ b/specs/032-ingest-result-correlation/research.md
@@ -1,0 +1,77 @@
+# Research: Ingest Website Result Correlation Fields
+
+**Feature Branch**: `032-ingest-result-correlation`
+**Date**: 2026-04-30
+
+## Decisions
+
+### D1 — Add identification fields directly to `IngestWebsiteResult` rather than wrapping the result
+
+**Decision**: Extend the existing `IngestWebsiteResult` Pydantic model with four new fields (`body_of_knowledge_id`, `type`, `purpose`, `persona_id`).
+
+**Rationale**: The result envelope is the wire contract with the alkemio-server. Wrapping the result in an outer correlation object would force a coordinated server release and break every existing consumer. Adding fields directly is purely additive — old consumers ignore the new fields, new consumers read them.
+
+**Alternatives considered**:
+- *Wrapper envelope* (`{correlation: {...}, result: {...}}`): rejected — breaking change requiring coordinated server release.
+- *Correlation in RabbitMQ message headers*: rejected — separates correlation data from the payload, requires server-side header parsing, and breaks the principle that the event body is self-describing.
+- *Server keeps a request → result correlation map keyed by message ID*: rejected — adds stateful complexity to the server for what is fundamentally a request/response shape.
+
+### D2 — Default each new field to empty string
+
+**Decision**: All four fields default to `""` rather than `None` or being required.
+
+**Rationale**: Empty-string default makes the model constructible with no arguments, which keeps the existing call sites (and tests) working without migration. It also produces a stable wire format: the field is always present in the JSON payload, never `null` and never absent, which is the simplest contract for the server to consume. Using `None` (with `Optional[str]`) would force every consumer to handle null, and using a required field would break any caller that doesn't yet pass the value.
+
+**Alternatives considered**:
+- *Required fields with no default*: rejected — breaks existing call sites and any future caller that doesn't have the value.
+- *Optional with `None` default*: rejected — introduces null-handling on the consumer side for no benefit.
+
+### D3 — `body_of_knowledge_id` defaults to empty string for the website plugin
+
+**Decision**: The website ingest plugin does not populate `body_of_knowledge_id` — the field is left as its empty-string default in every emitted result.
+
+**Rationale**: Websites are identified by their base URL, not by a UUID body-of-knowledge ID. The field is included on the schema so the result envelope is consistent with other ingest result types (and so a future change can populate it without further schema work). Populating it with the URL would conflate two different identifier semantics on the server side.
+
+**Alternatives considered**:
+- *Populate with the base URL*: rejected — different semantic from a UUID-keyed body-of-knowledge ID; would mislead the server.
+- *Omit the field for the website plugin*: rejected — schema parity across ingest result types is more valuable than the small saving of one field.
+
+### D4 — camelCase aliases for `bodyOfKnowledgeId` and `personaId`, plain names for `type` and `purpose`
+
+**Decision**: Use Pydantic `Field(alias="...")` for the multi-word fields; leave single-word `type` and `purpose` aliasless.
+
+**Rationale**: The wire format is camelCase per the constitution's "Event Schema as Wire Contract" standard. Single-word fields are the same in both snake_case and camelCase, so no alias is needed. This matches the existing pattern in the same file (e.g., `IngestWebsite.base_url` aliased to `baseUrl`, but no aliases on the equally-positional `type` and `purpose`).
+
+**Alternatives considered**:
+- *Aliases on every field for consistency*: rejected — adds noise without changing wire format.
+- *Rename `type` and `purpose` to camelCase via Pydantic config*: rejected — they are already correct on the wire.
+
+### D5 — Propagate fields at every return site in the plugin handler
+
+**Decision**: Three return statements in `IngestWebsitePlugin.handle` (cleanup-only path, normal success/failure path, exception path) each construct `IngestWebsiteResult(...)` with `type=event.type, purpose=event.purpose, persona_id=event.persona_id` explicitly.
+
+**Rationale**: The handler has three independent return sites, each constructing its own `IngestWebsiteResult`. Centralising the construction in a helper would add indirection for what is three lines of identical kwargs. Tests cover all three sites by exercising the cleanup path (`test_empty_crawl_runs_cleanup`) and the normal path (`test_pipeline_composition`); the exception path is covered indirectly by the same construction pattern.
+
+**Alternatives considered**:
+- *Helper `_build_result(event, ...)` method*: rejected — premature abstraction over three call sites; adds indirection without simplifying the code.
+- *Post-handle middleware that copies fields onto every result*: rejected — pulls into the core a concern that belongs to the plugin; violates plugin-isolation and would touch the router.
+
+### D6 — Tests assert camelCase aliases in serialised output, not just attribute access
+
+**Decision**: `tests/core/test_events.py` calls `model_dump(...)` and inspects the resulting dict for the camelCase keys (`bodyOfKnowledgeId`, `personaId`).
+
+**Rationale**: The wire contract is the JSON output, not the Python attribute names. Asserting on the dict keys catches alias regressions that attribute-only tests would miss.
+
+**Alternatives considered**:
+- *Test only attribute access (`result.persona_id == "..."`)*: rejected — would not catch a missing alias that breaks the wire contract.
+
+## Summary Table
+
+| ID | Decision | Reason in one line |
+|----|----------|--------------------|
+| D1 | Add fields directly to result model | Additive change; no coordinated release |
+| D2 | Empty-string default | Stable wire format, no migration |
+| D3 | `bodyOfKnowledgeId` reserved but unpopulated | Schema parity; URL is not a UUID |
+| D4 | Aliases only where snake → camel differs | Match existing repo convention |
+| D5 | Inline kwargs at all three return sites | No abstraction needed for three call sites |
+| D6 | Assert camelCase keys in dumped dict | Wire format is the dict, not the attribute |

--- a/specs/032-ingest-result-correlation/spec.md
+++ b/specs/032-ingest-result-correlation/spec.md
@@ -1,0 +1,77 @@
+# Feature Specification: Ingest Website Result Correlation Fields
+
+**Feature Branch**: `032-ingest-result-correlation`
+**Created**: 2026-04-30
+**Status**: Implemented
+**Input**: Retrospec from code changes
+
+## User Scenarios & Testing
+
+### User Story 1 - Correlate Website Ingest Result to Owning Persona (Priority: P1)
+
+As an **alkemio-server result handler**, when I receive an `IngestWebsiteResult` event from the virtual-contributor over RabbitMQ, I MUST be able to identify which persona, body of knowledge, and content type the result belongs to — without keeping correlation state on my side.
+
+**Why this priority**: This is the core value of the change. The alkemio-server is the only consumer of the result envelope, and a result with no identification fields is effectively orphaned: the server cannot mark a body of knowledge as "ingested" or surface ingestion status to the persona's owner. Without these fields the entire end-to-end ingestion feedback loop is broken.
+
+**Independent Test**: Send an `IngestWebsite` event with a populated `personaId`, `type`, and `purpose`, then assert the resulting `IngestWebsiteResult` payload (camelCase, `by_alias=True`) contains the same `personaId`, `type`, `purpose`, and a `bodyOfKnowledgeId` field (defaulting to empty string for URL-keyed websites).
+
+**Acceptance Scenarios**:
+
+1. **Given** an `IngestWebsite` event with `personaId="p-1"`, `type="website"`, `purpose="knowledge"`, **When** the plugin completes a successful crawl-and-ingest run, **Then** the emitted `IngestWebsiteResult` JSON contains `personaId: "p-1"`, `type: "website"`, `purpose: "knowledge"`, and `bodyOfKnowledgeId: ""`.
+2. **Given** the same input event, **When** the crawl returns zero documents and the plugin runs the cleanup-only path, **Then** the emitted result still carries the same identification fields.
+3. **Given** the same input event, **When** the plugin raises an exception during ingest, **Then** the emitted failure result still carries the same identification fields so the server can mark the correct persona's ingest as failed.
+
+---
+
+### User Story 2 - Backward-Compatible Wire Format (Priority: P1)
+
+As an **alkemio-server operator**, I MUST be able to deploy the new virtual-contributor image without simultaneously deploying a server change. Existing servers that don't yet read the new fields MUST keep working.
+
+**Why this priority**: The two services release independently. Any change to the result envelope that breaks existing consumers blocks the release.
+
+**Independent Test**: Deserialize a result payload produced by the new code with a Pydantic model that lacks the new fields — it must succeed. Conversely, serialize a result with no identification fields set — it must produce a payload where the new fields default to empty strings (not omitted, not `null`).
+
+**Acceptance Scenarios**:
+
+1. **Given** the new `IngestWebsiteResult` model, **When** instantiated with no identification arguments, **Then** `model_dump(by_alias=True)` includes `bodyOfKnowledgeId: ""`, `personaId: ""`, `type: ""`, `purpose: ""`.
+2. **Given** a server that ignores unknown JSON fields, **When** it receives the new payload, **Then** existing fields (`result`, `error`, `timestamp`) are unchanged in name and type.
+
+---
+
+### Edge Cases
+
+- **Empty `IngestWebsite` request**: If the inbound event has empty strings for `type`, `purpose`, or `personaId`, the result simply echoes those empty strings — no validation is added because the wire contract does not require non-empty values.
+- **Cleanup-only path with no documents**: The result still carries identification fields so the server can record the empty-but-valid ingest run against the correct persona.
+- **Exception path**: A crash inside the ingest pipeline must not strip identification fields. The exception handler constructs a failure result with the same fields populated from the inbound event.
+- **`bodyOfKnowledgeId` for websites**: Websites are URL-identified, not UUID-keyed, so the field is reserved for future use but defaults to empty string for the website plugin. The field is present so the schema is consistent with other ingest result envelopes.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: `IngestWebsiteResult` MUST expose four identification fields — `body_of_knowledge_id`, `type`, `purpose`, `persona_id` — and serialize them with the camelCase aliases `bodyOfKnowledgeId`, `type`, `purpose`, `personaId`.
+- **FR-002**: Each identification field MUST default to an empty string so the model is constructible with no arguments and existing call sites need no migration.
+- **FR-003**: The `IngestWebsitePlugin.handle` method MUST copy `type`, `purpose`, and `persona_id` from the inbound `IngestWebsite` event to every `IngestWebsiteResult` it returns, on every code path: cleanup-only, successful ingest, failed ingest, and exception.
+- **FR-004**: The result envelope MUST remain backward-compatible: no existing field is renamed, retyped, or removed, and the new fields are additive.
+- **FR-005**: Identification fields MUST round-trip via `model_dump(by_alias=True)` and `model_validate(...)` without loss.
+- **FR-006**: Test coverage MUST include: default-value serialization (FR-002), explicit-value round-trip (FR-005), propagation from request to result on the normal-ingest path (FR-003), and propagation on the empty-crawl cleanup path (FR-003).
+
+### Key Entities
+
+- **IngestWebsiteResult**: The Pydantic event model emitted by the website ingest plugin. Now carries `body_of_knowledge_id`, `type`, `purpose`, `persona_id` alongside the pre-existing `result`, `error`, `timestamp` fields.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of `IngestWebsiteResult` envelopes emitted by the plugin carry non-default identification fields when the inbound request specifies them.
+- **SC-002**: Existing `IngestWebsiteResult` consumers (alkemio-server) continue to deserialize result payloads with no error after this change.
+- **SC-003**: The alkemio-server can correlate every received `IngestWebsiteResult` to its originating persona without consulting any local state — the result envelope is self-describing.
+- **SC-004**: Test suite asserts identification-field propagation on at least the normal-ingest path and the cleanup-only path; both pass.
+
+## Assumptions
+
+- The alkemio-server result handler treats unknown JSON fields as ignorable (the standard JSON-deserialization contract on its side).
+- Empty-string defaults are acceptable substitutes for "not specified" — neither side treats them as semantically distinct from missing fields.
+- The `bodyOfKnowledgeId` field is reserved for parity with other ingest result schemas; the website plugin does not yet need to populate it because websites are keyed by URL, not UUID. A future change may begin populating it without further schema work.
+- No coordinated server release is required — the change is additive on the wire.

--- a/specs/032-ingest-result-correlation/tasks.md
+++ b/specs/032-ingest-result-correlation/tasks.md
@@ -1,0 +1,102 @@
+# Tasks: Ingest Website Result Correlation Fields
+
+**Input**: Design documents from `specs/032-ingest-result-correlation/`
+**Organization**: Tasks grouped by user story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1 = correlation, US2 = backward compatibility)
+- All tasks below are marked `[X]` because the implementation already exists on this branch.
+
+---
+
+## Phase 1: Foundational
+
+**Purpose**: No foundational scaffolding required — the event model and plugin already exist.
+
+- [X] T001 Confirm `IngestWebsiteResult` exists in `core/events/ingest_website.py` and is wired through `core/router.py`.
+- [X] T002 Confirm `IngestWebsitePlugin.handle` returns an `IngestWebsiteResult` on every code path.
+
+**Checkpoint**: Foundation verified — both user stories can proceed.
+
+---
+
+## Phase 2: User Story 1 — Correlate Website Ingest Result to Owning Persona (P1) 🎯 MVP
+
+**Goal**: Deliver enough information in the result envelope for the alkemio-server to correlate the result back to the persona that owns the body of knowledge.
+
+**Independent Test**: Construct `IngestWebsiteResult` from a known `IngestWebsite` event, dump to dict, assert `personaId`, `type`, `purpose` round-trip.
+
+### Tests for User Story 1
+
+- [X] T010 [P] [US1] Add `test_result_with_identification_fields` to `tests/core/test_events.py` asserting explicit values round-trip via `model_dump(by_alias=True)`.
+- [X] T011 [P] [US1] Extend `test_pipeline_composition` in `tests/plugins/test_ingest_website.py` to assert `result.persona_id == event.persona_id`, `result.type == event.type`, `result.purpose == event.purpose` on the normal-ingest path.
+- [X] T012 [P] [US1] Extend `test_empty_crawl_runs_cleanup` in `tests/plugins/test_ingest_website.py` to assert the same propagation on the cleanup-only path.
+
+### Implementation for User Story 1
+
+- [X] T013 [US1] Add `body_of_knowledge_id`, `type`, `purpose`, `persona_id` fields to `IngestWebsiteResult` in `core/events/ingest_website.py`, with empty-string defaults and `Field(alias=...)` for the multi-word fields.
+- [X] T014 [US1] Update the docstring of `IngestWebsiteResult` to explain why `bodyOfKnowledgeId` defaults to empty string for the website plugin.
+- [X] T015 [US1] In `plugins/ingest_website/plugin.py`, populate `type=event.type, purpose=event.purpose, persona_id=event.persona_id` in the cleanup-only success/failure return path.
+- [X] T016 [US1] In `plugins/ingest_website/plugin.py`, populate the same three kwargs in the normal-ingest success/failure return path.
+- [X] T017 [US1] In `plugins/ingest_website/plugin.py`, populate the same three kwargs in the exception handler return path.
+
+**Checkpoint**: User Story 1 fully functional — every result emitted from `IngestWebsitePlugin` carries identification fields populated from the inbound request.
+
+---
+
+## Phase 3: User Story 2 — Backward-Compatible Wire Format (P1)
+
+**Goal**: Existing alkemio-server deployments that do not yet read the new fields continue to deserialize result payloads without error.
+
+**Independent Test**: Construct `IngestWebsiteResult()` with no kwargs; assert `model_dump(by_alias=True)` produces a payload with the new fields defaulting to `""`, and that all pre-existing fields (`result`, `error`, `timestamp`) keep their names and types.
+
+### Tests for User Story 2
+
+- [X] T020 [P] [US2] Extend `test_result_model` in `tests/core/test_events.py` to assert default payload includes `bodyOfKnowledgeId == ""`, `personaId == ""`, `type == ""`, `purpose == ""`. The same test also confirms the pre-existing `timestamp`, `result`, `error` fields keep their names and types.
+
+### Implementation for User Story 2
+
+User Story 2 is delivered by the same edit as T013: every new field on `IngestWebsiteResult` carries an empty-string default, and no pre-existing field is renamed or retyped. No additional implementation tasks beyond T020.
+
+**Checkpoint**: User Story 2 fully functional — the wire format is additive, no consumer migration required.
+
+---
+
+## Phase 4: Polish
+
+- [X] T030 [P] Document the field additions in this spec's `data-model.md` and `contracts/ingest-website-result.md`.
+- [X] T031 Run the affected test files locally — `poetry run pytest tests/core/test_events.py tests/plugins/test_ingest_website.py` — and confirm they pass.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Phase 1 (Foundational): trivial — verified state of the existing code, no work.
+- Phase 2 (US1): depends on Phase 1.
+- Phase 3 (US2): may proceed in parallel with Phase 2 because both rely on the same schema edit (T013), and US2's test (T020) operates on the same file as US1's (T010).
+- Phase 4 (Polish): after Phase 2 and Phase 3.
+
+### Within Each User Story
+
+- Tests (T010–T012, T020) MUST be written before implementation to verify they fail first.
+- Schema change (T013) before plugin propagation (T015–T017).
+- Plugin propagation tasks (T015–T017) target the same file (`plugin.py`) so cannot be parallelised with each other, but each is a single localised edit.
+
+### Parallel Opportunities
+
+- T010, T011, T012, T020 — different test functions, no shared state — can be drafted in parallel.
+- T015, T016, T017 — same file but distinct return sites — can be applied in one edit pass.
+
+> Note: earlier revisions of this file enumerated separate tasks T021 ("use empty-string defaults") and T022 ("verify pre-existing fields unchanged"). They were placeholder "covered-by" entries with no independent work and were folded into T013 (schema edit) and T020 (test assertion) respectively.
+
+---
+
+## Notes
+
+- All tasks `[X]` because the code already exists on this branch (commit `3dedb17`).
+- Single PR delivery: the schema change, plugin change, and tests ship together — splitting would yield non-viable specs.
+- No ADR required — see plan.md Constitution Check (P8 N/A).

--- a/specs/033-ingest-space-kb-routing/checklists/requirements.md
+++ b/specs/033-ingest-space-kb-routing/checklists/requirements.md
@@ -1,0 +1,64 @@
+# Specification Quality Checklist: Ingest Space Knowledge-Base Routing
+
+**Purpose**: Validate specification completeness and quality
+**Created**: 2026-05-11
+**Feature**: [spec.md](../spec.md)
+
+## User Stories
+
+- [X] CHK001 At least one user story defined with priority label (P1/P2/P3).
+- [X] CHK002 Each user story has a clear "Why this priority" rationale grounded in measured impact (`69/238` BoKs affected) or operational value.
+- [X] CHK003 Each user story has at least one Given/When/Then acceptance scenario.
+- [X] CHK004 Each user story has an "Independent Test" describing how it can be verified in isolation.
+- [X] CHK005 Stories are ordered by priority and the P1 story is the MVP routing fix.
+
+## Requirements
+
+- [X] CHK010 Functional requirements numbered (FR-001 … FR-009).
+- [X] CHK011 Each functional requirement is concrete and testable.
+- [X] CHK012 No requirements contain `[NEEDS CLARIFICATION: …]` markers.
+- [X] CHK013 Backward-compatibility requirement on the public reader API stated explicitly (FR-008).
+- [X] CHK014 Wire-format invariance stated explicitly (FR-007).
+- [X] CHK015 Test-coverage requirement stated explicitly (FR-009) and enumerates the specific tests that must exist.
+
+## Edge Cases
+
+- [X] CHK020 Missing-entity behaviour described for both reader paths.
+- [X] CHK021 Empty-knowledge-base path described (zero callouts, zero description).
+- [X] CHK022 Unknown / empty `type` fallback behaviour described.
+- [X] CHK023 Transport-error path described (preserves previously-good chunks).
+- [X] CHK024 Id-collision concern raised and dismissed (BoK ids are globally unique).
+
+## Success Criteria
+
+- [X] CHK030 Measurable outcomes numbered (SC-001 … SC-004).
+- [X] CHK031 Each criterion is technology-agnostic and verifiable post-deploy.
+- [X] CHK032 Test-suite gating criterion present (SC-004) so future regressions are caught at PR time.
+
+## Assumptions
+
+- [X] CHK040 Assumptions section present and lists external-system contracts (server schema, type vocabulary).
+- [X] CHK041 "No coordinated server release" assumption stated explicitly.
+- [X] CHK042 Knowledge-base flatness (no nested subspaces) called out as a forward-compatibility risk.
+- [X] CHK043 `top_doc_type` opt-in semantics stated so the unaffectedness of existing callers is explicit.
+
+## Cross-Artifact Consistency
+
+- [X] CHK050 Spec's user stories map to tasks.md phases (US1 → Phase 2, US2 → Phase 3, US3 → Phase 4).
+- [X] CHK051 Spec's FRs are covered by plan.md Constitution Check rows and tasks.md tests.
+- [X] CHK052 Spec's GraphQL claims match `contracts/ingest-graphql-lookup.md` before/after diff.
+- [X] CHK053 `data-model.md` documents every new symbol the implementation introduces (constants, query, two functions, one parameter).
+- [X] CHK054 `quickstart.md` references the same files-changed table as `plan.md` and `data-model.md`.
+
+## Constitution Alignment
+
+- [X] CHK060 Plan includes a Constitution Check covering all 8 principles + relevant Architecture Standards.
+- [X] CHK061 No constitution violations require justification (no Complexity Tracking entries).
+- [X] CHK062 GraphQL routing change documented but does not require an ADR — the underlying server endpoints already exist and the wire schema is unchanged (justified in plan.md, P8 N/A).
+- [X] CHK063 SOLID compliance (P2) reviewed across the three new symbols.
+
+## Notes
+
+- Spec is retrospective — written after the code change on commit `0a48620` (PR #98).
+- All checklist items pass.
+- The GraphQL guardrail test (T005) is the durable safeguard against a future revert to `lookup.space()` on the KB path.

--- a/specs/033-ingest-space-kb-routing/contracts/ingest-graphql-lookup.md
+++ b/specs/033-ingest-space-kb-routing/contracts/ingest-graphql-lookup.md
@@ -1,0 +1,100 @@
+# Contract: Ingest GraphQL Lookup Routing
+
+**Feature**: [spec.md](../spec.md)
+**Date**: 2026-05-11
+
+## Scope
+
+This contract describes the client-side GraphQL queries the ingest-space
+plugin issues against the Alkemio server's private API, and how the choice
+between them is governed by the inbound `IngestBodyOfKnowledge` event's
+`type` field.
+
+No change is made to any RabbitMQ event schema; the contract here is the
+plugin's expectations of the Alkemio GraphQL schema. The server endpoints
+referenced (`lookup.space`, `lookup.knowledgeBase`) already exist —
+this PR begins exercising the second one rather than introducing either.
+
+## Before / After
+
+### Before
+
+For every `IngestBodyOfKnowledge` event, regardless of `type`:
+
+```graphql
+query SpaceTree($spaceId: UUID!) {
+  lookup {
+    space(ID: $spaceId) { id, profile { … }, collaboration { … }, subspaces [...] }
+  }
+}
+```
+
+The server returns `ENTITY_NOT_FOUND` when `$spaceId` resolves to a
+knowledge-base entity (which lives in a different table), and the
+ingest pipeline aborts.
+
+### After
+
+The plugin selects one of two queries based on `event.type`:
+
+| `event.type` | GraphQL operation | Variables |
+|---|---|---|
+| `"alkemio-space"` (or unknown) | `query SpaceTree($spaceId: UUID!) { lookup { space(ID: $spaceId) { … } } }` | `{ spaceId: <bok_id> }` |
+| `"alkemio-knowledge-base"` | `query KnowledgeBaseTree($kbId: UUID!) { lookup { knowledgeBase(ID: $kbId) { id, profile { displayName description url }, calloutsSet { callouts { … _CALLOUT_FIELDS … } } } } }` | `{ kbId: <bok_id> }` |
+
+## GraphQL Schema Expectations
+
+The plugin assumes the server exposes the following resolver field on the
+`Lookup` type:
+
+```graphql
+type LookupQueryResults {
+  knowledgeBase(ID: UUID!): KnowledgeBase!
+}
+
+type KnowledgeBase {
+  id: UUID!
+  profile: Profile!
+  calloutsSet: CalloutsSet!
+}
+```
+
+Selected fields used by the client:
+
+- `KnowledgeBase.id` (UUID)
+- `KnowledgeBase.profile { displayName, description, url }`
+- `KnowledgeBase.calloutsSet.callouts` — each member with the same shape the
+  space query already selects: `id, framing { profile { … } }, contributions { post {…}, whiteboard {…}, link {…} }`.
+
+The client never selects `KnowledgeBase.virtualContributor` or
+`KnowledgeBase.authorization`. The server's existing READ_ABOUT
+authorisation check on `lookup.knowledgeBase` is sufficient — the same
+session token that authorised `lookup.space` previously authorises
+`lookup.knowledgeBase` for the ingest service identity.
+
+## Wire Compatibility
+
+| Event | Pre-change | Post-change |
+|---|---|---|
+| `IngestBodyOfKnowledge` (consumed) | fields read: all except `type` | fields read: all incl. `type` |
+| `IngestBodyOfKnowledgeResult` (produced) | unchanged shape | unchanged shape |
+
+Reading the `type` field is **not** a wire change — the field was already
+defined on the event model. Consumers that emit the event are unaffected.
+
+## Error Paths
+
+| Condition | Server response | Plugin behaviour | Reported result |
+|---|---|---|---|
+| KB id resolves to a real knowledge base with callouts | 200 OK with KB payload | Walk the tree, ingest documents, run pipeline | `result: "success"` |
+| KB id resolves to a real knowledge base with no callouts and no description | 200 OK with KB payload, empty `calloutsSet.callouts` | Cleanup pipeline runs against the empty collection | `result: "success"` |
+| KB id does not resolve (deleted, never existed, unauthorised) | 200 OK with `data.lookup.knowledgeBase: null` (or a GraphQL error) | Reader returns `[]`; cleanup pipeline runs | `result: "success"` if the GraphQL call did not raise; `result: "failure"` if it did |
+| Network / transport error during the lookup | `httpx`/transport exception | Caught by plugin's exception handler; no cleanup runs | `result: "failure"`, `error.message` populated |
+| `event.type` is unknown / empty / missing | n/a (client-side) | Falls back to `lookup.space(ID:)` — same behaviour as today | Same as the corresponding space-path outcome |
+
+## Backward Compatibility
+
+- No GraphQL query the plugin previously issued is removed; `lookup.space(ID:)` keeps its exact shape and variable name (`$spaceId`).
+- No new field is added to any RabbitMQ message.
+- No change to the collection naming convention (`{bok_id}-{purpose}`).
+- The legacy entrypoint `read_space_tree(graphql_client, space_id)` is exported with its existing signature, so any external caller (and the existing test suite) continues to work.

--- a/specs/033-ingest-space-kb-routing/data-model.md
+++ b/specs/033-ingest-space-kb-routing/data-model.md
@@ -1,0 +1,119 @@
+# Data Model: Ingest Space Knowledge-Base Routing
+
+**Feature Branch**: `033-ingest-space-kb-routing`
+**Date**: 2026-05-11
+
+This feature does not change the persisted data model or the wire schema of
+any RabbitMQ event. It introduces two module-level constants, one new
+GraphQL query document, two new module-level functions, and one new
+optional parameter on an existing internal function. The only metadata
+change observable to downstream consumers is the value of the `type` field
+on root documents emitted from knowledge-base traversals.
+
+## New / Modified Entities
+
+### Module-level constants (new)
+
+In `plugins/ingest_space/space_reader.py`:
+
+| Name | Type | Value | Purpose |
+|---|---|---|---|
+| `BOK_TYPE_SPACE` | `str` | `"alkemio-space"` | Wire-format value of `IngestBodyOfKnowledge.type` for space-backed BoKs |
+| `BOK_TYPE_KNOWLEDGE_BASE` | `str` | `"alkemio-knowledge-base"` | Wire-format value of `IngestBodyOfKnowledge.type` for knowledge-base-backed BoKs |
+
+Single source of truth so tests and the dispatcher agree on the vocabulary
+without sprinkling string literals through the module.
+
+### GraphQL document (new)
+
+`KNOWLEDGE_BASE_QUERY`: module-level constant containing the query string
+
+```graphql
+query KnowledgeBaseTree($kbId: UUID!) {
+  lookup {
+    knowledgeBase(ID: $kbId) {
+      id
+      profile { displayName description url }
+      calloutsSet {
+        callouts { … _CALLOUT_FIELDS … }
+      }
+    }
+  }
+}
+```
+
+`_CALLOUT_FIELDS` is the same fragment the space-tree query uses, so post /
+whiteboard / link selections stay in lockstep between both readers.
+
+### `read_knowledge_base_tree` (new function)
+
+```python
+async def read_knowledge_base_tree(
+    graphql_client, kb_id: str,
+) -> list[Document]:
+    ...
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `graphql_client` | `Any` (duck-typed) | Must expose an awaitable `query(query_str, variables) -> dict` and `fetch_url(url) -> tuple[bytes, str] \| None` (the latter is consumed by callout link extraction inside `_process_space`). |
+| `kb_id` | `str` | UUID of the knowledge base to ingest. |
+| **returns** | `list[Document]` | Documents extracted from the KB's callouts; empty list if the KB does not resolve. |
+
+Internal flow:
+
+1. Issue `KNOWLEDGE_BASE_QUERY` with `{"kbId": kb_id}`.
+2. Read `data["lookup"]["knowledgeBase"]`; return `[]` if `None`.
+3. Reshape to `{**kb, "collaboration": {"calloutsSet": kb["calloutsSet"]}, "subspaces": []}`.
+4. Call `_process_space(...)` with `depth=0` and `top_doc_type=DocumentType.KNOWLEDGE.value`.
+5. Log doc count and link-fetch stats at INFO.
+
+### `read_body_of_knowledge` (new function)
+
+```python
+async def read_body_of_knowledge(
+    graphql_client, bok_id: str, bok_type: str,
+) -> list[Document]:
+    ...
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `bok_type` | `str` | The `type` field from `IngestBodyOfKnowledge`. |
+| **returns** | `list[Document]` | Result of the selected reader; semantically identical to whichever underlying reader runs. |
+
+Branching:
+
+| `bok_type` value | Reader invoked |
+|---|---|
+| `BOK_TYPE_KNOWLEDGE_BASE` | `read_knowledge_base_tree` |
+| anything else (incl. `BOK_TYPE_SPACE`, empty string, unknown) | `read_space_tree` |
+
+### `_process_space.top_doc_type` (new parameter)
+
+| Field | Type | Default | Purpose |
+|---|---|---|---|
+| `top_doc_type` | `str \| None` (kw-only) | `None` | If set, the depth-0 document is tagged with this value instead of `DocumentType.SPACE` / `DocumentType.SUBSPACE`. |
+
+Behaviour rules:
+
+- When `top_doc_type is None`: depth-0 → `DocumentType.SPACE`, depth>0 → `DocumentType.SUBSPACE`. Identical to the prior behaviour.
+- When `top_doc_type is not None` and `depth == 0`: doc type is `top_doc_type`.
+- When `top_doc_type is not None` and `depth > 0`: ignored — recursion still uses `SUBSPACE`. (Knowledge bases have no subspaces, so this branch is unreachable today but defined for safety.)
+
+## Document Metadata Changes Observable Downstream
+
+| Path | Pre-change `metadata.type` of root document | Post-change `metadata.type` of root document |
+|---|---|---|
+| `lookup.space(ID:)` → `read_space_tree` | `"space"` | `"space"` (unchanged) |
+| `lookup.knowledgeBase(ID:)` → `read_knowledge_base_tree` | (path did not exist; an empty collection was produced) | `"knowledge"` |
+
+All other document types (`callout`, `post`, `whiteboard`, `link`,
+`subspace`) are unchanged.
+
+## Unchanged
+
+- Event schemas: `IngestBodyOfKnowledge` and `IngestBodyOfKnowledgeResult`.
+- Pipeline steps: chunking, content hashing, change detection, summarisation, embedding, store, orphan cleanup.
+- Collection naming: still `{bok_id}-{purpose}`.
+- All adapters (`KnowledgeStorePort`, `EmbeddingsPort`, `LLMPort`).

--- a/specs/033-ingest-space-kb-routing/plan.md
+++ b/specs/033-ingest-space-kb-routing/plan.md
@@ -1,0 +1,86 @@
+# Implementation Plan: Ingest Space Knowledge-Base Routing
+
+**Branch**: `033-ingest-space-kb-routing` | **Date**: 2026-05-11 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/033-ingest-space-kb-routing/spec.md`
+
+## Summary
+
+Branch the ingest-space plugin on the inbound event's `type` field so that
+`alkemio-knowledge-base` bodies of knowledge are fetched via
+`lookup.knowledgeBase(ID:)` instead of `lookup.space(ID:)`. The fix is entirely
+client-side. A new `read_knowledge_base_tree` reader normalises the
+knowledge-base GraphQL response into the dict shape the existing
+`_process_space` traversal already understands (synthetic
+`collaboration.calloutsSet`, empty `subspaces`), so all callout / post /
+whiteboard / link handling is reused unchanged. A thin `read_body_of_knowledge`
+dispatcher selects the reader from `event.type`, with unknown types falling back
+to the space reader to preserve today's behaviour for the dominant case. The
+plugin logs the resolved type for operator visibility.
+
+## Technical Context
+
+**Language/Version**: Python 3.12
+**Primary Dependencies**: httpx (GraphQL transport), Pydantic v2 (event models), aio-pika (RabbitMQ)
+**Storage**: ChromaDB via `KnowledgeStorePort` (unchanged by this feature)
+**Testing**: pytest with `asyncio_mode = "auto"`; in-memory mocks in `tests/conftest.py` (`MockEmbeddingsPort`, `MockKnowledgeStorePort`, `MockLLMPort`) and the test factory `make_ingest_body_of_knowledge`
+**Target Platform**: Linux container (single image, `PLUGIN_TYPE=ingest_space`)
+**Project Type**: Microkernel + Hexagonal Python service
+**Performance Goals**: No measurable change — the knowledge-base query is structurally simpler than the space tree query (no subspaces). Round-trip cost is dominated by network and server work, not the query string.
+**Constraints**: Wire contract (`IngestBodyOfKnowledge` / `IngestBodyOfKnowledgeResult`) MUST NOT change. Public function `read_space_tree` MUST keep its signature for backward compatibility.
+**Scale/Scope**: One plugin (`ingest_space`), one module (`space_reader.py`), three return sites in `plugin.handle`. ~80 lines added in `space_reader.py`, ~10 lines in `plugin.py`, ~170 lines of tests.
+
+## Constitution Check
+
+| Principle / Standard | Status | Notes |
+|---|---|---|
+| P1 AI-Native Development | PASS | Change is small, deterministic, fully covered by automated tests. Routing decision is gated by tests so no human verification is needed beyond CI. |
+| P2 SOLID Architecture | PASS | Single Responsibility preserved — `read_space_tree` keeps its existing behaviour; the new reader has the single job of walking a knowledge base; the dispatcher has the single job of picking between them. Open/Closed: adding the new path required zero changes to `_process_space` semantics (only an additive optional parameter). |
+| P3 No Vendor Lock-in | N/A | No LLM/embedding/provider code touched. |
+| P4 Optimised Feedback Loops | PASS | Twelve new tests added alongside the implementation. All run locally under `poetry run pytest tests/plugins/test_ingest_space.py` in under a second. CI runs the same suite. |
+| P5 Best Available Infrastructure | N/A | No CI/CD change. |
+| P6 Spec-Driven Development | PASS | This retrospec records the spec for an urgent bug fix shipped on a `fix/…` branch. The fix was small enough to qualify for P6's bug-fix exception clause but is promoted to a full SDD artifact set for traceability and to gate any future routing changes against the test suite. |
+| P7 No Filling Tests | PASS | Each new test guards a real behavioural contract — the dispatcher's branching, the KB reader's GraphQL choice, the root-document type tag, and end-to-end plugin propagation. No trivial getters, no framework re-assertions. |
+| P8 Architecture Decision Records | N/A | No port interface, plugin contract, or wire-format change. The new GraphQL query is an internal client choice — `lookup.knowledgeBase` is a pre-existing server endpoint. |
+| Microkernel Architecture | PASS | Change confined to `plugins/ingest_space/`. Core untouched. No cross-plugin coupling. |
+| Plugin Contract | PASS | `PluginContract` protocol unchanged; the plugin still handles `IngestBodyOfKnowledge` and returns `IngestBodyOfKnowledgeResult`. |
+| Event Schema as Wire Contract | PASS | No field added, renamed, retyped, or removed on either event. The existing `type` field is now read (it was previously ignored); semantics of `type` are clarified by use, not by schema change. |
+| Domain Logic Isolation | PASS | The ingest pipeline (`core/domain/pipeline`) is unchanged. The plugin still composes `ChunkStep`, `ContentHashStep`, `ChangeDetectionStep`, `EmbedStep`, `StoreStep`, and the summarisation steps exactly as before. |
+| Async-First Design | PASS | All new functions are `async def`. GraphQL calls go through the existing async client. |
+| Simplicity Over Speculation | PASS | The KB reader reuses `_process_space` via a synthetic-shape adapter rather than duplicating callout traversal code. The dispatcher is a six-line `if/else`. The new `top_doc_type` parameter is the minimal hook required to differentiate root tagging — no broader refactor of `_process_space`. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/033-ingest-space-kb-routing/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── tasks.md
+├── contracts/
+│   └── ingest-graphql-lookup.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+plugins/
+└── ingest_space/
+    ├── space_reader.py         # Modified: KB query, KB reader, dispatcher, top_doc_type kwarg
+    └── plugin.py               # Modified: dispatch on event.type; log resolved type
+
+tests/
+└── plugins/
+    └── test_ingest_space.py    # Modified: KB reader, dispatcher, plugin dispatch tests
+```
+
+**Structure Decision**: Standard microkernel layout. Every change lives inside the `ingest_space` plugin module and its dedicated test file. Nothing in `core/` is touched. No new files are introduced.
+
+## Complexity Tracking
+
+No constitution violations — this section is not applicable.

--- a/specs/033-ingest-space-kb-routing/quickstart.md
+++ b/specs/033-ingest-space-kb-routing/quickstart.md
@@ -1,0 +1,87 @@
+# Quickstart: Ingest Space Knowledge-Base Routing
+
+**Feature Branch**: `033-ingest-space-kb-routing`
+**Date**: 2026-05-11
+
+## What this feature does
+
+Routes `IngestBodyOfKnowledge` events to the correct GraphQL lookup
+endpoint based on the body-of-knowledge type:
+
+- `type: "alkemio-space"` → `lookup.space(ID:)`
+- `type: "alkemio-knowledge-base"` → `lookup.knowledgeBase(ID:)`
+- anything else → falls back to `lookup.space(ID:)`
+
+Before this change the plugin only knew about spaces, so the ~29 % of VCs
+backed by knowledge bases were producing empty Chroma collections, which
+RAG queries then consumed as if they were real grounding.
+
+## Configuration
+
+No new environment variables. No new configuration. The change is gated
+entirely by the `type` field on inbound RabbitMQ messages, which the
+Alkemio server already populates.
+
+## How to verify it works
+
+### 1. Unit / integration tests (local)
+
+```bash
+poetry run pytest tests/plugins/test_ingest_space.py -q
+```
+
+Expect 37+ tests, all green. The new classes added by this feature:
+
+- `TestKnowledgeBaseReader` — four tests covering the KB GraphQL query, root document type tagging, and empty-result handling.
+- `TestBodyOfKnowledgeDispatcher` — three tests asserting the dispatcher routes each known type and the unknown-type fallback.
+- `TestIngestSpacePluginDispatchesOnType` — two end-to-end tests that the plugin propagates `event.type` into the dispatcher and the correct reader is awaited.
+
+### 2. Acceptance environment (post-deploy)
+
+After a release containing this fix is deployed to acceptance:
+
+1. Pick a VC whose body of knowledge is an `alkemio-knowledge-base` — the
+   acceptance database has 69 of them at the time of writing. The
+   reference case from the bug report is `test-vc-flow-003`, BoK id
+   `e2cf604d-8ef0-43d5-8220-9324f43ce4ca`.
+2. Trigger a refresh of that body of knowledge (UI: "UPDATE KNOWLEDGE";
+   or publish an `IngestBodyOfKnowledge` event directly to the
+   `virtual-contributor-ingest-body-of-knowledge` queue).
+3. Tail the `ingest-space` pod logs. Confirm:
+   - A line of the form `Ingesting BoK <id> (type=alkemio-knowledge-base, purpose=knowledge)`.
+   - No `Unable to find Space using options 'undefined'` error follows.
+   - The pipeline reaches `Knowledge base tree: emitted N unique documents` with `N > 0` if the KB has content, or `N = 0` if it does not.
+4. Query the resulting Chroma collection (`{bok_id}-knowledge`) and confirm
+   chunks are present (or the collection is empty after cleanup, if the KB
+   itself was empty).
+5. Ask a question of the VC that previously hallucinated; confirm the
+   answer is grounded and cites sources.
+
+### 3. Regression check for space-backed VCs
+
+Pick any VC whose body of knowledge is an `alkemio-space` (169 of them on
+acceptance — most VCs). Trigger a refresh; confirm:
+
+- A line of the form `Ingesting BoK <id> (type=alkemio-space, …)`.
+- Existing `Space tree: emitted N unique documents` log line still appears with the same shape.
+- The resulting collection contains the same documents it did before this change (chunk count, dedup behaviour identical).
+
+## Files changed
+
+| Path | Change |
+|---|---|
+| `plugins/ingest_space/space_reader.py` | + `BOK_TYPE_*` constants, `KNOWLEDGE_BASE_QUERY`, `read_knowledge_base_tree()`, `read_body_of_knowledge()` dispatcher, `top_doc_type` kwarg on `_process_space` |
+| `plugins/ingest_space/plugin.py` | Route through `read_body_of_knowledge(event.type)`; log resolved type at the start of `handle()` |
+| `tests/plugins/test_ingest_space.py` | New `TestKnowledgeBaseReader`, `TestBodyOfKnowledgeDispatcher`, `TestIngestSpacePluginDispatchesOnType` |
+
+## Rollback
+
+The change is additive on the client side. To roll back:
+
+1. Revert the commit on `fix/ingest-space-knowledge-base` (PR #98).
+2. Redeploy the previous image.
+
+No data migration, no schema rollback, no coordinated server change.
+Existing collections produced under the new code remain valid input for
+RAG queries; the only difference is the `type` metadata on root documents,
+which downstream consumers do not branch on today.

--- a/specs/033-ingest-space-kb-routing/research.md
+++ b/specs/033-ingest-space-kb-routing/research.md
@@ -1,0 +1,160 @@
+# Research: Ingest Space Knowledge-Base Routing
+
+**Feature Branch**: `033-ingest-space-kb-routing`
+**Date**: 2026-05-11
+
+## Background
+
+The ingest-space plugin runs against every `IngestBodyOfKnowledge` event the
+RabbitMQ queue delivers, regardless of the body-of-knowledge type. The event
+carries a `type` field (`alkemio-space` or `alkemio-knowledge-base`) but the
+plugin previously ignored it and always issued `lookup.space(ID:)` via GraphQL.
+Knowledge-base BoKs live in a different table on the Alkemio server, so the
+query returns `ENTITY_NOT_FOUND` and the pipeline aborts after creating the
+empty `{bok_id}-{purpose}` collection upfront — leaving an empty Chroma
+collection that downstream RAG queries silently consume, producing
+hallucinated answers.
+
+Postgres survey on acceptance at the time of the fix:
+
+| `bodyOfKnowledgeType` | count |
+|---|---|
+| `alkemio-space` | 169 |
+| `alkemio-knowledge-base` | 69 |
+
+i.e. ~29 % of the platform's VCs were affected.
+
+## Decisions
+
+### Decision 1: Branch on `event.type` in a small dispatcher
+
+**Decision**: Add `read_body_of_knowledge(graphql_client, bok_id, bok_type)`
+that selects between `read_space_tree` and `read_knowledge_base_tree` based
+on the type.
+
+**Rationale**: The branching point is at the GraphQL boundary — different
+queries returning different shapes. A six-line `if/else` is the right level
+of abstraction: it reads naturally, it is trivial to test, and it keeps the
+two readers' implementations free of type-checking conditionals. The
+plugin's `handle()` stays a one-liner against the dispatcher, so future
+types can be added by extending the dispatcher without touching the plugin.
+
+**Alternatives considered**:
+
+- *Push the branching into `_process_space`*: rejected — it would mix
+  GraphQL transport with the document-tree walker. They are orthogonal
+  responsibilities.
+- *Have the plugin issue both queries and merge results*: rejected —
+  doubles GraphQL load, introduces ambiguity when both succeed (cannot
+  happen today but is the kind of speculative complexity Principle 10
+  forbids), and obscures the intent in logs.
+- *Read the BoK type from the server before deciding*: rejected — adds a
+  round trip and re-implements information the server already includes in
+  the event envelope. The server is authoritative on the type field.
+
+### Decision 2: Reshape the KB response to reuse `_process_space`
+
+**Decision**: `read_knowledge_base_tree` wraps the GraphQL response into the
+dict layout `_process_space` already understands, by inserting a synthetic
+`collaboration.calloutsSet` and an empty `subspaces` list:
+
+```python
+space_shaped = {
+    **kb,
+    "collaboration": {"calloutsSet": kb.get("calloutsSet")},
+    "subspaces": [],
+}
+```
+
+**Rationale**: The callout / contribution traversal is identical between
+spaces and knowledge bases. Duplicating ~150 lines of post / whiteboard /
+link extraction in a parallel KB walker is exactly the kind of code that
+silently drifts out of sync. By adapting the response shape at one place,
+all future callout-handling improvements automatically apply to both code
+paths.
+
+**Alternatives considered**:
+
+- *Parameterise `_process_space` with extractor callbacks*: rejected —
+  over-engineered for a single new caller. Adding a callback API to a
+  recursive walker invites further callback explosions when the next new
+  caller arrives.
+- *Refactor `_process_space` into two halves (root vs. callouts)*: rejected
+  — current single-function design is small enough to keep; splitting it
+  introduces a coordination contract between the two halves with no
+  near-term benefit.
+
+### Decision 3: Override the root document type via a kw-only `top_doc_type`
+
+**Decision**: Add `top_doc_type: str | None = None` to `_process_space`.
+When set and `depth == 0`, the root document is tagged with that value
+instead of `DocumentType.SPACE`. Knowledge-base callers pass
+`DocumentType.KNOWLEDGE.value`.
+
+**Rationale**: The existing `SPACE` / `SUBSPACE` branching is semantically
+correct for spaces. Knowledge bases are not spaces — `DocumentType.KNOWLEDGE`
+already exists for exactly this purpose. Tagging root documents accurately
+removes a future class of bugs where a downstream consumer adds
+type-sensitive logic (filtering, display) and silently miscategorises ~29 %
+of VCs.
+
+**Alternatives considered**:
+
+- *Always tag the root as `SPACE`*: rejected — accurate today only because
+  no consumer differentiates. Inaccurate metadata is technical debt.
+- *Always tag the root as `KNOWLEDGE` regardless of source*: rejected —
+  would change the type tag for the 169 / 238 space-backed VCs, which is a
+  larger behavioural change than this PR justifies.
+- *Detect the type from the dict shape inside `_process_space`*: rejected —
+  binds the walker to the response wire format, which the caller already
+  knows. The override parameter is opt-in and explicit.
+
+### Decision 4: Unknown `type` defaults to the space reader
+
+**Decision**: Any `bok_type` value the dispatcher does not recognise routes
+to `read_space_tree`.
+
+**Rationale**: Space is the dominant case (169 / 238). The space reader's
+existing failure mode for an id that does not resolve is benign — it
+returns an empty list, the plugin's empty-result handler runs cleanup, and
+the run is reported as success. By contrast, failing fast on unknown types
+would surface as a new wave of `result: failure` envelopes for any future
+server-introduced BoK type before this plugin is updated. The "soft" default
+keeps the platform working during such a transition window.
+
+**Alternatives considered**:
+
+- *Raise on unknown types*: rejected for the reasons above. We can revisit
+  if the server begins frequently introducing new types; today the BoK
+  vocabulary is stable.
+- *Log a warning but continue*: deferred — the plugin already logs the
+  resolved type at INFO (US-2). A warning can be added in the future once
+  we have a list of "known" types to validate against, rather than relying
+  on the hard-coded string match in this PR.
+
+### Decision 5: Keep `read_space_tree` exported with its existing signature
+
+**Decision**: The new dispatcher does not replace `read_space_tree`.
+`read_space_tree(graphql_client, space_id)` keeps the same name, parameters,
+and return type.
+
+**Rationale**: The existing test suite imports `read_space_tree` directly
+and the plugin previously called it as a top-level function. Breaking the
+import surface for a routing improvement would be pure churn. The
+dispatcher is an additional entry point, not a replacement.
+
+**Alternatives considered**:
+
+- *Rename `read_space_tree` to `_read_space_tree` (private)*: rejected —
+  forces unnecessary test rewrites and external import breakage for no
+  behavioural gain.
+
+## Decision Summary
+
+| # | Decision | One-line rationale |
+|---|---|---|
+| 1 | Dispatch on `event.type` via a small `read_body_of_knowledge` function | Single branching point, naturally testable, keeps the plugin a one-liner |
+| 2 | Reshape the KB response and reuse `_process_space` | Avoids duplicating ~150 lines of callout/post/whiteboard/link extraction |
+| 3 | Override root document type via `top_doc_type` kwarg | Knowledge bases are tagged `knowledge`, not `space`; existing callers unaffected |
+| 4 | Unknown `bok_type` defaults to the space reader | Preserves today's behaviour for the dominant case during any future server-side type expansion |
+| 5 | Keep `read_space_tree` public with its existing signature | Avoids churn for existing callers and tests |

--- a/specs/033-ingest-space-kb-routing/spec.md
+++ b/specs/033-ingest-space-kb-routing/spec.md
@@ -1,0 +1,102 @@
+# Feature Specification: Ingest Space Knowledge-Base Routing
+
+**Feature Branch**: `033-ingest-space-kb-routing`
+**Created**: 2026-05-11
+**Status**: Implemented
+**Input**: Retrospec from code changes
+
+## User Scenarios & Testing
+
+### User Story 1 - Knowledge-Base-Backed VCs Successfully Ingest (Priority: P1)
+
+As a **virtual contributor operator**, when I create or refresh a virtual contributor whose body of knowledge is an **alkemio-knowledge-base** (not a space), I MUST receive a populated knowledge collection so that downstream RAG queries are grounded in real content instead of hallucinated.
+
+**Why this priority**: On the acceptance environment, 69 of 238 VCs (~29 %) are backed by `alkemio-knowledge-base`. Before this change, every single one of them was producing an empty Chroma collection because the ingest-space plugin issued `lookup.space()` for all bodies of knowledge regardless of type. The Alkemio server returned `ENTITY_NOT_FOUND`, the pipeline aborted before reaching the orphan-cleanup safety net, and the empty placeholder collection survived — which then served as the RAG source for every expert / guidance query against those VCs, producing confident-but-hallucinated answers. Restoring ingest for ~29 % of the platform's VCs is the highest-impact behavioural change available.
+
+**Independent Test**: Publish an `IngestBodyOfKnowledge` event with `type: "alkemio-knowledge-base"` and a valid `bodyOfKnowledgeId` whose knowledge base contains at least one callout. Assert that (a) the ingest pipeline completes with `result: "success"`, (b) the resulting collection contains chunks derived from the knowledge base's callouts, and (c) no `Unable to find Space` error appears in the plugin logs.
+
+**Acceptance Scenarios**:
+
+1. **Given** an `IngestBodyOfKnowledge` event with `type="alkemio-knowledge-base"` and a `bodyOfKnowledgeId` that resolves to a knowledge base on the Alkemio server, **When** the plugin handles the event, **Then** it issues a `lookup.knowledgeBase(ID: …)` GraphQL query (not `lookup.space()`) and the resulting documents are stored under the collection name `{bok_id}-{purpose}`.
+2. **Given** an `IngestBodyOfKnowledge` event with `type="alkemio-space"`, **When** the plugin handles the event, **Then** the pre-existing space-tree traversal runs unchanged and produces the same documents it did before this change.
+3. **Given** an `IngestBodyOfKnowledge` event with an unrecognised `type` value (e.g. a future addition, a typo, or an empty string), **When** the plugin handles the event, **Then** the plugin defaults to the space reader, preserving today's behaviour for the dominant case (169 / 238 VCs) rather than failing fast.
+
+---
+
+### User Story 2 - Operator Sees the Resolved Routing Decision in Logs (Priority: P2)
+
+As an **operator investigating an ingest run**, when I look at the ingest-space pod logs for a given BoK, I MUST be able to see which reader path was taken (`alkemio-space` vs `alkemio-knowledge-base`) so I can quickly distinguish "wrong type routed" from "right type but no content" without re-reading the source.
+
+**Why this priority**: This is observability scaffolding, not a behavioural fix. It is P2 because without it, diagnosing a future regression in routing requires reading the plugin source against the message body — slow under incident pressure. The cost of adding a single `logger.info` line is negligible.
+
+**Independent Test**: Trigger any ingest run and grep the pod logs for the line containing the BoK id and type — both must appear on a single line at INFO level before any further pipeline output for that BoK.
+
+**Acceptance Scenarios**:
+
+1. **Given** an `IngestBodyOfKnowledge` event arrives, **When** the plugin begins handling it, **Then** an INFO-level log line is emitted containing the `body_of_knowledge_id`, the `type`, and the `purpose` from the event.
+2. **Given** the same event, **When** the plugin completes the run, **Then** the existing pipeline log lines (chunk counts, embedding stats, etc.) remain unchanged.
+
+---
+
+### User Story 3 - Knowledge-Base Documents Are Tagged as `knowledge`, Not `space` (Priority: P3)
+
+As a **downstream consumer of the knowledge store** (expert / guidance plugins), when I filter or display documents by their `type` metadata, knowledge-base root documents MUST be tagged `knowledge` (not `space`) so the metadata accurately reflects what the document represents.
+
+**Why this priority**: The downstream consumers currently use the `type` field mostly for display/filtering, not for routing logic — so a mis-tag does not break behaviour today. But emitting accurate metadata removes a class of subtle future bugs where a consumer adds type-sensitive logic and silently miscategorises ~29 % of root documents. The `DocumentType.KNOWLEDGE` enum value already exists for exactly this purpose.
+
+**Independent Test**: Construct a knowledge-base GraphQL response with a populated profile description; invoke `read_knowledge_base_tree`; assert the returned root document's `metadata.type` equals `"knowledge"`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a knowledge-base lookup returns a payload with a non-empty `profile.description`, **When** `read_knowledge_base_tree` builds documents from it, **Then** the root document's `metadata.type` equals `DocumentType.KNOWLEDGE.value` (`"knowledge"`).
+2. **Given** a space lookup returns an equivalent payload, **When** `read_space_tree` builds documents from it, **Then** the root document's `metadata.type` equals `DocumentType.SPACE.value` (`"space"`) — i.e. the space path is unaffected by the new override.
+
+---
+
+### Edge Cases
+
+- **Knowledge base not found**: If `lookup.knowledgeBase(ID:)` returns `null` (entity missing or unauthorised), the reader returns an empty document list. The plugin's existing empty-result handler then runs the cleanup pipeline, removing any stale chunks for that BoK — the same behaviour today's space reader exhibits for a missing space.
+- **Empty knowledge base**: A knowledge base with no callouts and no profile description produces zero documents. Cleanup runs, the collection is empty, and the result is reported as `success` (no error, no orphan chunks).
+- **Knowledge base with the same id as a space**: BoK ids in Alkemio are globally unique across entity types, so this collision cannot occur. The dispatcher relies entirely on `event.type` — never on probing both endpoints.
+- **`event.type` is `None` or empty string**: Falls through to the space reader (the safe default for the dominant case). The space reader will then return an empty list if `lookup.space()` fails.
+- **GraphQL transport error on the knowledge-base query**: Propagates the same way as for the space query — the plugin's exception handler emits an `IngestBodyOfKnowledgeResult` with `result="failure"` and the error message, without running cleanup (so previously-good chunks are preserved).
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The ingest-space plugin MUST route `IngestBodyOfKnowledge` events to the GraphQL query that matches the event's `type` field — `lookup.space(ID:)` for `alkemio-space`, `lookup.knowledgeBase(ID:)` for `alkemio-knowledge-base`.
+- **FR-002**: An unrecognised `type` value MUST fall back to the space reader. The plugin MUST NOT raise an error, and MUST NOT attempt to probe both endpoints.
+- **FR-003**: `read_knowledge_base_tree` MUST issue a GraphQL query that selects, at minimum: `id`, `profile { displayName description url }`, and `calloutsSet { callouts { … } }` — using the same `_CALLOUT_FIELDS` fragment that the space reader uses.
+- **FR-004**: Documents emitted by the knowledge-base reader MUST go through the same `_process_space` callout/contribution traversal as the space reader, so post / whiteboard / link extraction behaves identically.
+- **FR-005**: The root document of a knowledge-base traversal MUST be tagged with `DocumentType.KNOWLEDGE` (wire value `"knowledge"`); callouts, posts, whiteboards, and links retain their existing types.
+- **FR-006**: The plugin MUST emit an INFO-level log line at the start of each `handle()` call containing the BoK id, type, and purpose.
+- **FR-007**: The wire contract of `IngestBodyOfKnowledge` and `IngestBodyOfKnowledgeResult` MUST NOT change — no new fields, no renames, no removals.
+- **FR-008**: The legacy entrypoint `read_space_tree` MUST remain available with its existing signature so external imports and existing tests continue to work.
+- **FR-009**: Test coverage MUST include: (a) the knowledge-base reader walks callouts correctly, (b) the knowledge-base reader emits `KNOWLEDGE`-typed root documents, (c) the knowledge-base reader returns an empty list on a `null` GraphQL response, (d) the dispatcher routes each known type to the matching reader, (e) the dispatcher falls back to the space reader on unknown types, and (f) the plugin propagates `event.type` into the dispatcher.
+
+### Key Entities
+
+- **`read_body_of_knowledge` (dispatcher)**: Module-level async function in `plugins/ingest_space/space_reader.py`. Takes a GraphQL client, a BoK id, and a BoK type string; returns a list of `Document`. Selects between `read_space_tree` and `read_knowledge_base_tree` based on the type.
+- **`read_knowledge_base_tree`**: Module-level async function that issues `KNOWLEDGE_BASE_QUERY`, reshapes the response into the same dict layout `_process_space` already understands, and delegates the traversal — passing `top_doc_type=DocumentType.KNOWLEDGE.value` so the root tag differs from the space path.
+- **`BOK_TYPE_SPACE` / `BOK_TYPE_KNOWLEDGE_BASE` constants**: Single source of truth for the wire-format `type` values used by `IngestBodyOfKnowledge`. Match the Alkemio server's published vocabulary.
+- **`_process_space.top_doc_type`**: New optional kw-only parameter that overrides the depth-0 document type. Default `None` preserves today's `SPACE` / `SUBSPACE` branching.
+- **`KNOWLEDGE_BASE_QUERY`**: Module-level GraphQL document string; same callout fragment as `SPACE_TREE_QUERY` but no `subspaces` and no `collaboration` wrapper.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: 100 % of `IngestBodyOfKnowledge` events with `type="alkemio-knowledge-base"` are routed to `lookup.knowledgeBase()`. None are routed to `lookup.space()`.
+- **SC-002**: Zero `IngestBodyOfKnowledgeResult` envelopes are emitted with `result="failure"` and an `error.message` containing `Unable to find Space` for events whose `type="alkemio-knowledge-base"`. This is observable directly from the VC's own published RabbitMQ result stream — no server-side log access required.
+- **SC-003**: The empty-`{bok_id}-knowledge` collections that the bulk refresh previously created for the ~69 knowledge-base-backed VCs are populated (or cleanly cleaned up, if the KB itself contains no callouts) on the next refresh wave.
+- **SC-004**: Test suite gates the routing decision: tests fail if a future change causes an `alkemio-knowledge-base` event to call `lookup.space()`, or vice versa.
+
+## Assumptions
+
+- The Alkemio server's `lookup.knowledgeBase(ID:)` resolver returns the shape captured in `KNOWLEDGE_BASE_QUERY`: `{ id, profile, calloutsSet { callouts { … } } }`. Verified against the server's `KnowledgeBase` entity definition at the time of writing.
+- BoK type values on the wire are stable strings — `alkemio-space` and `alkemio-knowledge-base`. The server controls this vocabulary; new types will be added by the server team and routed here in a subsequent change.
+- Knowledge bases are flat (no nested subspaces). If the server adds a hierarchy in the future, `read_knowledge_base_tree` will need to be extended.
+- Falling back to the space reader on unknown types is preferable to failing fast, because (a) the dominant case is space (169 / 238), so unknown-type messages from older servers are most plausibly mis-tagged spaces, and (b) the existing failure mode of an unknown-space-id (returns empty + cleans up) is already safe.
+- The new `top_doc_type` parameter on `_process_space` is opt-in — existing call sites pass nothing and observe identical behaviour.
+- No coordinated alkemio-server release is required: the GraphQL endpoints used by the new reader (`lookup.knowledgeBase`) already exist on every server version capable of holding a knowledge-base-typed BoK.

--- a/specs/033-ingest-space-kb-routing/tasks.md
+++ b/specs/033-ingest-space-kb-routing/tasks.md
@@ -1,0 +1,134 @@
+# Tasks: Ingest Space Knowledge-Base Routing
+
+**Input**: Design documents from `specs/033-ingest-space-kb-routing/`
+**Organization**: Tasks grouped by user story to enable independent verification of each story's behaviour.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+
+## Path Conventions
+
+Single project (microkernel + plugins). Paths anchored at repository root.
+
+---
+
+## Phase 1: Foundational (Shared Infrastructure)
+
+**Purpose**: Module-level scaffolding that every user story depends on.
+
+- [X] T001 [P] Add `BOK_TYPE_SPACE` and `BOK_TYPE_KNOWLEDGE_BASE` constants to `plugins/ingest_space/space_reader.py`
+- [X] T002 [P] Add `KNOWLEDGE_BASE_QUERY` GraphQL document to `plugins/ingest_space/space_reader.py`, reusing the existing `_CALLOUT_FIELDS` fragment
+
+**Checkpoint**: Constants and query string are defined; nothing depends on them yet.
+
+---
+
+## Phase 2: User Story 1 — Knowledge-Base-Backed VCs Ingest (Priority: P1) 🎯 MVP
+
+**Goal**: Route `alkemio-knowledge-base` events to `lookup.knowledgeBase()` and produce the same kind of documents the space path would produce, so the ~29 % of VCs previously stuck with empty collections start ingesting real content.
+
+**Independent Test**: Publish an `IngestBodyOfKnowledge` with `type="alkemio-knowledge-base"` and verify the resulting collection contains chunks derived from the KB's callouts; assert no `Unable to find Space` error in the plugin logs.
+
+### Tests for User Story 1
+
+- [X] T003 [P] [US1] `TestKnowledgeBaseReader.test_walks_callouts` — verify KB callouts produce post documents in `tests/plugins/test_ingest_space.py`
+- [X] T004 [P] [US1] `TestKnowledgeBaseReader.test_empty_knowledge_base_returns_empty_list` — verify `null` payload returns `[]` without raising
+- [X] T005 [P] [US1] `TestKnowledgeBaseReader.test_issues_knowledge_base_query` — assert the GraphQL query string contains `knowledgeBase(ID:` and NOT `space(ID:`, and variables are `{"kbId": …}`
+- [X] T006 [P] [US1] `TestBodyOfKnowledgeDispatcher.test_routes_alkemio_space_to_space_reader` — patch both readers, dispatcher calls only `read_space_tree`
+- [X] T007 [P] [US1] `TestBodyOfKnowledgeDispatcher.test_routes_alkemio_knowledge_base_to_kb_reader` — patch both readers, dispatcher calls only `read_knowledge_base_tree`
+- [X] T008 [P] [US1] `TestBodyOfKnowledgeDispatcher.test_unknown_type_defaults_to_space_reader` — unknown `bok_type` falls back to space reader
+- [X] T009 [P] [US1] `TestIngestSpacePluginDispatchesOnType.test_plugin_uses_knowledge_base_reader_for_alkemio_knowledge_base` — end-to-end propagation from `event.type` into the dispatcher
+- [X] T010 [P] [US1] `TestIngestSpacePluginDispatchesOnType.test_plugin_uses_space_reader_for_alkemio_space` — symmetric assertion for the space path
+
+### Implementation for User Story 1
+
+- [X] T011 [US1] Add `read_knowledge_base_tree(graphql_client, kb_id)` in `plugins/ingest_space/space_reader.py`: issue `KNOWLEDGE_BASE_QUERY`, return `[]` on missing payload, reshape response into `_process_space`-compatible dict, delegate traversal
+- [X] T012 [US1] Add `read_body_of_knowledge(graphql_client, bok_id, bok_type)` dispatcher in `plugins/ingest_space/space_reader.py`: select reader based on `bok_type`, fall back to `read_space_tree` on unknown types
+- [X] T013 [US1] Replace `read_space_tree(self._graphql_client, bok_id)` with `read_body_of_knowledge(self._graphql_client, bok_id, event.type)` in `plugins/ingest_space/plugin.py`
+
+**Checkpoint**: Knowledge-base BoKs route through `lookup.knowledgeBase()` and produce populated collections.
+
+---
+
+## Phase 3: User Story 2 — Operator Sees Resolved Routing in Logs (Priority: P2)
+
+**Goal**: Make the routing decision visible to operators reading pod logs.
+
+**Independent Test**: Trigger any ingest run; grep logs for a single INFO line containing the BoK id and type.
+
+### Implementation for User Story 2
+
+- [X] T014 [US2] Add `logger.info("Ingesting BoK %s (type=%s, purpose=%s)", bok_id, event.type, event.purpose)` at the top of `IngestSpacePlugin.handle()` (after the graphql_client null-check, before the reader call) in `plugins/ingest_space/plugin.py`
+
+**Checkpoint**: Every `handle()` call emits one INFO line capturing the routing-relevant fields.
+
+---
+
+## Phase 4: User Story 3 — KB Root Documents Tagged `knowledge` (Priority: P3)
+
+**Goal**: Tag depth-0 documents emitted from the knowledge-base path with `DocumentType.KNOWLEDGE`, not `DocumentType.SPACE`.
+
+**Independent Test**: Run the KB reader against a payload with a populated profile description; assert the root document's `metadata.type == "knowledge"`.
+
+### Tests for User Story 3
+
+- [X] T015 [P] [US3] `TestKnowledgeBaseReader.test_top_doc_type_is_knowledge` — root document type assertion
+
+### Implementation for User Story 3
+
+- [X] T016 [US3] Add kw-only `top_doc_type: str | None = None` to `_process_space` in `plugins/ingest_space/space_reader.py`; override the depth-0 type when set
+- [X] T017 [US3] Pass `top_doc_type=DocumentType.KNOWLEDGE.value` from `read_knowledge_base_tree` into `_process_space`
+
+**Checkpoint**: Root documents are tagged accurately; space-path tagging unchanged.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+- [X] T018 Run `poetry run ruff check core/ plugins/ tests/` and `poetry run pyright core/ plugins/` — both clean (no new errors)
+- [X] T019 Run `poetry run pytest tests/plugins/test_ingest_space.py -q` — full ingest_space suite green (37 tests)
+- [X] T020 Run `poetry run pytest --ignore=tests/evaluation -q` — full non-evaluation test suite green to confirm no regression elsewhere
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Foundational (Phase 1)**: No dependencies — can start immediately.
+- **User Story 1 (Phase 2)**: Depends on Foundational.
+- **User Story 2 (Phase 3)**: Independent of US1 — could be done first, but easier to add the log line once the routing exists.
+- **User Story 3 (Phase 4)**: Depends on Foundational; the implementation step T016 modifies the same function (`_process_space`) that US1 calls, so US1 and US3 must coordinate the diff but their tests are independent.
+- **Polish (Phase 5)**: After all user stories.
+
+### Within Each User Story
+
+- Tests written alongside the implementation (test-first not required for this single-author bug fix, but every behavioural change has a corresponding test before the PR is opened).
+- T013 (plugin route swap) depends on T011 and T012 being merged into the same module.
+- T017 (passing `top_doc_type`) depends on T016 (adding the parameter).
+
+### Parallel Opportunities
+
+- T001 and T002 are both module-level scaffolding in the same file, but their patches do not overlap — can be written in parallel.
+- T003–T010 are all test functions in different methods — fully parallel.
+
+---
+
+## Implementation Strategy
+
+**MVP scope**: Phase 1 + Phase 2 deliver the routing fix that unblocks the
+69 knowledge-base-backed VCs. US2 and US3 are quality-of-life improvements
+that ride along in the same PR because they touch the same files.
+
+**Sequencing the diff**: All tasks land in a single commit on
+`fix/ingest-space-knowledge-base` (PR #98). The retrospec spec is captured
+on this `033-ingest-space-kb-routing` branch.
+
+---
+
+## Notes
+
+- All tasks marked `[X]` because the implementation already shipped on `fix/ingest-space-knowledge-base` (PR #98) and this retrospec records the spec post-hoc.
+- The test suite includes a guardrail (T005) that asserts the GraphQL query string explicitly — so an accidental future revert to `lookup.space()` on the KB path is caught at test time, not in production.

--- a/tests/core/test_events.py
+++ b/tests/core/test_events.py
@@ -201,6 +201,13 @@ class TestIngestWebsiteSerialization:
         assert dumped["result"] == "success"
         assert dumped["error"] == ""
         assert isinstance(dumped["timestamp"], int)
+        # Identification fields must be present in the dumped payload
+        # (camelCase aliases) so the alkemio-server result handler can
+        # correlate the result back to a persona.
+        assert dumped["bodyOfKnowledgeId"] == ""
+        assert dumped["personaId"] == ""
+        assert dumped["type"] == ""
+        assert dumped["purpose"] == ""
 
     def test_result_failure(self):
         result = IngestWebsiteResult(
@@ -209,6 +216,21 @@ class TestIngestWebsiteSerialization:
         dumped = result.model_dump()
         assert dumped["result"] == "failure"
         assert dumped["error"] == "Connection timeout"
+
+    def test_result_with_identification_fields(self):
+        result = IngestWebsiteResult(
+            body_of_knowledge_id="bok-1",
+            type="website",
+            purpose="knowledge",
+            persona_id="persona-1",
+            result=IngestionResult.SUCCESS,
+        )
+        dumped = result.model_dump()
+        assert dumped["bodyOfKnowledgeId"] == "bok-1"
+        assert dumped["personaId"] == "persona-1"
+        assert dumped["type"] == "website"
+        assert dumped["purpose"] == "knowledge"
+        assert dumped["result"] == "success"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_ingest_space.py
+++ b/tests/plugins/test_ingest_space.py
@@ -6,10 +6,17 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from core.domain.ingest_pipeline import DocumentType
 from core.events.ingest_space import IngestBodyOfKnowledgeResult
 from plugins.ingest_space.file_parsers import parse_file
 from plugins.ingest_space.plugin import IngestSpacePlugin
-from plugins.ingest_space.space_reader import _process_space
+from plugins.ingest_space.space_reader import (
+    BOK_TYPE_KNOWLEDGE_BASE,
+    BOK_TYPE_SPACE,
+    _process_space,
+    read_body_of_knowledge,
+    read_knowledge_base_tree,
+)
 from tests.conftest import (
     MockEmbeddingsPort,
     MockKnowledgeStorePort,
@@ -689,3 +696,183 @@ class TestLinkFetching:
 
         assert stats["fetched"] == 1
         assert stats["skipped"] == 1
+
+
+class TestKnowledgeBaseReader:
+    """Tests for read_knowledge_base_tree — the alkemio-knowledge-base path."""
+
+    def _kb_payload(self, *, with_callout: bool = True):
+        callouts = []
+        if with_callout:
+            callouts.append({
+                "id": "co-1",
+                "framing": {"profile": {
+                    "displayName": "KB Callout",
+                    "description": "Callout desc",
+                }},
+                "contributions": [{
+                    "post": {
+                        "id": "post-1",
+                        "profile": {
+                            "displayName": "P",
+                            "description": "Post body",
+                        },
+                    },
+                }],
+            })
+        return {
+            "lookup": {
+                "knowledgeBase": {
+                    "id": "kb-1",
+                    "profile": {
+                        "displayName": "KB Root",
+                        "description": "Root description",
+                    },
+                    "calloutsSet": {"callouts": callouts},
+                },
+            },
+        }
+
+    async def test_walks_callouts(self):
+        gc = _mock_graphql_client()
+        gc.query = AsyncMock(return_value=self._kb_payload())
+        documents = await read_knowledge_base_tree(gc, "kb-1")
+        # KB root + callout + post
+        ids = {d.metadata.document_id for d in documents}
+        assert "kb-1" in ids
+        assert "co-1" in ids
+        assert "post-1" in ids
+
+    async def test_top_doc_type_is_knowledge(self):
+        gc = _mock_graphql_client()
+        gc.query = AsyncMock(return_value=self._kb_payload(with_callout=False))
+        documents = await read_knowledge_base_tree(gc, "kb-1")
+        root = next(d for d in documents if d.metadata.document_id == "kb-1")
+        assert root.metadata.type == DocumentType.KNOWLEDGE.value
+
+    async def test_empty_knowledge_base_returns_empty_list(self):
+        gc = _mock_graphql_client()
+        gc.query = AsyncMock(return_value={"lookup": {"knowledgeBase": None}})
+        documents = await read_knowledge_base_tree(gc, "kb-missing")
+        assert documents == []
+
+    async def test_issues_knowledge_base_query(self):
+        """Ensure we call lookup.knowledgeBase(), not lookup.space()."""
+        gc = _mock_graphql_client()
+        gc.query = AsyncMock(return_value={"lookup": {"knowledgeBase": None}})
+        await read_knowledge_base_tree(gc, "kb-1")
+        # Inspect the GraphQL query string passed to the client
+        call_args = gc.query.call_args
+        query_str = call_args.args[0]
+        variables = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("variables", {})
+        assert "knowledgeBase(ID:" in query_str
+        assert "space(ID:" not in query_str
+        assert variables == {"kbId": "kb-1"}
+
+
+class TestBodyOfKnowledgeDispatcher:
+    """Tests for the read_body_of_knowledge type-routing dispatcher."""
+
+    async def test_routes_alkemio_space_to_space_reader(self):
+        gc = MagicMock()
+        with patch(
+            "plugins.ingest_space.space_reader.read_space_tree",
+            new=AsyncMock(return_value=[]),
+        ) as space_mock, patch(
+            "plugins.ingest_space.space_reader.read_knowledge_base_tree",
+            new=AsyncMock(return_value=[]),
+        ) as kb_mock:
+            await read_body_of_knowledge(gc, "bok-1", BOK_TYPE_SPACE)
+        space_mock.assert_awaited_once_with(gc, "bok-1")
+        kb_mock.assert_not_awaited()
+
+    async def test_routes_alkemio_knowledge_base_to_kb_reader(self):
+        gc = MagicMock()
+        with patch(
+            "plugins.ingest_space.space_reader.read_space_tree",
+            new=AsyncMock(return_value=[]),
+        ) as space_mock, patch(
+            "plugins.ingest_space.space_reader.read_knowledge_base_tree",
+            new=AsyncMock(return_value=[]),
+        ) as kb_mock:
+            await read_body_of_knowledge(gc, "bok-1", BOK_TYPE_KNOWLEDGE_BASE)
+        kb_mock.assert_awaited_once_with(gc, "bok-1")
+        space_mock.assert_not_awaited()
+
+    async def test_unknown_type_defaults_to_space_reader(self):
+        """Unknown bok_type strings fall back to the space path (dominant case)."""
+        gc = MagicMock()
+        with patch(
+            "plugins.ingest_space.space_reader.read_space_tree",
+            new=AsyncMock(return_value=[]),
+        ) as space_mock, patch(
+            "plugins.ingest_space.space_reader.read_knowledge_base_tree",
+            new=AsyncMock(return_value=[]),
+        ) as kb_mock:
+            await read_body_of_knowledge(gc, "bok-1", "something-unexpected")
+        space_mock.assert_awaited_once_with(gc, "bok-1")
+        kb_mock.assert_not_awaited()
+
+
+class TestIngestSpacePluginDispatchesOnType:
+    """The plugin must pass event.type through to the dispatcher."""
+
+    async def test_plugin_uses_knowledge_base_reader_for_alkemio_knowledge_base(self):
+        store = MockKnowledgeStorePort()
+        llm = MockLLMPort()
+        embeddings = MockEmbeddingsPort()
+        plugin = IngestSpacePlugin(
+            llm=llm,
+            embeddings=embeddings,
+            knowledge_store=store,
+            graphql_client=AsyncMock(),
+        )
+        event = make_ingest_body_of_knowledge(type=BOK_TYPE_KNOWLEDGE_BASE)
+        with patch(
+            "plugins.ingest_space.space_reader.read_knowledge_base_tree",
+            new=AsyncMock(return_value=[]),
+        ) as kb_mock, patch(
+            "plugins.ingest_space.space_reader.read_space_tree",
+            new=AsyncMock(return_value=[]),
+        ) as space_mock:
+            result = await plugin.handle(event)
+
+        assert result.result == "success"
+        kb_mock.assert_awaited_once()
+        space_mock.assert_not_awaited()
+        # Zero-document cleanup branch: no LLM/embeddings work,
+        # and no collection-level deletion either.
+        assert llm.calls == []
+        assert embeddings.calls == []
+        assert embeddings.query_calls == []
+        assert store.deleted == []
+
+    async def test_plugin_uses_space_reader_for_alkemio_space(self):
+        store = MockKnowledgeStorePort()
+        llm = MockLLMPort()
+        embeddings = MockEmbeddingsPort()
+        plugin = IngestSpacePlugin(
+            llm=llm,
+            embeddings=embeddings,
+            knowledge_store=store,
+            graphql_client=AsyncMock(),
+        )
+        event = make_ingest_body_of_knowledge(type=BOK_TYPE_SPACE)
+        with patch(
+            "plugins.ingest_space.space_reader.read_knowledge_base_tree",
+            new=AsyncMock(return_value=[]),
+        ) as kb_mock, patch(
+            "plugins.ingest_space.space_reader.read_space_tree",
+            new=AsyncMock(return_value=[]),
+        ) as space_mock:
+            result = await plugin.handle(event)
+
+        assert result.result == "success"
+        space_mock.assert_awaited_once()
+        kb_mock.assert_not_awaited()
+        # Zero-document cleanup branch: no LLM/embeddings work,
+        # and no collection-level deletion either.
+        assert llm.calls == []
+        assert embeddings.calls == []
+        assert embeddings.query_calls == []
+        assert store.deleted == []

--- a/tests/plugins/test_ingest_website.py
+++ b/tests/plugins/test_ingest_website.py
@@ -448,6 +448,15 @@ class TestIngestWebsitePlugin:
         # delete_collection is no longer called — incremental dedup replaces it
         assert plugin._knowledge_store.deleted == []
         assert "example.com-knowledge" in plugin._knowledge_store.collections
+        # Identification fields must be propagated from the request event
+        # so the alkemio-server result handler can correlate the result
+        # back to the persona.
+        assert result.persona_id == event.persona_id
+        assert result.type == event.type
+        assert result.purpose == event.purpose
+        # bodyOfKnowledgeId defaults to "" for the website plugin
+        # (websites are URL-identified, not UUID-keyed) — lock in the contract.
+        assert result.body_of_knowledge_id == ""
 
     async def test_empty_crawl_runs_cleanup(self):
         """When crawl returns [], cleanup deletes pre-existing chunks."""
@@ -476,6 +485,12 @@ class TestIngestWebsitePlugin:
         assert result.result == "success"
         # All pre-existing chunks should have been deleted
         assert len(store.collections.get(collection, [])) == 0
+        # Cleanup-only path must still propagate identification fields.
+        assert result.persona_id == event.persona_id
+        assert result.type == event.type
+        assert result.purpose == event.purpose
+        # bodyOfKnowledgeId defaults to "" — covers the cleanup-only path too.
+        assert result.body_of_knowledge_id == ""
 
     async def test_empty_extract_runs_cleanup(self):
         """When crawl returns pages but extraction yields nothing, cleanup runs."""


### PR DESCRIPTION
## Summary

Release PR promoting two fixes from `develop` to `main`. semantic-release on the merge commit will tag **v0.1.3** (two `fix:` commits since v0.1.2 → patch bump).

### Fixes included

1. **fix(ingest-website): include identification fields in result envelope (spec 032)** — PR #99
   - `IngestWebsiteResult` gains `bodyOfKnowledgeId`, `type`, `purpose`, `personaId` (additive, empty-string defaults). Plugin propagates the identification fields from the inbound event on all three return paths (cleanup-only, normal success/failure, exception). Unblocks the alkemio-server's ability to correlate ingest results back to the originating persona.

2. **fix(ingest-space): route alkemio-knowledge-base BoKs to lookup.knowledgeBase() (spec 033)** — PR #100
   - Adds a small dispatcher that branches `IngestBodyOfKnowledge` events to the correct GraphQL lookup based on `event.type`. ~29 % of platform VCs (69 / 238 on acceptance) were previously producing empty Chroma collections because the plugin always called `lookup.space()`, which 404'd for KB-backed BoKs. Those VCs will start ingesting real content after this release ships.

### SDD artifacts

- `specs/032-ingest-result-correlation/` — full SDD set for the ingest-website fix.
- `specs/033-ingest-space-kb-routing/` — full SDD set for the ingest-space fix.

### Test gates (verified on develop)

- `poetry run pytest --ignore=tests/evaluation -q` — full non-evaluation suite green.
- `poetry run ruff check core/ plugins/ tests/` — clean.
- `poetry run pyright core/ plugins/` — 0 errors.

### Post-merge

- semantic-release tags **v0.1.3** and writes the CHANGELOG entry.
- Docker Hub publishes `alkemio/virtual-contributor:v0.1.3`.
- On the acceptance deploy that picks up this image: trigger ingest for any `alkemio-knowledge-base`-backed VC (e.g. `test-vc-flow-003`, BoK `e2cf604d-…`); confirm pod logs show the KB reader was used and the resulting collection is populated. Confirm an `IngestWebsiteResult` envelope carries the new `personaId` field end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)